### PR TITLE
refactor import validation

### DIFF
--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -19,12 +19,6 @@ import (
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 )
 
-// CheckSiblingDependentsOfParentsReason defines the reason for the parent dependent validation
-const CheckSiblingDependentsOfParentsReason = "CheckSiblingDependentsOfParentsReason"
-
-// CheckImportsReason defines the reason for the import validation
-const CheckImportsReason = "CheckImportsReason"
-
 // NewValidator creates new import validator.
 // It validates if all imports of a component are satisfied given a context.
 func NewValidator(op *installations.Operation) *Validator {
@@ -37,15 +31,23 @@ func NewValidator(op *installations.Operation) *Validator {
 
 // OutdatedImports validates whether a imported data object or target is outdated.
 func (v *Validator) OutdatedImports(ctx context.Context, inst *installations.Installation) (bool, error) {
+	const OutdatedImportsReason = "OutdatedImports"
 	fldPath := field.NewPath(fmt.Sprintf("(Inst %s)", inst.Info.Name))
+	cond := lsv1alpha1helper.GetOrInitCondition(inst.Info.Status.Conditions, lsv1alpha1.ValidateImportsCondition)
 
 	for _, dataImport := range inst.Info.Spec.Imports.Data {
 		impPath := fldPath.Child(dataImport.Name)
 		outdated, err := v.checkDataImportIsOutdated(ctx, impPath, inst, dataImport)
 		if err != nil {
+			inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionUnknown,
+				OutdatedImportsReason,
+				fmt.Sprintf("Check for outdated data imports failed: %s", err.Error())))
 			return false, err
 		}
 		if outdated {
+			inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionTrue,
+				OutdatedImportsReason,
+				"A least one data import is outdated"))
 			return true, nil
 		}
 	}
@@ -54,21 +56,29 @@ func (v *Validator) OutdatedImports(ctx context.Context, inst *installations.Ins
 		impPath := fldPath.Child(targetImport.Name)
 		outdated, err := v.checkTargetImportIsOutdated(ctx, impPath, inst, targetImport)
 		if err != nil {
+			inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionUnknown,
+				OutdatedImportsReason,
+				fmt.Sprintf("Check for outdated target imports failed: %s", err.Error())))
 			return false, err
 		}
 		if outdated {
+			inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionTrue,
+				OutdatedImportsReason,
+				"A least one target import is outdated"))
 			return true, nil
 		}
 	}
-
+	inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
+		OutdatedImportsReason,
+		"All imports are up-to-date"))
 	return false, nil
 }
 
-// Validate traverses through all components and validates if all imports are
-// satisfied with the correct version
-func (v *Validator) Validate(ctx context.Context, inst *installations.Installation) error {
+// CheckDependentInstallations checks whether all dependencies are succeeded.
+// It traverses through all dependent siblings and all dependent siblings of its parents.
+func (v *Validator) CheckDependentInstallations(ctx context.Context, inst *installations.Installation) (bool, error) {
+	const CheckSiblingDependentsOfParentsReason = "CheckSiblingDependentsOfParents"
 	cond := lsv1alpha1helper.GetOrInitCondition(inst.Info.Status.Conditions, lsv1alpha1.ValidateImportsCondition)
-	fldPath := field.NewPath(fmt.Sprintf("(Inst %s)", inst.Info.Name))
 
 	// check if parent has sibling installation dependencies that are not finished yet
 	completed, err := CheckCompletedSiblingDependentsOfParent(ctx, v.Operation, v.parent)
@@ -76,21 +86,29 @@ func (v *Validator) Validate(ctx context.Context, inst *installations.Installati
 		inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 			CheckSiblingDependentsOfParentsReason,
 			fmt.Sprintf("Check for progressing dependents of the parent failed: %s", err.Error())))
-		return err
+		return false, err
 	}
+
 	if !completed {
 		inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 			CheckSiblingDependentsOfParentsReason,
 			"Waiting until all progressing dependents of the parent are finished"))
-		return installations.NewNotCompletedDependentsError("A parent or parent's parent sibling Installation dependency is not completed yet", nil)
 	}
+	return completed, err
+}
+
+// ImportsSatisfied validates if all imports are satisfied with the correct version.
+func (v *Validator) ImportsSatisfied(ctx context.Context, inst *installations.Installation) error {
+	const ImportsSatisfiedReason = "ImportsSatisfied"
+	cond := lsv1alpha1helper.GetOrInitCondition(inst.Info.Status.Conditions, lsv1alpha1.ValidateImportsCondition)
+	fldPath := field.NewPath(fmt.Sprintf("(Inst %s)", inst.Info.Name))
 
 	for _, dataImport := range inst.Info.Spec.Imports.Data {
 		impPath := fldPath.Child(dataImport.Name)
-		err = v.checkDataImportIsSatisfied(ctx, impPath, inst, dataImport)
+		err := v.checkDataImportIsSatisfied(ctx, impPath, inst, dataImport)
 		if err != nil {
 			inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
-				CheckImportsReason,
+				ImportsSatisfiedReason,
 				fmt.Sprintf("Waiting until all imports are satisfied: %s", err.Error())))
 			return err
 		}
@@ -98,17 +116,17 @@ func (v *Validator) Validate(ctx context.Context, inst *installations.Installati
 
 	for _, targetImport := range inst.Info.Spec.Imports.Targets {
 		impPath := fldPath.Child(targetImport.Name)
-		err = v.checkTargetImportIsSatisfied(ctx, impPath, inst, targetImport)
+		err := v.checkTargetImportIsSatisfied(ctx, impPath, inst, targetImport)
 		if err != nil {
 			inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
-				CheckImportsReason,
+				ImportsSatisfiedReason,
 				fmt.Sprintf("Waiting until all imports are satisfied: %s", err.Error())))
 			return err
 		}
 	}
 
 	inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionTrue,
-		CheckImportsReason,
+		ImportsSatisfiedReason,
 		"All imports are satisfied"))
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors import validation, so that it is split into separate functions for better readability and better flow control e.g with "force reconcile"

/kind quality
/priority normal

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
