### PR TITLE
Fix a nil pointer when a configmap reference data import key does not exist

### DIFF
--- a/pkg/landscaper/installations/helper_test.go
+++ b/pkg/landscaper/installations/helper_test.go
@@ -5,14 +5,18 @@
 package installations
 
 import (
+	"context"
+
 	g "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/kubernetes"
+	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
 var _ = g.Describe("helper", func() {
@@ -50,6 +54,157 @@ var _ = g.Describe("helper", func() {
 			isRoot := IsRootInstallation(inst)
 			Expect(isRoot).To(BeFalse())
 		})
+	})
+
+	g.Context("GetDataImport", func() {
+
+		var (
+			kubeClient client.Client
+		)
+
+		g.BeforeEach(func() {
+			var err error
+			kubeClient, _, err = envtest.NewFakeClientFromPath("")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		g.It("should get an import from a dataobject", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			data := &lsv1alpha1.DataObject{}
+			data.Name = "test-do"
+			data.Namespace = "default"
+			data.Data = lsv1alpha1.NewAnyJSON([]byte("\"val1\""))
+			Expect(kubeClient.Create(ctx, data)).To(Succeed())
+
+			inst := &Installation{
+				Info: &lsv1alpha1.Installation{},
+			}
+			inst.Info.Namespace = data.Namespace
+			do, owner, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
+				Name:    "imp",
+				DataRef: "#test-do",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(BeNil())
+			Expect(do.Data).To(Equal("val1"))
+		})
+
+		g.It("should throw an error if the dataobject does not exist", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+
+			inst := &Installation{
+				Info: &lsv1alpha1.Installation{},
+			}
+			inst.Info.Namespace = "default"
+			_, _, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
+				Name:    "imp",
+				DataRef: "#test-do",
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		g.It("should get an import from a configmap", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			cm := &corev1.ConfigMap{}
+			cm.Name = "test-cm"
+			cm.Namespace = "default"
+			cm.Data = map[string]string{
+				"key1": "\"val1\"",
+			}
+			Expect(kubeClient.Create(ctx, cm)).To(Succeed())
+
+			do, owner, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+				Name: "imp",
+				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
+					ObjectReference: lsv1alpha1.ObjectReference{
+						Name:      cm.Name,
+						Namespace: cm.Namespace,
+					},
+					Key: "key1",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(BeNil())
+			Expect(do.Data).To(Equal("val1"))
+		})
+
+		g.It("should throw an error if the imported key of a configmap does not exist", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			cm := &corev1.ConfigMap{}
+			cm.Name = "test-cm"
+			cm.Namespace = "default"
+			cm.Data = map[string]string{
+				"key1": "\"val1\"",
+			}
+			Expect(kubeClient.Create(ctx, cm)).To(Succeed())
+
+			_, _, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+				Name: "imp",
+				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
+					ObjectReference: lsv1alpha1.ObjectReference{
+						Name:      cm.Name,
+						Namespace: cm.Namespace,
+					},
+					Key: "key2",
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		g.It("should get an import from a secret", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			secret := &corev1.Secret{}
+			secret.Name = "test-secret"
+			secret.Namespace = "default"
+			secret.Data = map[string][]byte{
+				"key1": []byte("\"val1\""),
+			}
+			Expect(kubeClient.Create(ctx, secret)).To(Succeed())
+
+			do, owner, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+				Name: "imp",
+				SecretRef: &lsv1alpha1.SecretReference{
+					ObjectReference: lsv1alpha1.ObjectReference{
+						Name:      secret.Name,
+						Namespace: secret.Namespace,
+					},
+					Key: "key1",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(BeNil())
+			Expect(do.Data).To(Equal("val1"))
+		})
+
+		g.It("should throw an error if the imported key of a secret does not exist", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			secret := &corev1.Secret{}
+			secret.Name = "test-secret"
+			secret.Namespace = "default"
+			secret.Data = map[string][]byte{
+				"key1": []byte("\"val1\""),
+			}
+			Expect(kubeClient.Create(ctx, secret)).To(Succeed())
+
+			_, _, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+				Name: "imp",
+				SecretRef: &lsv1alpha1.SecretReference{
+					ObjectReference: lsv1alpha1.ObjectReference{
+						Name:      secret.Name,
+						Namespace: secret.Namespace,
+					},
+					Key: "key2",
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
 	})
 
 })

--- a/pkg/landscaper/installations/imports/helper.go
+++ b/pkg/landscaper/installations/imports/helper.go
@@ -108,7 +108,7 @@ func getImportSource(ctx context.Context, op *installations.Operation, inst *ins
 	}
 
 	// we have to get the corresponding installation from the the cluster
-	_, owner, err := installations.GetDataImport(ctx, op, op.Context().Name, inst, dataImport)
+	_, owner, err := installations.GetDataImport(ctx, op.Client(), op.Context().Name, inst, dataImport)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -130,7 +130,7 @@ func (v *Validator) ImportsSatisfied(ctx context.Context, inst *installations.In
 
 func (v *Validator) checkDataImportIsOutdated(ctx context.Context, fldPath *field.Path, inst *installations.Installation, dataImport lsv1alpha1.DataImport) (bool, error) {
 	// get deploy item from current context
-	do, owner, err := installations.GetDataImport(ctx, v, v.Context().Name, inst, dataImport)
+	do, owner, err := installations.GetDataImport(ctx, v.Client(), v.Context().Name, inst, dataImport)
 	if err != nil {
 		return false, fmt.Errorf("%s: unable to get data object for '%s': %w", fldPath.String(), dataImport.Name, err)
 	}
@@ -192,7 +192,7 @@ func (v *Validator) checkTargetImportIsOutdated(ctx context.Context, fldPath *fi
 
 func (v *Validator) checkDataImportIsSatisfied(ctx context.Context, fldPath *field.Path, inst *installations.Installation, dataImport lsv1alpha1.DataImport) error {
 	// get deploy item from current context
-	_, owner, err := installations.GetDataImport(ctx, v, v.Context().Name, inst, dataImport)
+	_, owner, err := installations.GetDataImport(ctx, v.Client(), v.Context().Name, inst, dataImport)
 	if err != nil {
 		return fmt.Errorf("%s: unable to get data object for '%s': %w", fldPath.String(), dataImport.Name, err)
 	}

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -126,7 +126,7 @@ func (o *Operation) GetImportedDataObjects(ctx context.Context) (map[string]*dat
 	dataObjects := map[string]*dataobjects.DataObject{}
 	for _, def := range o.Inst.Info.Spec.Imports.Data {
 
-		do, _, err := GetDataImport(ctx, o, o.Context().Name, o.Inst, def)
+		do, _, err := GetDataImport(ctx, o.Client(), o.Context().Name, o.Inst, def)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a bug in the installation data import that paniced when a key of a configmap was not defined.

also added some unit tests for the dataobject and secret import

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug in the Landscaper controller that caused a panic when a imported configmap key was undefined.
```
