### PR TITLE
Add allow plain http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tmp
 .DS_Store
 
 *.report
+
+**/gomock_reflect_*

--- a/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/templates/_helpers.tpl
@@ -67,6 +67,7 @@ apiVersion: config.landscaper.gardener.cloud/v1alpha1
 kind: LandscaperConfiguration
 
 registries:
+  allowPlainHttp: {{ .Values.landscaper.allowPlainHttpRegistries }}
   components:
   {{- if .Values.landscaper.registrySecrets.components }}
     oci:

--- a/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/templates/_helpers.tpl
@@ -71,18 +71,22 @@ registries:
   {{- if .Values.landscaper.registryConfig.components }}
     oci:
       allowPlainHttp: {{ .Values.landscaper.registryConfig.components.allowPlainHttpRegistries }}
+      {{- if .Values.landscaper.registryConfig.components.secrets }}
       configFiles:
       {{- range $key, $value := .Values.landscaper.registryConfig.components.secrets }}
       - /app/ls/registry/components/{{ $key }}
+      {{- end }}
       {{- end }}
   {{- end }}
   blueprints:
     {{- if .Values.landscaper.registryConfig.blueprints }}
     oci:
       allowPlainHttp: {{ .Values.landscaper.registryConfig.blueprints.allowPlainHttpRegistries }}
+      {{- if .Values.landscaper.registryConfig.blueprints.secrets }}
       configFiles:
       {{- range $key, $value := .Values.landscaper.registryConfig.blueprints.secrets }}
       - /app/ls/registry/blueprints/{{ $key }}
+      {{- end }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/templates/_helpers.tpl
@@ -67,20 +67,21 @@ apiVersion: config.landscaper.gardener.cloud/v1alpha1
 kind: LandscaperConfiguration
 
 registries:
-  allowPlainHttp: {{ .Values.landscaper.allowPlainHttpRegistries }}
   components:
-  {{- if .Values.landscaper.registrySecrets.components }}
+  {{- if .Values.landscaper.registryConfig.components }}
     oci:
+      allowPlainHttp: {{ .Values.landscaper.registryConfig.components.allowPlainHttpRegistries }}
       configFiles:
-      {{- range $key, $value := .Values.landscaper.registrySecrets.components }}
+      {{- range $key, $value := .Values.landscaper.registryConfig.components.secrets }}
       - /app/ls/registry/components/{{ $key }}
       {{- end }}
   {{- end }}
   blueprints:
-    {{- if .Values.landscaper.registrySecrets.blueprints }}
+    {{- if .Values.landscaper.registryConfig.blueprints }}
     oci:
+      allowPlainHttp: {{ .Values.landscaper.registryConfig.blueprints.allowPlainHttpRegistries }}
       configFiles:
-      {{- range $key, $value := .Values.landscaper.registrySecrets.blueprints }}
+      {{- range $key, $value := .Values.landscaper.registryConfig.blueprints.secrets }}
       - /app/ls/registry/blueprints/{{ $key }}
       {{- end }}
     {{- end }}

--- a/charts/landscaper/templates/deployment.yaml
+++ b/charts/landscaper/templates/deployment.yaml
@@ -46,11 +46,11 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /app/ls/config
-          {{- if .Values.landscaper.registrySecrets.blueprints }}
+          {{- if .Values.landscaper.registryConfig.blueprints.secrets }}
           - name: blueprintsregistry
             mountPath: /app/ls/registry/blueprints
           {{- end }}
-          {{- if .Values.landscaper.registrySecrets.components }}
+          {{- if .Values.landscaper.registryConfig.components.secrets }}
           - name: blueprintsregistry
             mountPath: /app/ls/registry/components
           {{- end }}
@@ -60,12 +60,12 @@ spec:
       - name: config
         secret:
           secretName: {{ include "landscaper.fullname" . }}-config
-      {{- if .Values.landscaper.registrySecrets.blueprints }}
+      {{- if .Values.landscaper.registryConfig.blueprints.secrets }}
       - name: blueprintsregistry
         secret:
           secretName: {{ include "landscaper.fullname" . }}-registry-blueprints
       {{- end }}
-      {{- if .Values.landscaper.registrySecrets.components }}
+      {{- if .Values.landscaper.registryConfig.components.secrets }}
       - name: componentsregistry
         secret:
           secretName: {{ include "landscaper.fullname" . }}-registry-components

--- a/charts/landscaper/templates/registry-secret.yaml
+++ b/charts/landscaper/templates/registry-secret.yaml
@@ -3,7 +3,7 @@
  SPDX-License-Identifier: Apache-2.0
 */}}
 
