### PR TITLE
[Fix]- Helm deployer is failing with nil reference which crash the whole landscaper

### DIFF
--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -162,10 +162,15 @@ func (h *Helm) createOrUpdateExport(ctx context.Context, values map[string]inter
 }
 
 func (h *Helm) DeleteFiles(ctx context.Context) error {
+	h.log.Info("Deleting files.")
 	h.DeployItem.Status.Phase = lsv1alpha1.ExecutionPhaseDeleting
 	status := &helmv1alpha1.ProviderStatus{}
-	if _, _, err := serializer.NewCodecFactory(Helmscheme).UniversalDecoder().Decode(h.DeployItem.Status.ProviderStatus.Raw, nil, status); err != nil {
-		return err
+
+	if h.DeployItem.Status.ProviderStatus != nil {
+		h.log.V(5).Info(fmt.Sprintf("Provider status is: %s", h.DeployItem.Status.ProviderStatus))
+		if _, _, err := serializer.NewCodecFactory(Helmscheme).UniversalDecoder().Decode(h.DeployItem.Status.ProviderStatus.Raw, nil, status); err != nil {
+			return err
+		}
 	}
 
 	if len(status.ManagedResources) == 0 {


### PR DESCRIPTION
**How to categorize this PR?**
/area helm-deployer
/kind bug
/priority normal

**What this PR does / why we need it**:
If helm deployment(handled by helm-deployer) fails during deployment(for example not correct configuration of the helm chart) the ProviderStatus of the Helm object is nil. After that if we try to delete the installation containing the deployment we end up with a broken landscaper with the following error:
```Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)```
This results to broken landscaper and all finalisers are stuck. The execution, installation, deploy-items are stuck and cannot be deleted from the cluster. Even reinstall of the landscaper don't fix the error as the resources are still in the cluster.
The only way to delete the resources is to edit the resources and remove the finalisers manually.

**Special notes for your reviewer**:
I'm open for further discussion on the topic if needed.

**Steps to reproduce**
1. Create installation which contains helm deployment
2. Ensure invalid configuration in the helm values so that the deployment is not successfully reconciled.
3. Delete the installation
4. Result is **Status: CrashLoopBackOff** of landscaper with **invalid memory address or nil pointer dereference** error in the logs of landscaper

```other operator
- category: bugfix
Fixing successful cleanup of resources of failed helm deployment
```
