### PR TITLE
change last update time only if needed

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/helpers.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers.go
@@ -5,6 +5,7 @@
 package helper
 
 import (
+	"reflect"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,13 +68,18 @@ func UpdatedCondition(condition v1alpha1.Condition, status v1alpha1.ConditionSta
 		Reason:             reason,
 		Message:            message,
 		LastTransitionTime: condition.LastTransitionTime,
-		LastUpdateTime:     metav1.Now(),
+		LastUpdateTime:     condition.LastUpdateTime,
 		Codes:              codes,
+	}
+
+	if !reflect.DeepEqual(condition, newCondition) {
+		newCondition.LastUpdateTime = metav1.Now()
 	}
 
 	if condition.Status != status {
 		newCondition.LastTransitionTime = metav1.Now()
 	}
+
 	return newCondition
 }
 


### PR DESCRIPTION

**Which issue(s) this PR fixes**:
An infinite loop of reconcile events. Suppose the deployment of a deploy item has succeeded. Then the execution controller sets the ReconcileDeployItems condition [here](https://github.com/gardener/landscaper/blob/c0336d6cbfcca046df3b0a6495a9766d0e04e996/pkg/landscaper/execution/reconcile.go#L87-L88) and updates the status of the execution [here](https://github.com/gardener/landscaper/blob/c0336d6cbfcca046df3b0a6495a9766d0e04e996/pkg/landscaper/controllers/execution/actuator.go#L85). The status update leads to another event for the execution controller. Again, the condition is set and the status updated, and so on. Since the timestamp in the condition always changes, the deep equal at 2 is always false, so that this never stops. (At least it does not stop if we spend enough time between two rounds so that the timestamps are different. This happens when we debug.)

With this pull request the logic of updating a condition is changed such that last update time is only changed if something has really changed.