### PR TITLE
add blueprint definition to templating import values

### DIFF
--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -129,7 +129,7 @@ subinstallations:
 
 A Blueprint's deploy executions may contain any number of template executors. 
 A template executor must return a list of deploy items templates.<br>
-A deploy item template exposes specific deploy item fields and will be rendered to DeployItem CRs by teh landscaper.
+A deploy item template exposes specific deploy item fields and will be rendered to DeployItem CRs by the landscaper.
 
 __DeployItem Template__:
 ```yaml
@@ -154,6 +154,7 @@ imports:
   <import-name>: <import value>
 cd: <component descriptor>
 components: <list of all referenced component descriptors>
+blueprint: <blueprint definition> # blueprint definition from the Installation
 ```
 
 All list of deployitem templates of all template executors are appended to one list as they are specified in the deployExecution.
@@ -205,6 +206,20 @@ components:
       acccess:
         type: ociRegistry
         imageReference: ubuntu:0.18.0
+blueprint:
+ ref:
+  #      repositoryContext:
+  #        type: ociRegistry
+  #        baseUrl: eu.gcr.io/myproj
+  componentName: github.com/gardener/gardener
+  version: v1.7.2
+  resourceName: gardener
+#    inline:
+#      filesystem: # vfs filesystem
+#        blueprint.yaml: 
+#          apiVersion: landscaper.gardener.cloud/v1alpha1
+#          kind: Blueprint
+#          ...
 ```
 
 

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -51,7 +51,14 @@ func (o *ExecutionOperation) Ensure(ctx context.Context, inst *installations.Ins
 		KubeClient: o.Client(),
 		Inst:       inst.Info,
 	}
-	executions, err := template.New(o.BlobResolver, templateStateHandler).TemplateDeployExecutions(inst.Blueprint, o.ComponentDescriptor, o.ResolvedComponentDescriptorList, imports)
+
+	executions, err := template.New(o.BlobResolver, templateStateHandler).TemplateDeployExecutions(template.DeployExecutionOptions{
+		Imports:              imports,
+		Installation:         inst.Info,
+		Blueprint:            inst.Blueprint,
+		ComponentDescriptor:  o.ComponentDescriptor,
+		ComponentDescriptors: o.ResolvedComponentDescriptorList,
+	})
 	if err != nil {
 		inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 			TemplatingFailedReason, "Unable to template executions"))

--- a/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-11.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-11.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: GoTemplate
+  template: |
+    deployItems:
+    - name: init
+      type: container
+      config:
+        apiVersion: example.test/v1
+        kind: Configuration
+        blueprint:
+    {{ toYaml .blueprint | indent 6 }}

--- a/pkg/landscaper/installations/executions/template/testdata/spifftemplate/template-11.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/spifftemplate/template-11.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: Spiff
+  template:
+    deployItems:
+    - name: init
+      type: container
+      config:
+        apiVersion: example.test/v1
+        kind: Configuration
+        blueprint: (( __ctx.OUTER[0].blueprint ))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

An additional field has been added that contains information about the currently used blueprint (e.g blueprint ref/component descriptor ref).

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
An additional input value for the deploy executions has been added that contains information about the blueprint
```
