### PR TITLE
Fix/manifest deployer

### DIFF
--- a/pkg/deployer/manifest/objectapplier.go
+++ b/pkg/deployer/manifest/objectapplier.go
@@ -92,9 +92,6 @@ func (a *ObjectApplier) ApplyObject(ctx context.Context, i int, manifestData man
 			},
 		},
 	}
-	a.mux.Lock()
-	a.managedResources = append(a.managedResources, mr)
-	a.mux.Unlock()
 
 	currObj := unstructured.Unstructured{} // can't use obj.NewEmptyInstance() as this returns a runtime.Unstructured object which doesn't implement client.Object
 	currObj.GetObjectKind().SetGroupVersionKind(uObj.GetObjectKind().GroupVersionKind())
@@ -109,12 +106,14 @@ func (a *ObjectApplier) ApplyObject(ctx context.Context, i int, manifestData man
 			return fmt.Errorf("unable to create resource %s: %w", key.String(), err)
 		}
 		a.mux.Lock()
+		a.managedResources = append(a.managedResources, mr)
 		a.managedObjects = append(a.managedObjects, uObj)
 		a.mux.Unlock()
 		return nil
 	}
 
 	a.mux.Lock()
+	a.managedResources = append(a.managedResources, mr)
 	a.managedObjects = append(a.managedObjects, uObj)
 	a.mux.Unlock()
 

--- a/pkg/deployer/manifest/test/testdata/04-di-invalid.yaml
+++ b/pkg/deployer/manifest/test/testdata/04-di-invalid.yaml
@@ -1,0 +1,27 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: my-manifests
+spec:
+  type: landscaper.gardener.cloud/kubernetes-manifest
+
+  target: # has to be of type landscaper.gardener.cloud/kubernetes-cluster
+    name: my-cluster
+    namespace: test
+
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+
+    updateStrategy: update
+
+    manifests:
+    - policy: manage
+      manifest:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: my-secret
+          namespace: nonexistingns
+        stringData:
+          config: abc


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area manifest-deployer
/kind bug
/priority normal

**What this PR does / why we need it**:

A bug has been fixed that caused the provider status of a manifest deploy item to grow infinite when the resource could not be created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @In-Ko 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed that caused the provider status of a manifest deploy item to grow infinite when the resource could not be created.
```
