### PR TITLE
Reduce length of label values

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/dataobjects.go
+++ b/pkg/apis/core/v1alpha1/helper/dataobjects.go
@@ -22,6 +22,10 @@ const SourceDelimiter = "/"
 
 const NonContextifiedPrefix = "#"
 
+const InstallationPrefix = "Inst."
+
+const ExecutionPrefix = "Exec."
+
 // GenerateDataObjectName generates the unique name for a data object exported or imported by a installation.
 // It returns a non contextified data name if the name starts with a "#".
 func GenerateDataObjectName(context string, name string) string {
@@ -60,10 +64,10 @@ func ObjectFromDataObjectSource(src string) (string, lsv1alpha1.ObjectReference,
 
 // DataObjectSourceFromInstallation returns the data object source for a Installation.
 func DataObjectSourceFromInstallation(src *lsv1alpha1.Installation) string {
-	return fmt.Sprintf("Inst.%s", src.GetName())
+	return InstallationPrefix + src.GetName()
 }
 
 // DataObjectSourceFromExecution returns the data object source for a Execution.
 func DataObjectSourceFromExecution(src *lsv1alpha1.Execution) string {
-	return fmt.Sprintf("Exec.%s", src.GetName())
+	return ExecutionPrefix + src.GetName()
 }

--- a/pkg/apis/core/v1alpha1/helper/dataobjects.go
+++ b/pkg/apis/core/v1alpha1/helper/dataobjects.go
@@ -22,10 +22,10 @@ const SourceDelimiter = "/"
 
 const NonContextifiedPrefix = "#"
 
-// Prefix combined with installation name is used as label value. Do not change length.
+// InstallationPrefix is the prefix combined with installation name is used as label value. Do not change length.
 const InstallationPrefix = "Inst."
 
-// Prefix combined with execution name is used as label value. Do not change length.
+// ExecutionPrefix is the prefix combined with execution name is used as label value. Do not change length.
 const ExecutionPrefix = "Exec."
 
 // GenerateDataObjectName generates the unique name for a data object exported or imported by a installation.

--- a/pkg/apis/core/v1alpha1/helper/dataobjects.go
+++ b/pkg/apis/core/v1alpha1/helper/dataobjects.go
@@ -60,10 +60,10 @@ func ObjectFromDataObjectSource(src string) (string, lsv1alpha1.ObjectReference,
 
 // DataObjectSourceFromInstallation returns the data object source for a Installation.
 func DataObjectSourceFromInstallation(src *lsv1alpha1.Installation) string {
-	return fmt.Sprintf("Installation.%s.%s", src.GetNamespace(), src.GetName())
+	return fmt.Sprintf("Inst.%s", src.GetName())
 }
 
 // DataObjectSourceFromExecution returns the data object source for a Execution.
 func DataObjectSourceFromExecution(src *lsv1alpha1.Execution) string {
-	return fmt.Sprintf("Execution.%s.%s", src.GetNamespace(), src.GetName())
+	return fmt.Sprintf("Exec.%s", src.GetName())
 }

--- a/pkg/apis/core/v1alpha1/helper/dataobjects.go
+++ b/pkg/apis/core/v1alpha1/helper/dataobjects.go
@@ -22,8 +22,10 @@ const SourceDelimiter = "/"
 
 const NonContextifiedPrefix = "#"
 
+// Prefix combined with installation name is used as label value. Do not change length.
 const InstallationPrefix = "Inst."
 
+// Prefix combined with execution name is used as label value. Do not change length.
 const ExecutionPrefix = "Exec."
 
 // GenerateDataObjectName generates the unique name for a data object exported or imported by a installation.

--- a/pkg/apis/core/validation/blueprint.go
+++ b/pkg/apis/core/validation/blueprint.go
@@ -7,6 +7,8 @@ package validation
 import (
 	"os"
 
+	"k8s.io/apimachinery/pkg/util/validation"
+
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -261,6 +263,11 @@ func ValidateInstallationTemplate(fldPath *field.Path, template *core.Installati
 	} else {
 		for _, msg := range apivalidation.NameIsDNSLabel(template.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), template.Name, msg))
+		}
+
+		// need to reduce lenght by 1 because "-" is added during subinstallation creation
+		if len(template.Name) > InstallationGenerateNameMaxLength-1 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), template.Name, validation.MaxLenError(InstallationGenerateNameMaxLength-1)))
 		}
 	}
 

