### PR TITLE
simplify reconcile of executions and set observed generation earlier

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/helpers.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers.go
@@ -23,6 +23,11 @@ func HasOperation(obj metav1.ObjectMeta, op v1alpha1.Operation) bool {
 	return v1alpha1.Operation(currentOp) == op
 }
 
+func GetOperation(obj metav1.ObjectMeta) string {
+	currentOp := obj.Annotations[v1alpha1.OperationAnnotation]
+	return currentOp
+}
+
 // SetOperation sets the given operation annotation on aa object.
 func SetOperation(obj *metav1.ObjectMeta, op v1alpha1.Operation) {
 	metav1.SetMetaDataAnnotation(obj, v1alpha1.OperationAnnotation, string(op))

--- a/pkg/apis/core/v1alpha1/helper/helpers.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers.go
@@ -24,8 +24,7 @@ func HasOperation(obj metav1.ObjectMeta, op v1alpha1.Operation) bool {
 }
 
 func GetOperation(obj metav1.ObjectMeta) string {
-	currentOp := obj.Annotations[v1alpha1.OperationAnnotation]
-	return currentOp
+	return obj.Annotations[v1alpha1.OperationAnnotation]
 }
 
 // SetOperation sets the given operation annotation on aa object.

--- a/pkg/landscaper/controllers/execution/actuator.go
+++ b/pkg/landscaper/controllers/execution/actuator.go
@@ -99,9 +99,7 @@ func (a *actuator) Reconcile(req reconcile.Request) (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	requeue := !lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) || exec.Generation != exec.Status.ObservedGeneration
-
-	return reconcile.Result{Requeue: requeue}, nil
+	return reconcile.Result{}, nil
 }
 
 func (a *actuator) Ensure(ctx context.Context, exec *lsv1alpha1.Execution, forceReconcile bool) error {

--- a/pkg/landscaper/controllers/execution/actuator.go
+++ b/pkg/landscaper/controllers/execution/actuator.go
@@ -99,7 +99,9 @@ func (a *actuator) Reconcile(req reconcile.Request) (reconcile.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, nil
+	requeue := !lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) || exec.Generation != exec.Status.ObservedGeneration
+
+	return reconcile.Result{Requeue: requeue}, nil
 }
 
 func (a *actuator) Ensure(ctx context.Context, exec *lsv1alpha1.Execution, forceReconcile bool) error {

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -80,6 +80,8 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 		phase = lsv1alpha1helper.CombinedExecutionPhase(phase, lsv1alpha1.ExecutionPhaseInit)
 	}
 
+	o.exec.Status.ObservedGeneration = o.exec.Generation
+
 	if !lsv1alpha1helper.IsCompletedExecutionPhase(phase) {
 		return nil
 	}
@@ -90,7 +92,6 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 
 	cond = lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionTrue,
 		"DeployItemsReconciled", "All DeployItems are successfully reconciled")
-	o.exec.Status.ObservedGeneration = o.exec.Generation
 	return o.UpdateStatus(ctx, phase, cond)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Simplifies the reconcile logic for executions.
* Set observed generation earlier
