### PR TITLE
check observed generation of di

### DIFF
--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -40,7 +40,9 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 	for _, item := range executionItems {
 		if item.DeployItem != nil && !o.forceReconcile {
 			phase = lsv1alpha1helper.CombinedExecutionPhase(phase, item.DeployItem.Status.Phase)
-			if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) {
+			deployItemStatusUpToDate := item.DeployItem.Status.ObservedGeneration == item.DeployItem.GetGeneration()
+
+			if !(lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) && deployItemStatusUpToDate) {
 				o.Log().V(5).Info("deploy item not triggered because already existing and not completed", "name", item.Info.Name)
 				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
 				continue

--- a/pkg/landscaper/execution/testdata/state/test2/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test2/10-deploy-item.yaml
@@ -18,3 +18,4 @@ spec:
 
 status:
   phase: Progressing
+  observedGeneration: 1


### PR DESCRIPTION

**Which issue(s) this PR fixes**:
In the [reconcile method](https://github.com/gardener/landscaper/blob/c0336d6cbfcca046df3b0a6495a9766d0e04e996/pkg/landscaper/execution/reconcile.go#L43) the execution controller considers only the phase of the deploy item. It must also compare generation and observed generation of the deploy item? In the case that we observed, the deploy item spec was updated, but the deployer had not yet done anything. The deploy item phase was still successful from before. The execution controller ignored the generation difference and reported a success too early.


