### PR TITLE
Enable optional imports

### DIFF
--- a/pkg/apis/core/v1alpha1/types_blueprint.go
+++ b/pkg/apis/core/v1alpha1/types_blueprint.go
@@ -70,8 +70,6 @@ type ImportDefinition struct {
 
 	// ConditionalImports are Imports that are only valid if this imports is satisfied.
 	// Does only make sense for optional imports.
-	// todo: maybe restrict only for required=false
-	// todo: see if this works with recursion
 	// +optional
 	ConditionalImports []ImportDefinition `json:"imports,omitempty"`
 }

--- a/pkg/apis/core/validation/blueprint_test.go
+++ b/pkg/apis/core/validation/blueprint_test.go
@@ -50,6 +50,25 @@ var _ = Describe("Blueprint", func() {
 				"Field": Equal("b[0][myimport]"),
 			}))))
 		})
+
+		It("should fail if there are conditional imports on a required import", func() {
+			importDefinition := core.ImportDefinition{}
+			importDefinition.Name = "myimport"
+			importDefinition.TargetType = "test"
+			conImportDef := core.ImportDefinition{}
+			conImportDef.Name = "myConditionalImport"
+			conImportDef.TargetType = "test"
+			importDefinition.ConditionalImports = []core.ImportDefinition{
+				conImportDef,
+			}
+
+			allErrs := validation.ValidateBlueprintImportDefinitions(field.NewPath("x"), []core.ImportDefinition{importDefinition})
+			Expect(allErrs).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("x[0][myimport]"),
+				"Detail": Equal("conditional imports on required import"),
+			}))))
+		})
 	})
 
 	Context("ExportDefinitions", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Enables optional imports for the blueprint validation.
Also adds a check to make sure that there are no conditional imports on a required import.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
