### PR TITLE
add local rendering command

### DIFF
--- a/cmd/landscaper-cli/app/app.go
+++ b/cmd/landscaper-cli/app/app.go
@@ -21,7 +21,7 @@ func NewLandscaperCliCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "landscaper-cli",
 		Short: "landscaper cli",
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			log, err := logger.NewCliLogger()
 			if err != nil {
 				fmt.Println("unable to setup logger")
@@ -32,7 +32,7 @@ func NewLandscaperCliCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	logger.InitFlags(cmd.Flags())
+	logger.InitFlags(cmd.PersistentFlags())
 
 	cmd.AddCommand(NewVersionCommand())
 	cmd.AddCommand(blueprints.NewBlueprintsCommand(ctx))

--- a/cmd/landscaper-cli/app/blueprints/blueprints.go
+++ b/cmd/landscaper-cli/app/blueprints/blueprints.go
@@ -21,6 +21,7 @@ func NewBlueprintsCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(NewPushCommand(ctx))
 	cmd.AddCommand(NewGetCommand(ctx))
 	cmd.AddCommand(NewValidationCommand(ctx))
+	cmd.AddCommand(NewRenderCommand(ctx))
 
 	return cmd
 }

--- a/cmd/landscaper-cli/app/blueprints/render.go
+++ b/cmd/landscaper-cli/app/blueprints/render.go
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprints
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/codec"
+	"github.com/go-logr/logr"
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	"github.com/mandelsoft/vfs/pkg/projectionfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
+	"github.com/gardener/landscaper/pkg/apis/core"
+	lsv1alpha1 "github.com/gardener/landscaper/pkg/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/apis/core/validation"
+	"github.com/gardener/landscaper/pkg/kubernetes"
+	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
+	"github.com/gardener/landscaper/pkg/landscaper/execution"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations"
+	lsoperation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/registry/components/cdutils"
+	"github.com/gardener/landscaper/pkg/logger"
+)
+
+const (
+	OutputResourceDeployItems      = "deployitems"
+	OutputResourceSubinstallations = "subinstallations"
+)
+
+var (
+	OutputResourceAllTerms              = sets.NewString("all")
+	OutputResourceDeployItemsTerms      = sets.NewString(OutputResourceDeployItems, "di")
+	OutputResourceSubinstallationsTerms = sets.NewString(OutputResourceSubinstallations, "subinst", "inst")
+)
+
+const (
+	JSONOut = "json"
+	YAMLOut = "yaml"
+)
+
+type renderOptions struct {
+	// blueprintPath is the path to the directory containing the definition.
+	blueprintPath string
+	// componentDescriptorPath is the path tot he component descriptor to be used
+	componentDescriptorPath string
+	// valueFiles is a list of filepaths to value yaml files.
+	valueFiles []string
+	// outputFormat defines the format of the output
+	outputFormat string
+	// outDir is the directory where the rendered should be written to.
+	outDir string
+
+	outputResources     sets.String
+	blueprint           *lsv1alpha1.Blueprint
+	blueprintFs         vfs.FileSystem
+	componentDescriptor *cdutils.ResolvedComponentDescriptor
+	values              *Values
+}
+
+// NewRenderCommand creates a new local command to render a blueprint instance locally
+func NewRenderCommand(ctx context.Context) *cobra.Command {
+	opts := &renderOptions{}
+	cmd := &cobra.Command{
+		Use:     "render",
+		Args:    cobra.RangeArgs(1, 2),
+		Example: "landscapercli blueprints render [path to Blueprint directory] [all,deployitems,subinstallations]",
+		Short:   "renders the given blueprint",
+		Long: fmt.Sprintf(`
+Renders the blueprint with the given values files.
+All value files are merged whereas the later defined will overwrite the values of the previous ones
+
+By default all rendered resources are printed to stdout.
+Specific resources can be printed by adding a second argument.
+landscapercli local render [path to Blueprint directory] [resource]
+Available resources are
+- %s: renders all available resources
+- %s: renders deployitems
+- %s: renders subinstallations
+`,
+			strings.Join(OutputResourceAllTerms.List(), "|"),
+			strings.Join(OutputResourceDeployItemsTerms.List(), "|"),
+			strings.Join(OutputResourceSubinstallationsTerms.List(), "|")),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opts.Complete(args); err != nil {
+				fmt.Println(err.Error())
+				os.Exit(1)
+			}
+
+			if err := opts.run(ctx, logger.Log); err != nil {
+				fmt.Println(err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *renderOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&o.componentDescriptorPath, "component-descriptor", "c", "", "Path to the local component descriptor")
+	fs.StringArrayVarP(&o.valueFiles, "file", "f", []string{}, "List of filepaths to value yaml files that define the imports")
+	fs.StringVarP(&o.outputFormat, "output", "o", YAMLOut, "The format of the output. Can be json or yaml.")
+	fs.StringVarP(&o.outDir, "write", "w", "", "The output directory where the rendered files should be written to")
+}
+
+func (o *renderOptions) run(ctx context.Context, log logr.Logger) error {
+	log.V(3).Info(fmt.Sprintf("rendering %s", strings.Join(o.outputResources.List(), ", ")))
+
+	dummyOperation := &lsoperation.Operation{}
+
+	blueprint, err := blueprints.New(o.blueprint, o.blueprintFs)
+	if err != nil {
+		return err
+	}
+
+	if o.outputResources.Has(OutputResourceDeployItems) {
+		templateStateHandler := template.NewMemoryStateHandler()
+		deployItemTemplates, err := template.New(dummyOperation, templateStateHandler).TemplateDeployExecutions(blueprint, o.componentDescriptor, o.values.Imports)
+		if err != nil {
+			return fmt.Errorf("unable to template deploy executions: %w", err)
+		}
+
+		// print out state
+		stateOut := map[string]map[string]json.RawMessage{
+			"state": map[string]json.RawMessage{},
+		}
+		for key, state := range templateStateHandler {
+			stateOut["state"][key] = json.RawMessage(state)
+		}
+		if err := o.out(stateOut, "state"); err != nil {
+			return err
+		}
+
+		for _, diTmpl := range deployItemTemplates {
+			di := &lsv1alpha1.DeployItem{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: lsv1alpha1.SchemeGroupVersion.String(),
+					Kind:       "DeployItem",
+				},
+			}
+			execution.ApplyDeployItemTemplate(di, diTmpl)
+			if err := o.out(di, "deployitems", diTmpl.Name); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.outputResources.Has(OutputResourceSubinstallations) {
+		dummyInst := &lsv1alpha1.Installation{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: lsv1alpha1.SchemeGroupVersion.String(),
+				Kind:       "Installation",
+			},
+		}
+		if len(blueprint.Subinstallations) == 0 {
+			fmt.Printf("No subinstallations defined\n")
+		}
+		for _, subInstTmpl := range blueprint.Subinstallations {
+			subBlueprint, err := subinstallations.GetBlueprintDefinitionFromInstallationTemplate(dummyInst, subInstTmpl, o.componentDescriptor)
+			if err != nil {
+				fmt.Printf("unable to get blueprint: %s\n", err.Error())
+			}
+			subInst := &lsv1alpha1.Installation{}
+			subInst.Spec = lsv1alpha1.InstallationSpec{
+				Blueprint:          *(*lsv1alpha1.BlueprintDefinition)(unsafe.Pointer(&subBlueprint)),
+				Imports:            subInstTmpl.Imports,
+				ImportDataMappings: subInstTmpl.ImportDataMappings,
+				Exports:            subInstTmpl.Exports,
+				ExportDataMappings: subInstTmpl.ExportDataMappings,
+			}
+			if err := o.out(subInst, "subinstallations", subInstTmpl.Name); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o *renderOptions) Complete(args []string) error {
+	o.blueprintPath = args[0]
+	data, err := ioutil.ReadFile(filepath.Join(o.blueprintPath, lsv1alpha1.BlueprintFilePath))
+	if err != nil {
+		return fmt.Errorf("unable to read blueprint from %s: %w", filepath.Join(o.blueprintPath, lsv1alpha1.BlueprintFilePath), err)
+	}
+	o.blueprint = &lsv1alpha1.Blueprint{}
+	if _, _, err := serializer.NewCodecFactory(kubernetes.LandscaperScheme).UniversalDecoder().Decode(data, nil, o.blueprint); err != nil {
+		return err
+	}
+	o.blueprintFs, err = projectionfs.New(osfs.New(), o.blueprintPath)
+	if err != nil {
+		return fmt.Errorf("unable to construct blueprint filesystem: %w", err)
+	}
+
+	if len(o.componentDescriptorPath) != 0 {
+		data, err := ioutil.ReadFile(o.componentDescriptorPath)
+		if err != nil {
+			return fmt.Errorf("unable to read component descriptor from %s: %w", o.componentDescriptorPath, err)
+		}
+		cd := cdv2.ComponentDescriptor{}
+		if err := codec.Decode(data, &cd); err != nil {
+			return fmt.Errorf("unable to decode component descriptor: %w", err)
+		}
+		resCd, err := cdutils.ConvertFromComponentDescriptor(cd, func(meta cdv2.ComponentReference) (cdv2.ComponentDescriptor, error) {
+			return cdv2.ComponentDescriptor{}, nil
+		})
+		if err != nil {
+			return fmt.Errorf("unable to convert component descriptor to a resolved component descriptor: %w", err)
+		}
+		o.componentDescriptor = &resCd
+	}
+
+	o.values = &Values{}
+	for _, filePath := range o.valueFiles {
+		data, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("unable to read values file '%s': %w", filePath, err)
+		}
+		values := &Values{}
+		if err := yaml.Unmarshal(data, values); err != nil {
+			return fmt.Errorf("unable to parse values file '%s': %w", filePath, err)
+		}
+
+		MergeValues(o.values, values)
+	}
+
+	if err := o.parseOutputResources(args); err != nil {
+		return err
+	}
+
+	return o.Validate()
+}
+
+// Validate validates push options
+func (o *renderOptions) Validate() error {
+	blueprint := &core.Blueprint{}
+	if err := lsv1alpha1.Convert_v1alpha1_Blueprint_To_core_Blueprint(o.blueprint, blueprint, nil); err != nil {
+		return err
+	}
+	if errList := validation.ValidateBlueprint(o.blueprintFs, blueprint); len(errList) != 0 {
+		return errList.ToAggregate()
+	}
+
+	if err := ValidateValues(o.values); err != nil {
+		return err
+	}
+
+	if o.outputFormat != YAMLOut && o.outputFormat != JSONOut {
+		return fmt.Errorf("output format is expected to be json or yaml but got '%s'", o.outputFormat)
+	}
+
+	return nil
+}
+
+func (o *renderOptions) parseOutputResources(args []string) error {
+	allResources := sets.NewString(OutputResourceDeployItems, OutputResourceSubinstallations)
+	if len(args) == 1 {
+		o.outputResources = allResources
+		return nil
+	}
+	if len(args) > 1 {
+		resources := strings.Split(args[1], ",")
+		o.outputResources = sets.NewString()
+		for _, res := range resources {
+			if OutputResourceAllTerms.Has(res) {
+				o.outputResources = allResources
+				return nil
+			} else if OutputResourceDeployItemsTerms.Has(res) {
+				o.outputResources.Insert(OutputResourceDeployItems)
+			} else if OutputResourceSubinstallationsTerms.Has(res) {
+				o.outputResources.Insert(OutputResourceSubinstallations)
+			} else {
+				return fmt.Errorf("unknown resource '%s'", res)
+			}
+		}
+	}
+	return nil
+}
+
+func (o *renderOptions) out(obj interface{}, names ...string) error {
+
+	var data []byte
+	switch o.outputFormat {
+	case YAMLOut:
+		var err error
+		data, err = yaml.Marshal(obj)
+		if err != nil {
+			return err
+		}
+	case JSONOut:
+		var err error
+		data, err = json.MarshalIndent(obj, "", "  ")
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown output format '%s'", o.outputFormat)
+	}
+
+	// print to stdout if no directory is given
+	if len(o.outDir) == 0 {
+
+		if len(names) != 0 {
+			fmt.Println("--------------------------------------")
+			fmt.Printf("-- %s\n", strings.Join(names, " "))
+			fmt.Println("--------------------------------------")
+		}
+		fmt.Printf("%s\n", data)
+		return nil
+	}
+
+	objFilePath := filepath.Join(append([]string{o.outDir}, names...)...)
+	if err := os.MkdirAll(filepath.Dir(objFilePath), os.ModePerm); err != nil {
+		return fmt.Errorf("unable to create path %s", o.outDir)
+	}
+	return ioutil.WriteFile(objFilePath, data, os.ModePerm)
+}

--- a/cmd/landscaper-cli/app/blueprints/types.go
+++ b/cmd/landscaper-cli/app/blueprints/types.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprints
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Values defines a local values file that conatins the imports to be used to render the blueprint.
+type Values struct {
+	Imports map[string]interface{} `json:"imports,omitempty"`
+}
+
+// ValidateValues validates values file.
+func ValidateValues(values *Values) error {
+	allErrs := field.ErrorList{}
+
+	fldPath := field.NewPath("imports")
+	for key, val := range values.Imports {
+		if val == nil {
+			allErrs = append(allErrs, field.Required(fldPath.Key(key), "value must not be empty"))
+		}
+	}
+
+	return allErrs.ToAggregate()
+}
+
+// MergeValues merges all values of b into a.
+func MergeValues(a, b *Values) {
+	if a.Imports == nil {
+		a.Imports = b.Imports
+		return
+	}
+	for key, val := range b.Imports {
+		a.Imports[key] = val
+	}
+}

--- a/docs/tutorials/resources/ingress-nginx/import-values.yaml
+++ b/docs/tutorials/resources/ingress-nginx/import-values.yaml
@@ -1,0 +1,11 @@
+imports:
+  cluster:
+    apiVersion: landscaper.gardener.cloud/v1alpha1
+    kind: Target
+    metadata:
+      name: my-cluster
+    spec:
+      type: landscaper.gardener.cloud/kubernetes-cluster
+      config:
+        kubeconfig: |
+          apiVersion:...

--- a/docs/usage/LandscaperCli.md
+++ b/docs/usage/LandscaperCli.md
@@ -1,0 +1,91 @@
+# Landscaper Cli Usage
+
+- [Render Blueprints locally](#render-blueprints)
+
+
+### Render Blueprints
+
+During the execution of a blueprint with an installation, deployitems and subinstallation are created by the landscaper based on the imported values.
+
+The generated resources can be locally tested by using the landsacper cli and its `render` command.
+
+```shell script
+landscaper-cli blueprints render [path to blueprint directory]
+
+landscaper-cli blueprints render [path to blueprint directory] -f values.yaml -c component-descriptor.yaml
+```
+
+A component descriptor can be defined by using the `-c` flag that is a path to the component descriptor.
+
+The command renders the resulting DeployItems(with the templating state) and the subinstallations and prints them to stdout.<br>
+The output will print the rendered resources in the following structure
+```shell script
+--------------------------------------
+-- state
+--------------------------------------
+state:
+  <execution name>: ...
+
+--------------------------------------
+-- deployitems <deployitem name>
+--------------------------------------
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+...
+
+--------------------------------------
+-- subinstllations <subinstallation name>
+--------------------------------------
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+...
+```
+
+Alternatively, the rendered resources can be written to a directory by specifying `-w /path/to/output`.
+The resources are written as files in the following directory structure to the given path.
+```
+/path/to/output
+├── deployitems
+│   └── mydeployitem
+├── state
+└── subinstallations
+    └── mysubinstallation
+```
+
+#### Import Values
+
+The imported values can be defined using value files and reference them via commandline flag `-f`.
+```yaml
+# /dev/values.yaml
+imports:
+  <import name>: <my value>
+```
+```shell script
+landscaper-cli blueprints render -f /dev/values.yaml [path to blueprint directory]
+```
+
+__Example__
+```
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+imports:
+- name: myFirstImport
+  schema:
+    type: string
+- name: mySecondImport
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+```
+```
+imports:
+  myFirstImport: "this is a import"
+  mySecondImport: 
+    metadata:
+      name: my-target
+      namespace: default
+    spec:
+       type: landscaper.gardener.cloud/kubernetes-cluster
+       config:
+         kubeconfig: |
+            apiVersion: ....
+```
+

--- a/pkg/landscaper/installations/executions/template/state.go
+++ b/pkg/landscaper/installations/executions/template/state.go
@@ -99,20 +99,20 @@ func (s KubernetesStateHandler) secretName(name string) string {
 	return base32.NewEncoding(lsv1alpha1helper.Base32EncodeStdLowerCase).WithPadding(base32.NoPadding).EncodeToString(h.Sum(nil))
 }
 
-type memoryStateHandler map[string][]byte
+type MemoryStateHandler map[string][]byte
 
-var _ GenericStateHandler = memoryStateHandler{}
+var _ GenericStateHandler = MemoryStateHandler{}
 
-func NewMemoryStateHandler() GenericStateHandler {
-	return memoryStateHandler{}
+func NewMemoryStateHandler() MemoryStateHandler {
+	return MemoryStateHandler{}
 }
 
-func (m memoryStateHandler) Store(_ context.Context, name string, data []byte) error {
+func (m MemoryStateHandler) Store(_ context.Context, name string, data []byte) error {
 	m[name] = data
 	return nil
 }
 
-func (m memoryStateHandler) Get(_ context.Context, name string) ([]byte, error) {
+func (m MemoryStateHandler) Get(_ context.Context, name string) ([]byte, error) {
 	data, ok := m[name]
 	if !ok {
 		return nil, StateNotFoundErr


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

documentation has to be done

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adds a local command to the landscaper cli to locally render and verify blueprints.
```