--- a/pkg/apis/core/validation/installation.go
+++ b/pkg/apis/core/validation/installation.go
@@ -17,7 +17,7 @@ import (
 
 const InstallationNameMaxLength = validation.DNS1123LabelMaxLength - len(helper.InstallationPrefix)
 
-// max length of an installation name minus the number of random characters kubernetes uses to generate a unique name
+// InstallationGenerateNameMaxLength is the max length of an installation name minus the number of random characters kubernetes uses to generate a unique name
 const InstallationGenerateNameMaxLength = InstallationNameMaxLength - 5
 
 // ValidateInstallation validates an Installation

--- a/pkg/apis/core/validation/installation.go
+++ b/pkg/apis/core/validation/installation.go
@@ -17,6 +17,7 @@ import (
 
 const InstallationNameMaxLength = validation.DNS1123LabelMaxLength - len(helper.InstallationPrefix)
 
+// max length of an installation name minus the number of random characters kubernetes uses to generate a unique name
 const InstallationGenerateNameMaxLength = InstallationNameMaxLength - 5
 
 // ValidateInstallation validates an Installation

--- a/pkg/apis/core/validation/installation.go
+++ b/pkg/apis/core/validation/installation.go
@@ -15,9 +15,9 @@ import (
 	"github.com/gardener/landscaper/pkg/apis/core"
 )
 
-const installationNameMaxLength = validation.DNS1123LabelMaxLength - len(helper.InstallationPrefix)
+const InstallationNameMaxLength = validation.DNS1123LabelMaxLength - len(helper.InstallationPrefix)
 
-const installationGenerateNameMaxLength = installationNameMaxLength - 5
+const InstallationGenerateNameMaxLength = InstallationNameMaxLength - 5
 
 // ValidateInstallation validates an Installation
 func ValidateInstallation(inst *core.Installation) field.ErrorList {
@@ -32,10 +32,10 @@ func validateInstallationObjectMeta(objMeta *metav1.ObjectMeta, fldPath *field.P
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(objMeta, true, apivalidation.NameIsDNSLabel, fldPath)...)
 
-	if len(objMeta.GetName()) > installationNameMaxLength {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), objMeta.GetName(), validation.MaxLenError(installationNameMaxLength)))
-	} else if len(objMeta.GetGenerateName()) > installationGenerateNameMaxLength {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("generateName"), objMeta.GetGenerateName(), validation.MaxLenError(installationGenerateNameMaxLength)))
+	if len(objMeta.GetName()) > InstallationNameMaxLength {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), objMeta.GetName(), validation.MaxLenError(InstallationNameMaxLength)))
+	} else if len(objMeta.GetGenerateName()) > InstallationGenerateNameMaxLength {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("generateName"), objMeta.GetGenerateName(), validation.MaxLenError(InstallationGenerateNameMaxLength)))
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/installation.go
+++ b/pkg/apis/core/validation/installation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/landscaper/pkg/apis/core"
 )
 
+// InstallationNameMaxLength is the max allowed length of an installation name
 const InstallationNameMaxLength = validation.DNS1123LabelMaxLength - len(helper.InstallationPrefix)
 
 // InstallationGenerateNameMaxLength is the max length of an installation name minus the number of random characters kubernetes uses to generate a unique name

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -177,6 +177,9 @@ func (o *Operation) checkRunnable(ctx context.Context, item executionItem, items
 			if o.exec.Generation != lastAppliedGeneration { // dependent deploy item not up-to-date
 				return false, nil
 			}
+			if exec.DeployItem.Status.ObservedGeneration != exec.DeployItem.Generation { // dependent deploy item status not up-to-date
+				return false, nil
+			}
 			if exec.DeployItem.Status.Phase != lsv1alpha1.ExecutionPhaseSucceeded { // dependent deploy item not finished
 				return false, nil
 			}

--- a/pkg/landscaper/installations/exports/testdata/state/test1/11-a-export.yaml
+++ b/pkg/landscaper/installations/exports/testdata/state/test1/11-a-export.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ dataObjectName ( dataObjectContext "test1" "root" )  "a.z" }}
   namespace: test1
   labels:
