### PR TITLE
Pass labels to deploy items

### DIFF
--- a/charts/landscaper/templates/crd/landscaper.gardener.cloud_executions.yaml
+++ b/charts/landscaper/templates/crd/landscaper.gardener.cloud_executions.yaml
@@ -57,6 +57,11 @@ spec:
                       items:
                         type: string
                       type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels is the map of labels to be added to the deploy item.
+                      type: object
                     name:
                       description: Name is the unique name of the execution.
                       type: string

--- a/pkg/apis/core/types_execution.go
+++ b/pkg/apis/core/types_execution.go
@@ -91,6 +91,10 @@ type DeployItemTemplate struct {
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
 
+	// Labels is the map of labels to be added to the deploy item.
+	// +optional
+	Labels map[string]string  `json:"labels,omitempty"`
+
 	// ProviderConfiguration contains the type specific configuration for the execution.
 	Configuration *runtime.RawExtension `json:"config"`
 

--- a/pkg/apis/core/types_execution.go
+++ b/pkg/apis/core/types_execution.go
@@ -93,7 +93,7 @@ type DeployItemTemplate struct {
 
 	// Labels is the map of labels to be added to the deploy item.
 	// +optional
-	Labels map[string]string  `json:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// ProviderConfiguration contains the type specific configuration for the execution.
 	Configuration *runtime.RawExtension `json:"config"`

--- a/pkg/apis/core/v1alpha1/types_execution.go
+++ b/pkg/apis/core/v1alpha1/types_execution.go
@@ -110,6 +110,10 @@ type DeployItemTemplate struct {
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
 
+	// Labels is the map of labels to be added to the deploy item.
+	// +optional
+	Labels map[string]string  `json:"labels,omitempty"`
+
 	// ProviderConfiguration contains the type specific configuration for the execution.
 	// +kubebuilder:validation:XEmbeddedResource
 	// +kubebuilder:validation:XPreserveUnknownFields

--- a/pkg/apis/core/v1alpha1/types_execution.go
+++ b/pkg/apis/core/v1alpha1/types_execution.go
@@ -112,7 +112,7 @@ type DeployItemTemplate struct {
 
 	// Labels is the map of labels to be added to the deploy item.
 	// +optional
-	Labels map[string]string  `json:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// ProviderConfiguration contains the type specific configuration for the execution.
 	// +kubebuilder:validation:XEmbeddedResource

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -12,9 +12,8 @@ package v1alpha1
 
 import (
 	"encoding/json"
-
-	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
-	v1 "k8s.io/api/core/v1"
+	"github.com/gardener/component-spec/bindings-go/apis/v2"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -446,6 +445,13 @@ func (in *DeployItemTemplate) DeepCopyInto(out *DeployItemTemplate) {
 		in, out := &in.Target, &out.Target
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Configuration != nil {
 		in, out := &in.Configuration, &out.Configuration

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -12,8 +12,9 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"github.com/gardener/component-spec/bindings-go/apis/v2"
-	"k8s.io/api/core/v1"
+
+	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -103,6 +103,9 @@ func (o *Operation) deployOrTrigger(ctx context.Context, item executionItem) err
 		item.DeployItem.Spec.Type = item.Info.Type
 		item.DeployItem.Spec.Target = item.Info.Target
 		item.DeployItem.Spec.Configuration = item.Info.Configuration
+		for k, v := range item.Info.Labels {
+			kutil.SetMetaDataLabel(&item.DeployItem.ObjectMeta, k, v)
+		}
 		kutil.SetMetaDataLabel(&item.DeployItem.ObjectMeta, lsv1alpha1.ExecutionManagedByLabel, o.exec.Name)
 		kutil.SetMetaDataLabel(&item.DeployItem.ObjectMeta, lsv1alpha1.ExecutionManagedNameLabel, item.Info.Name)
 		metav1.SetMetaDataAnnotation(&item.DeployItem.ObjectMeta, lsv1alpha1.ExecutionDependsOnAnnotation, strings.Join(item.Info.DependsOn, ","))


### PR DESCRIPTION
**What this PR does / why we need it**:
Labels can be added to a deploy item by specifying them in the deploy items template of a blueprint.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Both DeployItemTemplate structures have been extended by a map for labels. 
- Execution CRD and deep copy method have been regenerated.
- The execution controller passes the labels to the deploy item.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
