### PR TITLE
Prevent that installation phase switches too early to Succeeded

### DIFF
--- a/pkg/landscaper/installations/executions/complete.go
+++ b/pkg/landscaper/installations/executions/complete.go
@@ -25,6 +25,11 @@ func (o *ExecutionOperation) CombinedState(ctx context.Context, inst *installati
 	if err := o.Client().Get(ctx, inst.Info.Status.ExecutionReference.NamespacedName(), exec); err != nil {
 		return "", err
 	}
+
+	if exec.Generation != exec.Status.ObservedGeneration {
+		return lsv1alpha1.ExecutionPhaseProgressing, nil
+	}
+
 	return exec.Status.Phase, nil
 }
 

--- a/pkg/landscaper/installations/subinstallations/complete.go
+++ b/pkg/landscaper/installations/subinstallations/complete.go
@@ -23,7 +23,11 @@ func (o *Operation) CombinedState(ctx context.Context, inst *installations.Insta
 	phases := make([]lsv1alpha1.ComponentInstallationPhase, len(subinsts))
 
 	for _, v := range subinsts {
-		phases = append(phases, v.Status.Phase)
+		if v.Generation != v.Status.ObservedGeneration {
+			phases = append(phases, lsv1alpha1.ComponentPhaseProgressing)
+		} else {
+			phases = append(phases, v.Status.Phase)
+		}
 	}
 
 	return helper.CombinedInstallationPhase(phases...), nil


### PR DESCRIPTION
**How to categorize this PR?**
/priority normal
/kind bug

**What this PR does / why we need it**:
It sporadically happens, that an installation switches to phase `Succeeded`, although an underlying deploy item is not finished. This happens sometimes after an installation or an import parameter value was changed.

- Suppose an import parameter of an installation changes.  
- The installation switches to `Progressing` and updates its execution.  
- The installation controller gets further events caused by:  
  1. the own status change. 
  2. the status change of the execution, namely when the execution controller updates the deploy item and sets the phase of the execution to `Progressing`.  
- Suppose event (i) happens before event (ii). Then the installation controller sees the execution as `Succeeded` and switches itself to `Succeeded`, which is too early.  

This PR does not only consider the phase of the execution, but also compares its generation and observed generation.