-    data.landscaper.gardener.cloud/context: "Installation.test1.root"
+    data.landscaper.gardener.cloud/context: "Inst.root"
     data.landscaper.gardener.cloud/key: "a.z"
   ownerReferences:
   - apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/pkg/landscaper/installations/exports/testdata/state/test1/21-b-export.yaml
+++ b/pkg/landscaper/installations/exports/testdata/state/test1/21-b-export.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ dataObjectName ( dataObjectContext "test1" "root" )  "root.z" }}
   namespace: test1
   labels:
-    data.landscaper.gardener.cloud/context: "Installation.test1.root"
+    data.landscaper.gardener.cloud/context: "Inst.root"
     data.landscaper.gardener.cloud/key: "root.z"
   ownerReferences:
   - apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/pkg/landscaper/installations/exports/testdata/state/test1/31-c-export.yaml
+++ b/pkg/landscaper/installations/exports/testdata/state/test1/31-c-export.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ dataObjectName ( dataObjectContext "test1" "root" )  "root.y" }}
   namespace: test1
   labels:
-    data.landscaper.gardener.cloud/context: "Installation.test1.root"
+    data.landscaper.gardener.cloud/context: "Inst.root"
     data.landscaper.gardener.cloud/key: "root.y"
   ownerReferences:
   - apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/pkg/landscaper/installations/exports/testdata/state/test3/21-a-secret.yaml
+++ b/pkg/landscaper/installations/exports/testdata/state/test3/21-a-secret.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ dataObjectName ( dataObjectContext "test3" "root" )  "root.z" }}
   namespace: test3
   labels:
-    data.landscaper.gardener.cloud/context: "Installation.test3.root"
+    data.landscaper.gardener.cloud/context: "Inst.root"
     data.landscaper.gardener.cloud/key: "root.z"
   ownerReferences:
   - apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/pkg/landscaper/installations/exports/testdata/state/test4/21-e-target.yaml
+++ b/pkg/landscaper/installations/exports/testdata/state/test4/21-e-target.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ dataObjectName ( dataObjectContext "test4" "root" )  "root.z" }}
   namespace: test4
   labels:
-    data.landscaper.gardener.cloud/context: "Installation.test4.root"
+    data.landscaper.gardener.cloud/context: "Inst.root"
     data.landscaper.gardener.cloud/key: "root.z"
   ownerReferences:
   - apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/pkg/landscaper/installations/imports/testdata/state/test4/11-root-import.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test4/11-root-import.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ dataObjectName ( dataObjectContext "test4" "root" )  "root.a" }}
   namespace: test4
   labels:
-    data.landscaper.gardener.cloud/context: "Installation.test4.root"
+    data.landscaper.gardener.cloud/context: "Inst.root"
     data.landscaper.gardener.cloud/key: "root.z"
   ownerReferences:
   - apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -12,6 +12,8 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/gardener/landscaper/pkg/apis/core/validation"
+
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -151,7 +153,13 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context, inst *lsv
 
 	if subInst == nil {
 		subInst = &lsv1alpha1.Installation{}
-		subInst.GenerateName = fmt.Sprintf("%s-", subInstTmpl.Name)
+
+		generateName := subInstTmpl.Name
+		if len(generateName) > validation.InstallationGenerateNameMaxLength-1 {
+			generateName = generateName[:validation.InstallationGenerateNameMaxLength-1]
+		}
+
+		subInst.GenerateName = fmt.Sprintf("%s-", generateName)
 		subInst.Namespace = inst.Namespace
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Data objects have labels `data.landscaper.gardener.cloud/context`and `data.landscaper.gardener.cloud/source` whose values could be longer than 63 characters. This PR tries to reduce their length by
- not including the namespace
- abbreviating "Installation" (resp "Execution") to "Inst" (resp. "Exec")  

Further checks to control name lengths could be implemented later, for example in a validating webhook.