-{{- if .Values.landscaper.registrySecrets.blueprints }}
+{{- if .Values.landscaper.registryConfig.blueprints.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,11 +11,11 @@ metadata:
   labels:
     {{- include "landscaper.labels" . | nindent 4 }}
 data:
-  {{- range $key, $value := .Values.landscaper.registrySecrets.blueprints }}
+  {{- range $key, $value := .Values.landscaper.registryConfig.blueprints.secrets }}
   {{ $key }}: {{ toJson $value | b64enc }}
   {{- end }}
 {{- end }}
-{{- if .Values.landscaper.registrySecrets.components }}
+{{- if .Values.landscaper.registryConfig.components.secrets }}
 ---
 apiVersion: v1
 kind: Secret
@@ -24,7 +24,7 @@ metadata:
   labels:
   {{- include "landscaper.labels" . | nindent 4 }}
 data:
-  {{- range $key, $value := .Values.landscaper.registrySecrets.components }}
+  {{- range $key, $value := .Values.landscaper.registryConfig.components.secrets }}
   {{ $key }}: {{ toJson $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/landscaper/values.yaml
+++ b/charts/landscaper/values.yaml
@@ -8,13 +8,16 @@
 
 landscaper:
 
-  allowPlainHttpRegistries: false
 
-  registrySecrets: # contains optional oci secrets
-    blueprints: {}
-#      <name>: <docker config json>
-    components: {}
-#      <name>: <docker config json>
+  registryConfig: # contains optional oci secrets
+    blueprints:
+      allowPlainHttpRegistries: false
+      secrets: {}
+#       <name>: <docker config json>
+    components:
+      allowPlainHttpRegistries: false
+      secrets: {}
+#       <name>: <docker config json>
 
   deployers: []
 #  - container

--- a/charts/landscaper/values.yaml
+++ b/charts/landscaper/values.yaml
@@ -7,6 +7,9 @@
 # Declare variables to be passed into your templates.
 
 landscaper:
+
+  allowPlainHttpRegistries: false
+
   registrySecrets: # contains optional oci secrets
     blueprints: {}
 #      <name>: <docker config json>

--- a/cmd/landscaper-cli/app/app.go
+++ b/cmd/landscaper-cli/app/app.go
@@ -43,8 +43,9 @@ func NewLandscaperCliCommand(ctx context.Context) *cobra.Command {
 
 func NewVersionCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "v",
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   "displays the version",
 		Run: func(cmd *cobra.Command, args []string) {
 			v := version.Get()
 			fmt.Printf("%#v", v)

--- a/cmd/landscaper-cli/app/blueprints/get.go
+++ b/cmd/landscaper-cli/app/blueprints/get.go
@@ -32,6 +32,8 @@ import (
 type showOptions struct {
 	// ref is the oci reference where the definition should eb uploaded.
 	ref string
+	// allowPlainHttp allows the fallback to http if the oci registry does not support https
+	allowPlainHttp bool
 
 	// cacheDir defines the oci cache directory
 	cacheDir string
@@ -69,7 +71,7 @@ func (o *showOptions) run(ctx context.Context, log logr.Logger) error {
 		return err
 	}
 
-	ociClient, err := oci.NewClient(log, oci.WithCache{Cache: cache})
+	ociClient, err := oci.NewClient(log, oci.WithCache{Cache: cache}, oci.AllowPlainHttp(o.allowPlainHttp))
 	if err != nil {
 		return err
 	}
@@ -127,5 +129,5 @@ func (o *showOptions) Complete(args []string) error {
 }
 
 func (o *showOptions) AddFlags(fs *pflag.FlagSet) {
-
+	fs.BoolVar(&o.allowPlainHttp, "allow-plain-http", false, "allows the fallback to http if the oci registry does not support https")
 }

--- a/cmd/landscaper-cli/app/blueprints/push.go
+++ b/cmd/landscaper-cli/app/blueprints/push.go
@@ -34,6 +34,8 @@ import (
 type pushOptions struct {
 	// ref is the oci reference where the definition should eb uploaded.
 	ref string
+	// allowPlainHttp allows the fallback to http if the oci registry does not support https
+	allowPlainHttp bool
 
 	// blueprintPath is the path to the directory containing the definition.
 	blueprintPath string
@@ -80,7 +82,10 @@ func (o *pushOptions) run(ctx context.Context, log logr.Logger) error {
 		return err
 	}
 
-	ociClient, err := oci.NewClient(log, oci.WithCache{Cache: cache}, oci.WithKnownMediaType(blueprintsregistry.ComponentDefinitionConfigMediaType))
+	ociClient, err := oci.NewClient(log,
+		oci.WithCache{Cache: cache},
+		oci.WithKnownMediaType(blueprintsregistry.ComponentDefinitionConfigMediaType),
+		oci.AllowPlainHttp(o.allowPlainHttp))
 	if err != nil {
 		return err
 	}
@@ -129,4 +134,6 @@ func (o *pushOptions) Validate() error {
 	return nil
 }
 
-func (o *pushOptions) AddFlags(fs *pflag.FlagSet) {}
+func (o *pushOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.allowPlainHttp, "allow-plain-http", false, "allows the fallback to http if the oci registry does not support https")
+}

--- a/cmd/landscaper-cli/app/componentdescriptor/get.go
+++ b/cmd/landscaper-cli/app/componentdescriptor/get.go
@@ -31,6 +31,8 @@ type showOptions struct {
 	componentName string
 	// version is the component version in the oci registry.
 	version string
+	// allowPlainHttp allows the fallback to http if the oci registry does not support https
+	allowPlainHttp bool
 
 	// cacheDir defines the oci cache directory
 	cacheDir string
@@ -68,7 +70,7 @@ func (o *showOptions) run(ctx context.Context, log logr.Logger) error {
 		return err
 	}
 
-	ociClient, err := oci.NewClient(log, oci.WithCache{Cache: cache})
+	ociClient, err := oci.NewClient(log, oci.WithCache{Cache: cache}, oci.AllowPlainHttp(o.allowPlainHttp))
 	if err != nil {
 		return err
 	}
@@ -135,5 +137,5 @@ func (o *showOptions) Complete(args []string) error {
 }
 
 func (o *showOptions) AddFlags(fs *pflag.FlagSet) {
-
+	fs.BoolVar(&o.allowPlainHttp, "allow-plain-http", false, "allows the fallback to http if the oci registry does not support https")
 }

--- a/cmd/landscaper-cli/app/componentdescriptor/push.go
+++ b/cmd/landscaper-cli/app/componentdescriptor/push.go
@@ -35,6 +35,8 @@ type pushOptions struct {
 	version string
 	// componentPath is the path to the directory containing the definition.
 	componentPath string
+	// allowPlainHttp allows the fallback to http if the oci registry does not support https
+	allowPlainHttp bool
 
 	// ref is the oci artifact uri reference to the uploaded component descriptor
 	ref string
@@ -93,7 +95,10 @@ func (o *pushOptions) run(ctx context.Context, log logr.Logger) error {
 		return err
 	}
 
-	ociClient, err := oci.NewClient(log, oci.WithCache{Cache: cache}, oci.WithKnownMediaType(componentsregistry.ComponentDescriptorMediaType))
+	ociClient, err := oci.NewClient(log,
+		oci.WithCache{Cache: cache},
+		oci.WithKnownMediaType(componentsregistry.ComponentDescriptorMediaType),
+		oci.AllowPlainHttp(o.allowPlainHttp))
 	if err != nil {
 		return err
 	}
@@ -176,4 +181,6 @@ func (o *pushOptions) Validate() error {
 	return nil
 }
 
-func (o *pushOptions) AddFlags(_ *pflag.FlagSet) {}
+func (o *pushOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.allowPlainHttp, "allow-plain-http", false, "allows the fallback to http if the oci registry does not support https")
+}

--- a/docs/gettingstarted/install-landscaper-controller.md
+++ b/docs/gettingstarted/install-landscaper-controller.md
@@ -30,6 +30,8 @@ the oci secrets can be provided using a map of `<config-name>: <docker auth>`.
 The docker auth config should be a docker auth config. 
 See the kubernetes pull secret documentation for a comprehensive guide https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker.
 
+In case of an OCI registry that is not exposed via https, the `allowPlainHttpRegistries` flag can be used.
+
 The landscaper does offload all deployment specific functionality like `helm` to deployers.
 For a very simple setup, internal deployers (`helm`, `manifest` and `container`) can be served by the landscaper.
 
@@ -40,23 +42,27 @@ image:
   tag: image version # .e.g. 0.0.0-dev-8bf4b8150f96fed8868618c56787b81fa4e095e6
 
 landscaper:
-  registrySecrets: # contains optional oci secrets
+  registryConfig: # contains optional oci secrets
     blueprints:
-      default: {
-        "auths": {
-          "hostname": {
-            "auth": "my auth"
+      allowPlainHttpRegistries: false
+      secrets:
+        default: {
+          "auths": {
+            "hostname": {
+              "auth": "my auth"
+            }
           }
         }
-      }
     components:
-      default: {
-        "auths": {
-           "hostname": {
-             "auth": "my auth"
-           }
+      allowPlainHttpRegistries: false
+      secrets:
+        default: {
+          "auths": {
+            "hostname": {
+              "auth": "my auth"
+            }
+          }
         }
-      }
   
   # deploy with integrated deployers for quick start
   deployers: 

--- a/docs/tutorials/00-local-setup.md
+++ b/docs/tutorials/00-local-setup.md
@@ -42,7 +42,9 @@ helm upgrade --install -n harbor registry harbor/harbor -f values.yaml
 ```
 
 In the example above, helm installs the registry in the `harbor` namespace.
-The registry can be used by the landscaper by referencing artifacts via it's internal service `registry-harbor-registry.harbor:5000`
+The registry can be used by the landscaper by referencing artifacts via it's internal service `registry-harbor-registry.harbor:5000`<br>
+:warning: The harbor registry and the Landscaper are deployed to the same cluster which means that their communication resides in the cluster's private network. 
+Therefore, it is not necessary to setup tls for the harbor registry but the Landscaper needs to be configured to allow connections to http registries. See the [landscaper configuration section](#configure-the-landscaper) for more details.
 
 The harbor is now only accessible from within the cluster, so the k8s proxy is needed to upload artifacts:
 ```shell script
@@ -130,6 +132,8 @@ apiVersion: config.landscaper.gardener.cloud/v1alpha1
 kind: LandscaperConfiguration
 
 registries:
+  # the local harbor registry only serves http so the landscaper has to be configured to do a fallback to http.
+  allowPlainHttp: true
   components:
     oci:
       configFiles:
@@ -143,6 +147,8 @@ registries:
 If the landscaper is deployed via helm, the credentials can be configured using the `values.yaml`:
 ```yaml
 landscaper:
+  # the local harbor registry only serves http so the landscaper has to be configured to do a fallback to http.
+  allowPlainHttpRegistries: true
   registrySecrets: # contains optional oci secrets
     blueprints:
       default: {

--- a/docs/tutorials/00-local-setup.md
+++ b/docs/tutorials/00-local-setup.md
@@ -148,24 +148,27 @@ If the landscaper is deployed via helm, the credentials can be configured using 
 ```yaml
 landscaper:
   # the local harbor registry only serves http so the landscaper has to be configured to do a fallback to http.
-  allowPlainHttpRegistries: true
-  registrySecrets: # contains optional oci secrets
+  registryConfig: # contains optional oci secrets
     blueprints:
-      default: {
-                   "auths": {
-                       "http://registry-harbor-registry.harbor:5000/": {
-                           "auth": "${AUTH_TOKEN}"
-                       }
-                   }
-               }
+      allowPlainHttpRegistries: false
+      secrets:
+        default:  {
+                    "auths": {
+                      "http://registry-harbor-registry.harbor:5000/": {
+                        "auth": "${AUTH_TOKEN}"
+                      }
+                    }
+                  }
     components:
-      default: {
-                   "auths": {
-                       "http://registry-harbor-registry.harbor:5000/": {
-                           "auth": "${AUTH_TOKEN}"
-                       }
-                   }
-               }
+      allowPlainHttpRegistries: false
+      secrets:
+        default:  {
+                    "auths": {
+                      "http://registry-harbor-registry.harbor:5000/": {
+                        "auth": "${AUTH_TOKEN}"
+                      }
+                    }
+                  }
 ```
 
 ### Common Pitfalls

--- a/pkg/apis/.schemas/container_Configuration.json
+++ b/pkg/apis/.schemas/container_Configuration.json
@@ -84,6 +84,9 @@
       "type": "object"
     },
     "OCIConfiguration": {
+      "required": [
+        "allowPlainHttp"
+      ],
       "properties": {
         "configFiles": {
           "items": {
@@ -94,6 +97,9 @@
         "cache": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/OCICacheConfiguration"
+        },
+        "allowPlainHttp": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/apis/.schemas/helm_Configuration.json
+++ b/pkg/apis/.schemas/helm_Configuration.json
@@ -41,6 +41,9 @@
       "type": "object"
     },
     "OCIConfiguration": {
+      "required": [
+        "allowPlainHttp"
+      ],
       "properties": {
         "configFiles": {
           "items": {
@@ -51,6 +54,9 @@
         "cache": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/OCICacheConfiguration"
+        },
+        "allowPlainHttp": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/apis/.schemas/landscaper_LandscaperConfiguration.json
+++ b/pkg/apis/.schemas/landscaper_LandscaperConfiguration.json
@@ -60,6 +60,9 @@
       "type": "object"
     },
     "OCIConfiguration": {
+      "required": [
+        "allowPlainHttp"
+      ],
       "properties": {
         "configFiles": {
           "items": {
@@ -70,6 +73,9 @@
         "cache": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/OCICacheConfiguration"
+        },
+        "allowPlainHttp": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -77,14 +83,10 @@
     },
     "RegistriesConfiguration": {
       "required": [
-        "allowPlainHttp",
         "blueprints",
         "components"
       ],
       "properties": {
-        "allowPlainHttp": {
-          "type": "boolean"
-        },
         "blueprints": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/RegistryConfiguration"

--- a/pkg/apis/.schemas/landscaper_LandscaperConfiguration.json
+++ b/pkg/apis/.schemas/landscaper_LandscaperConfiguration.json
@@ -77,10 +77,14 @@
     },
     "RegistriesConfiguration": {
       "required": [
+        "allowPlainHttp",
         "blueprints",
         "components"
       ],
       "properties": {
+        "allowPlainHttp": {
+          "type": "boolean"
+        },
         "blueprints": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/RegistryConfiguration"

--- a/pkg/apis/config/types_landscaper_config.go
+++ b/pkg/apis/config/types_landscaper_config.go
@@ -26,8 +26,6 @@ type LandscaperConfiguration struct {
 
 // RegistriesConfiguration contains the configuration options for blueprint and component registries
 type RegistriesConfiguration struct {
-	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
-	AllowPlainHttp bool `json:"allowPlainHttp"`
 	// Artifacts contains the configuration to fetch blueprints and jsonschemas
 	// from local or remote registries.
 	Artifacts RegistryConfiguration `json:"blueprints"`
@@ -61,6 +59,9 @@ type OCIConfiguration struct {
 	// Cache holds configuration for the oci cache
 	// +optional
 	Cache *OCICacheConfiguration `json:"cache,omitempty"`
+
+	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
+	AllowPlainHttp bool `json:"allowPlainHttp"`
 }
 
 // OCICacheConfiguration contains the configuration for the oci cache

--- a/pkg/apis/config/types_landscaper_config.go
+++ b/pkg/apis/config/types_landscaper_config.go
@@ -26,6 +26,8 @@ type LandscaperConfiguration struct {
 
 // RegistriesConfiguration contains the configuration options for blueprint and component registries
 type RegistriesConfiguration struct {
+	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
+	AllowPlainHttp bool `json:"allowPlainHttp"`
 	// Artifacts contains the configuration to fetch blueprints and jsonschemas
 	// from local or remote registries.
 	Artifacts RegistryConfiguration `json:"blueprints"`

--- a/pkg/apis/config/v1alpha1/types_landscaper_config.go
+++ b/pkg/apis/config/v1alpha1/types_landscaper_config.go
@@ -26,8 +26,6 @@ type LandscaperConfiguration struct {
 
 // RegistriesConfiguration contains the configuration options for blueprint and component registries
 type RegistriesConfiguration struct {
-	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
-	AllowPlainHttp bool `json:"allowPlainHttp"`
 	// Artifacts contains the configuration to fetch blueprints and jsonschemas
 	// from local or remote registries.
 	Artifacts RegistryConfiguration `json:"blueprints"`
@@ -61,6 +59,9 @@ type OCIConfiguration struct {
 	// Cache holds configuration for the oci cache
 	// +optional
 	Cache *OCICacheConfiguration `json:"cache,omitempty"`
+
+	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
+	AllowPlainHttp bool `json:"allowPlainHttp"`
 }
 
 // OCICacheConfiguration contains the configuration for the oci cache

--- a/pkg/apis/config/v1alpha1/types_landscaper_config.go
+++ b/pkg/apis/config/v1alpha1/types_landscaper_config.go
@@ -26,6 +26,8 @@ type LandscaperConfiguration struct {
 
 // RegistriesConfiguration contains the configuration options for blueprint and component registries
 type RegistriesConfiguration struct {
+	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
+	AllowPlainHttp bool `json:"allowPlainHttp"`
 	// Artifacts contains the configuration to fetch blueprints and jsonschemas
 	// from local or remote registries.
 	Artifacts RegistryConfiguration `json:"blueprints"`

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -182,6 +182,7 @@ func Convert_config_OCIConfiguration_To_v1alpha1_OCIConfiguration(in *config.OCI
 }
 
 func autoConvert_v1alpha1_RegistriesConfiguration_To_config_RegistriesConfiguration(in *RegistriesConfiguration, out *config.RegistriesConfiguration, s conversion.Scope) error {
+	out.AllowPlainHttp = in.AllowPlainHttp
 	if err := Convert_v1alpha1_RegistryConfiguration_To_config_RegistryConfiguration(&in.Artifacts, &out.Artifacts, s); err != nil {
 		return err
 	}
@@ -197,6 +198,7 @@ func Convert_v1alpha1_RegistriesConfiguration_To_config_RegistriesConfiguration(
 }
 
 func autoConvert_config_RegistriesConfiguration_To_v1alpha1_RegistriesConfiguration(in *config.RegistriesConfiguration, out *RegistriesConfiguration, s conversion.Scope) error {
+	out.AllowPlainHttp = in.AllowPlainHttp
 	if err := Convert_config_RegistryConfiguration_To_v1alpha1_RegistryConfiguration(&in.Artifacts, &out.Artifacts, s); err != nil {
 		return err
 	}

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -162,6 +162,7 @@ func Convert_config_OCICacheConfiguration_To_v1alpha1_OCICacheConfiguration(in *
 func autoConvert_v1alpha1_OCIConfiguration_To_config_OCIConfiguration(in *OCIConfiguration, out *config.OCIConfiguration, s conversion.Scope) error {
 	out.ConfigFiles = *(*[]string)(unsafe.Pointer(&in.ConfigFiles))
 	out.Cache = (*config.OCICacheConfiguration)(unsafe.Pointer(in.Cache))
+	out.AllowPlainHttp = in.AllowPlainHttp
 	return nil
 }
 
@@ -173,6 +174,7 @@ func Convert_v1alpha1_OCIConfiguration_To_config_OCIConfiguration(in *OCIConfigu
 func autoConvert_config_OCIConfiguration_To_v1alpha1_OCIConfiguration(in *config.OCIConfiguration, out *OCIConfiguration, s conversion.Scope) error {
 	out.ConfigFiles = *(*[]string)(unsafe.Pointer(&in.ConfigFiles))
 	out.Cache = (*OCICacheConfiguration)(unsafe.Pointer(in.Cache))
+	out.AllowPlainHttp = in.AllowPlainHttp
 	return nil
 }
 
@@ -182,7 +184,6 @@ func Convert_config_OCIConfiguration_To_v1alpha1_OCIConfiguration(in *config.OCI
 }
 
 func autoConvert_v1alpha1_RegistriesConfiguration_To_config_RegistriesConfiguration(in *RegistriesConfiguration, out *config.RegistriesConfiguration, s conversion.Scope) error {
-	out.AllowPlainHttp = in.AllowPlainHttp
 	if err := Convert_v1alpha1_RegistryConfiguration_To_config_RegistryConfiguration(&in.Artifacts, &out.Artifacts, s); err != nil {
 		return err
 	}
@@ -198,7 +199,6 @@ func Convert_v1alpha1_RegistriesConfiguration_To_config_RegistriesConfiguration(
 }
 
 func autoConvert_config_RegistriesConfiguration_To_v1alpha1_RegistriesConfiguration(in *config.RegistriesConfiguration, out *RegistriesConfiguration, s conversion.Scope) error {
-	out.AllowPlainHttp = in.AllowPlainHttp
 	if err := Convert_config_RegistryConfiguration_To_v1alpha1_RegistryConfiguration(&in.Artifacts, &out.Artifacts, s); err != nil {
 		return err
 	}

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -46,7 +46,10 @@ func (a *actuator) SetupRegistries(ctx context.Context, pullSecrets []lsv1alpha1
 	if err != nil {
 		return err
 	}
-	ociClient, err := oci.NewClient(a.Log(), oci.WithConfiguration(a.lsConfig.Registries.Components.OCI), oci.WithResolver{Resolver: ociKeyring})
+	ociClient, err := oci.NewClient(a.Log(),
+		oci.WithConfiguration(a.lsConfig.Registries.Components.OCI),
+		oci.WithResolver{Resolver: ociKeyring},
+		oci.AllowPlainHttp(a.lsConfig.Registries.AllowPlainHttp))
 	if err != nil {
 		return err
 	}
@@ -82,7 +85,10 @@ func (a *actuator) SetupRegistries(ctx context.Context, pullSecrets []lsv1alpha1
 	if err != nil {
 		return err
 	}
-	ociClient, err = oci.NewClient(a.Log(), oci.WithConfiguration(a.lsConfig.Registries.Artifacts.OCI), oci.WithResolver{Resolver: ociKeyring})
+	ociClient, err = oci.NewClient(a.Log(),
+		oci.WithConfiguration(a.lsConfig.Registries.Artifacts.OCI),
+		oci.WithResolver{Resolver: ociKeyring},
+		oci.AllowPlainHttp(a.lsConfig.Registries.AllowPlainHttp))
 	if err != nil {
 		return err
 	}

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -39,7 +39,7 @@ func (a *actuator) SetupRegistries(ctx context.Context, pullSecrets []lsv1alpha1
 
 	// always add a oci client to support unauthenticated requests
 	ociConfigFiles := make([]string, 0)
-	if a.lsConfig.Registries.Artifacts.OCI != nil {
+	if a.lsConfig.Registries.Components.OCI != nil {
 		ociConfigFiles = a.lsConfig.Registries.Components.OCI.ConfigFiles
 	}
 	ociKeyring, err := credentials.CreateOCIRegistryKeyring(secrets, ociConfigFiles)
@@ -48,8 +48,7 @@ func (a *actuator) SetupRegistries(ctx context.Context, pullSecrets []lsv1alpha1
 	}
 	ociClient, err := oci.NewClient(a.Log(),
 		oci.WithConfiguration(a.lsConfig.Registries.Components.OCI),
-		oci.WithResolver{Resolver: ociKeyring},
-		oci.AllowPlainHttp(a.lsConfig.Registries.AllowPlainHttp))
+		oci.WithResolver{Resolver: ociKeyring})
 	if err != nil {
 		return err
 	}
@@ -87,8 +86,7 @@ func (a *actuator) SetupRegistries(ctx context.Context, pullSecrets []lsv1alpha1
 	}
 	ociClient, err = oci.NewClient(a.Log(),
 		oci.WithConfiguration(a.lsConfig.Registries.Artifacts.OCI),
-		oci.WithResolver{Resolver: ociKeyring},
-		oci.AllowPlainHttp(a.lsConfig.Registries.AllowPlainHttp))
+		oci.WithResolver{Resolver: ociKeyring})
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/oci/client.go
+++ b/pkg/utils/oci/client.go
@@ -27,9 +27,10 @@ import (
 )
 
 type client struct {
-	log      logr.Logger
-	resolver Resolver
-	cache    cache.Cache
+	log            logr.Logger
+	resolver       Resolver
+	cache          cache.Cache
+	allowPlainHttp bool
 
 	knownMediaTypes sets.String
 }
@@ -57,6 +58,7 @@ func NewClient(log logr.Logger, opts ...Option) (Client, error) {
 
 	return &client{
 		log:             log,
+		allowPlainHttp:  options.AllowPlainHttp,
 		resolver:        options.Resolver,
 		cache:           options.Cache,
 		knownMediaTypes: DefaultKnownMediaTypes.Union(options.CustomMediaTypes),
@@ -69,7 +71,7 @@ func (c *client) InjectCache(cache cache.Cache) error {
 }
 
 func (c *client) GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error) {
-	resolver, err := c.resolver.Resolver(context.Background(), http.DefaultClient, false)
+	resolver, err := c.resolver.Resolver(context.Background(), http.DefaultClient, c.allowPlainHttp)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +120,7 @@ func (c *client) getFetchReader(ctx context.Context, ref string, desc ocispecv1.
 		}
 	}
 
-	resolver, err := c.resolver.Resolver(context.Background(), http.DefaultClient, false)
+	resolver, err := c.resolver.Resolver(context.Background(), http.DefaultClient, c.allowPlainHttp)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +145,7 @@ func (c *client) getFetchReader(ctx context.Context, ref string, desc ocispecv1.
 }
 
 func (c *client) PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest) error {
-	resolver, err := c.resolver.Resolver(context.Background(), http.DefaultClient, false)
+	resolver, err := c.resolver.Resolver(context.Background(), http.DefaultClient, c.allowPlainHttp)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/oci/types.go
+++ b/pkg/utils/oci/types.go
@@ -143,4 +143,5 @@ func (c *WithConfigurationStruct) ApplyOption(options *Options) {
 	if c.Cache != nil {
 		options.CacheConfig = c.Cache
 	}
+	c.AllowPlainHttp = options.AllowPlainHttp
 }

--- a/pkg/utils/oci/types.go
+++ b/pkg/utils/oci/types.go
@@ -143,5 +143,5 @@ func (c *WithConfigurationStruct) ApplyOption(options *Options) {
 	if c.Cache != nil {
 		options.CacheConfig = c.Cache
 	}
-	c.AllowPlainHttp = options.AllowPlainHttp
+	options.AllowPlainHttp = c.AllowPlainHttp
 }

--- a/pkg/utils/oci/types.go
+++ b/pkg/utils/oci/types.go
@@ -40,6 +40,9 @@ type Options struct {
 	// Paths configures local paths to search for docker configuration files
 	Paths []string
 
+	// AllowPlainHttp allows the fallback to http if https is not supported by the registry.
+	AllowPlainHttp bool
+
 	// Resolver sets the used resolver.
 	// A default resolver will be created if not given.
 	Resolver Resolver
@@ -118,6 +121,13 @@ func (c WithKnownMediaType) ApplyOption(options *Options) {
 	}
 
 	options.CustomMediaTypes.Insert(string(c))
+}
+
+// AllowPlainHttp sets the allow plain http flag.
+type AllowPlainHttp bool
+
+func (c AllowPlainHttp) ApplyOption(options *Options) {
+	options.AllowPlainHttp = bool(c)
 }
 
 // WithConfiguration applies external oci configuration as internal options.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/priority normal

**What this PR does / why we need it**:

Exposes `allowPlainHttp` configuration to the oci client and makes it configurable via Landscaper configuration and via flag in the various landscaper cli commands

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added support to configure http fallback for oci registries that do not support https
```
