### PR TITLE
Changed manifest deployer to use v1alpha2 objects internally

### DIFF
--- a/apis/deployer/manifest/validation/validation.go
+++ b/apis/deployer/manifest/validation/validation.go
@@ -10,11 +10,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/gardener/landscaper/apis/deployer/manifest"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 )
 
 // ValidateProviderConfiguration validates a manifest provider configuration.
-func ValidateProviderConfiguration(config *manifest.ProviderConfiguration) error {
+func ValidateProviderConfiguration(config *manifestv1alpha2.ProviderConfiguration) error {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateManifestList(field.NewPath(""), config.Manifests)...)
 	allErrs = append(allErrs, ValidateTimeout(field.NewPath("deleteTimeout"), config.DeleteTimeout)...)
@@ -23,7 +23,7 @@ func ValidateProviderConfiguration(config *manifest.ProviderConfiguration) error
 }
 
 // ValidateManifestList validates a list of manifests.
-func ValidateManifestList(fldPath *field.Path, list []manifest.Manifest) field.ErrorList {
+func ValidateManifestList(fldPath *field.Path, list []manifestv1alpha2.Manifest) field.ErrorList {
 	var allErrs field.ErrorList
 	for i, m := range list {
 		allErrs = append(allErrs, ValidateManifest(fldPath.Index(i), m)...)
@@ -32,7 +32,7 @@ func ValidateManifestList(fldPath *field.Path, list []manifest.Manifest) field.E
 }
 
 // ValidateManifest validates a manifest.
-func ValidateManifest(fldPath *field.Path, manifest manifest.Manifest) field.ErrorList {
+func ValidateManifest(fldPath *field.Path, manifest manifestv1alpha2.Manifest) field.ErrorList {
 	var allErrs field.ErrorList
 	if manifest.Manifest == nil || len(manifest.Manifest.Raw) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("manifest"), "manifest must be defined"))

--- a/charts/manifest-deployer/templates/_helpers.tpl
+++ b/charts/manifest-deployer/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Create the Manifest deployer config file which will be encapsulated in a secret.
 */}}
 {{- define "deployer-config" -}}
-apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
 kind: Configuration
 namespace: {{ .Values.deployer.namespace | default .Release.Namespace  }}
 {{- with .Values.targetSelector }}

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -16,7 +16,7 @@ import (
 	install "github.com/gardener/landscaper/apis/core/install"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 	helmv1alpha1 "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1"
-	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	containerctlr "github.com/gardener/landscaper/pkg/deployer/container"
 	helmctlr "github.com/gardener/landscaper/pkg/deployer/helm"
 	manifestctlr "github.com/gardener/landscaper/pkg/deployer/manifest"
@@ -121,7 +121,7 @@ func (o *options) run(ctx context.Context) error {
 				return fmt.Errorf("unable to add helm deployer: %w", err)
 			}
 		} else if deployerName == "manifest" {
-			config := &manifestv1alpha1.Configuration{}
+			config := &manifestv1alpha2.Configuration{}
 			if err := o.deployer.GetDeployerConfiguration(deployerName, config); err != nil {
 				return err
 			}

--- a/cmd/manifest-deployer-controller/app/options.go
+++ b/cmd/manifest-deployer-controller/app/options.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	"github.com/gardener/landscaper/pkg/deployer/manifest"
 	"github.com/gardener/landscaper/pkg/logger"
 )
@@ -22,7 +22,7 @@ type options struct {
 	log        logr.Logger
 	configPath string
 
-	config *manifestv1alpha1.Configuration
+	config *manifestv1alpha2.Configuration
 }
 
 func NewOptions() *options {
@@ -54,17 +54,17 @@ func (o *options) Complete() error {
 	return nil
 }
 
-func (o *options) parseConfigurationFile() (*manifestv1alpha1.Configuration, error) {
+func (o *options) parseConfigurationFile() (*manifestv1alpha2.Configuration, error) {
 	decoder := serializer.NewCodecFactory(manifest.ManifestScheme).UniversalDecoder()
 	if len(o.configPath) == 0 {
-		return &manifestv1alpha1.Configuration{}, nil
+		return &manifestv1alpha2.Configuration{}, nil
 	}
 	data, err := ioutil.ReadFile(o.configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	cfg := &manifestv1alpha1.Configuration{}
+	cfg := &manifestv1alpha2.Configuration{}
 	if _, _, err := decoder.Decode(data, nil, cfg); err != nil {
 		return nil, err
 	}

--- a/docs/tutorials/03-simple-import.md
+++ b/docs/tutorials/03-simple-import.md
@@ -76,13 +76,15 @@ deployItems:
     name: {{ .imports.cluster.metadata.name }}
     namespace: {{ .imports.cluster.metadata.namespace }}
   config:
-    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
     updateStrategy: patch
 
     manifests:
-      - apiVersion: apps/v1
+    - policy: manage
+      manifest:
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: {{ $name }}
@@ -105,7 +107,9 @@ deployItems:
                   - -text="hello world"
                   ports:
                     - containerPort: 5678
-      - apiVersion: v1
+    - policy: manage
+      manifest:
+        apiVersion: v1
         kind: Service
         metadata:
           name: {{ $name }}

--- a/docs/tutorials/05-external-jsonschema.md
+++ b/docs/tutorials/05-external-jsonschema.md
@@ -211,13 +211,15 @@ deployItems:
     name: {{ .imports.cluster.metadata.name }}
     namespace: {{ .imports.cluster.metadata.namespace }}
   config:
-    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
     updateStrategy: patch
 
     manifests:
-      - apiVersion: apps/v1
+    - policy: manage
+      manifest:
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: {{ $name }}
@@ -242,7 +244,9 @@ deployItems:
                     - containerPort: 5678
                   resources:
 {{ toYaml .imports.resources | indent 21 }}
-      - apiVersion: v1
+    - policy: manage
+      manifest:
+        apiVersion: v1
         kind: Service
         metadata:
           name: {{ $name }}

--- a/docs/tutorials/resources/echo-server/blueprint/defaultDeployExecution.yaml
+++ b/docs/tutorials/resources/echo-server/blueprint/defaultDeployExecution.yaml
@@ -10,13 +10,15 @@ deployItems:
     name: {{ .imports.cluster.metadata.name }}
     namespace: {{ .imports.cluster.metadata.namespace }}
   config:
-    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
     updateStrategy: patch
 
     manifests:
-      - apiVersion: apps/v1
+    - policy: manage
+      manifest:
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: {{ $name }}
@@ -39,7 +41,9 @@ deployItems:
                   - -text="hello world"
                   ports:
                     - containerPort: 5678
-      - apiVersion: v1
+    - policy: manage
+      manifest:
+        apiVersion: v1
         kind: Service
         metadata:
           name: {{ $name }}

--- a/docs/tutorials/resources/echo-server/blueprint/defaultDeployExecution.yaml
+++ b/docs/tutorials/resources/echo-server/blueprint/defaultDeployExecution.yaml
@@ -55,7 +55,9 @@ deployItems:
           - protocol: TCP
             port: 80
             targetPort: 5678
-      - apiVersion: networking.k8s.io/v1
+    - policy: manage
+      manifest:
+        apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: {{ $name }}

--- a/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/defaultDeployExecution.yaml
+++ b/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/defaultDeployExecution.yaml
@@ -11,13 +11,15 @@ deployItems:
     name: {{ .imports.cluster.metadata.name }}
     namespace: {{ .imports.cluster.metadata.namespace }}
   config:
-    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
     updateStrategy: patch
 
     manifests:
-      - apiVersion: apps/v1
+    - policy: manage
+      manifest:
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: {{ $name }}
@@ -42,7 +44,9 @@ deployItems:
                     - containerPort: 5678
                   resources:
 {{ toYaml .imports.resources | indent 21 }}
-      - apiVersion: v1
+    - policy: manage
+      manifest:
+        apiVersion: v1
         kind: Service
         metadata:
           name: {{ $name }}

--- a/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/defaultDeployExecution.yaml
+++ b/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/defaultDeployExecution.yaml
@@ -58,7 +58,9 @@ deployItems:
           - protocol: TCP
             port: 80
             targetPort: 5678
-      - apiVersion: networking.k8s.io/v1
+    - policy: manage
+      manifest:
+        apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: {{ $name }}

--- a/examples/deploy-items/40-DeployItem-Manifest-secret.yaml
+++ b/examples/deploy-items/40-DeployItem-Manifest-secret.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,14 +14,30 @@ spec:
     namespace: default
 
   config:
-    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
+    updateStrategy: patch
+    
+    healthChecks:
+      disableDefault: false
+      timeout: 3m
+
+    deleteTimeout: 3m
+
     manifests: # list of kubernetes manifests
-    - apiVersion: v1
-      kind: Secret
-      metadata:
-        name: my-secret
-        namespace: default
-      stringData:
-        config: my-val
+    - policy: manage
+      manifest:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: my-namespace
+    - policy: manage
+      manifest:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: my-secret
+          namespace: my-namespace
+        stringData:
+          config: my-val

--- a/pkg/deployer/manifest/add.go
+++ b/pkg/deployer/manifest/add.go
@@ -9,11 +9,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 )
 
 // AddControllerToManager adds a new manifest deployer to a controller manager.
-func AddControllerToManager(mgr manager.Manager, config *manifestv1alpha1.Configuration) error {
+func AddControllerToManager(mgr manager.Manager, config *manifestv1alpha2.Configuration) error {
 	deployer, err := NewController(
 		ctrl.Log.WithName("controllers").WithName("ManifestDeployer"),
 		mgr.GetClient(),

--- a/pkg/deployer/manifest/controller.go
+++ b/pkg/deployer/manifest/controller.go
@@ -19,14 +19,14 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	deployerlib "github.com/gardener/landscaper/pkg/deployer/lib"
 	"github.com/gardener/landscaper/pkg/deployer/targetselector"
 	"github.com/gardener/landscaper/pkg/utils/kubernetes"
 )
 
 // NewController creates a new deploy item controller that reconciles deploy items of type kubernetes manifest.
-func NewController(log logr.Logger, kubeClient client.Client, scheme *runtime.Scheme, config *manifestv1alpha1.Configuration) (reconcile.Reconciler, error) {
+func NewController(log logr.Logger, kubeClient client.Client, scheme *runtime.Scheme, config *manifestv1alpha2.Configuration) (reconcile.Reconciler, error) {
 	return &controller{
 		log:    log,
 		client: kubeClient,
@@ -39,7 +39,7 @@ type controller struct {
 	log    logr.Logger
 	client client.Client
 	scheme *runtime.Scheme
-	config *manifestv1alpha1.Configuration
+	config *manifestv1alpha2.Configuration
 }
 
 func (a *controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -19,7 +19,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	"github.com/gardener/landscaper/apis/deployer/manifest"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 	"github.com/gardener/landscaper/pkg/utils/kubernetes/health"
 )
@@ -35,12 +35,12 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 	}
 
 	if m.ProviderStatus == nil {
-		m.ProviderStatus = &manifest.ProviderStatus{
+		m.ProviderStatus = &manifestv1alpha2.ProviderStatus{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: manifest.SchemeGroupVersion.String(),
+				APIVersion: manifestv1alpha2.SchemeGroupVersion.String(),
 				Kind:       "ProviderStatus",
 			},
-			ManagedResources: make([]manifest.ManagedResourceStatus, 0),
+			ManagedResources: make([]manifestv1alpha2.ManagedResourceStatus, 0),
 		}
 	}
 
@@ -110,7 +110,7 @@ func (m *Manifest) Delete(ctx context.Context) error {
 
 	completed := true
 	for _, mr := range m.ProviderStatus.ManagedResources {
-		if mr.Policy == manifest.IgnorePolicy || mr.Policy == manifest.KeepPolicy {
+		if mr.Policy == manifestv1alpha2.IgnorePolicy || mr.Policy == manifestv1alpha2.KeepPolicy {
 			continue
 		}
 		ref := mr.Resource
@@ -154,9 +154,9 @@ func containsUnstructuredObject(obj *unstructured.Unstructured, objects []*unstr
 	return false
 }
 
-func encodeStatus(status *manifest.ProviderStatus) (*runtime.RawExtension, error) {
+func encodeStatus(status *manifestv1alpha2.ProviderStatus) (*runtime.RawExtension, error) {
 	status.TypeMeta = metav1.TypeMeta{
-		APIVersion: manifest.SchemeGroupVersion.String(),
+		APIVersion: manifestv1alpha2.SchemeGroupVersion.String(),
 		Kind:       "ProviderStatus",
 	}
 
@@ -179,7 +179,7 @@ func (m *Manifest) defaultCheckResourcesHealth(ctx context.Context, client clien
 	objects := make([]*unstructured.Unstructured, len(m.ProviderStatus.ManagedResources))
 	for i, managedResource := range m.ProviderStatus.ManagedResources {
 		// do not check ignored resources.
-		if managedResource.Policy == manifest.IgnorePolicy {
+		if managedResource.Policy == manifestv1alpha2.IgnorePolicy {
 			continue
 		}
 		ref := managedResource.Resource

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -18,8 +18,8 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	manifest "github.com/gardener/landscaper/apis/deployer/manifest"
 	manifestinstall "github.com/gardener/landscaper/apis/deployer/manifest/install"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 
 	manifestvalidation "github.com/gardener/landscaper/apis/deployer/manifest/validation"
 	"github.com/gardener/landscaper/pkg/api"
@@ -43,13 +43,13 @@ type Manifest struct {
 
 	DeployItem            *lsv1alpha1.DeployItem
 	Target                *lsv1alpha1.Target
-	ProviderConfiguration *manifest.ProviderConfiguration
-	ProviderStatus        *manifest.ProviderStatus
+	ProviderConfiguration *manifestv1alpha2.ProviderConfiguration
+	ProviderStatus        *manifestv1alpha2.ProviderStatus
 }
 
 // New creates a new internal manifest item
 func New(log logr.Logger, kubeClient client.Client, item *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) (*Manifest, error) {
-	config := &manifest.ProviderConfiguration{}
+	config := &manifestv1alpha2.ProviderConfiguration{}
 	currOp := "InitManifestOperation"
 	manifestDecoder := api.NewDecoder(ManifestScheme)
 	if _, _, err := manifestDecoder.Decode(item.Spec.Configuration.Raw, nil, config); err != nil {
@@ -62,9 +62,9 @@ func New(log logr.Logger, kubeClient client.Client, item *lsv1alpha1.DeployItem,
 			currOp, "ValidateProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
-	var status *manifest.ProviderStatus
+	var status *manifestv1alpha2.ProviderStatus
 	if item.Status.ProviderStatus != nil {
-		status = &manifest.ProviderStatus{}
+		status = &manifestv1alpha2.ProviderStatus{}
 		if _, _, err := manifestDecoder.Decode(item.Status.ProviderStatus.Raw, nil, status); err != nil {
 			return nil, lsv1alpha1helper.NewWrappedError(err,
 				currOp, "ParseProviderStatus", err.Error(), lsv1alpha1.ErrorConfigurationProblem)

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -17,8 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/apis/deployer/manifest"
-	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	"github.com/gardener/landscaper/pkg/api"
 	manifestctlr "github.com/gardener/landscaper/pkg/deployer/manifest"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
@@ -48,7 +47,7 @@ var _ = Describe("Manifest Deployer", func() {
 			logtesting.NullLogger{},
 			testenv.Client,
 			api.LandscaperScheme,
-			&manifestv1alpha1.Configuration{},
+			&manifestv1alpha2.Configuration{},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -64,7 +63,7 @@ var _ = Describe("Manifest Deployer", func() {
 		Expect(di.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
 		Expect(di.Status.ProviderStatus).ToNot(BeNil(), "the provider status should be written")
 
-		status := &manifest.ProviderStatus{}
+		status := &manifestv1alpha2.ProviderStatus{}
 		manifestDecoder := serializer.NewCodecFactory(manifestctlr.ManifestScheme).UniversalDecoder()
 		_, _, err = manifestDecoder.Decode(di.Status.ProviderStatus.Raw, nil, status)
 		testutil.ExpectNoError(err)
@@ -96,7 +95,7 @@ var _ = Describe("Manifest Deployer", func() {
 			logtesting.NullLogger{},
 			testenv.Client,
 			api.LandscaperScheme,
-			&manifestv1alpha1.Configuration{},
+			&manifestv1alpha2.Configuration{},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -146,7 +145,7 @@ var _ = Describe("Manifest Deployer", func() {
 			logtesting.NullLogger{},
 			testenv.Client,
 			api.LandscaperScheme,
-			&manifestv1alpha1.Configuration{},
+			&manifestv1alpha2.Configuration{},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -199,7 +198,7 @@ var _ = Describe("Manifest Deployer", func() {
 			logtesting.NullLogger{},
 			testenv.Client,
 			api.LandscaperScheme,
-			&manifestv1alpha1.Configuration{},
+			&manifestv1alpha2.Configuration{},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -214,7 +213,7 @@ var _ = Describe("Manifest Deployer", func() {
 		Expect(di.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseProgressing))
 		Expect(di.Status.ProviderStatus).ToNot(BeNil(), "the provider status should be written")
 
-		status := &manifest.ProviderStatus{}
+		status := &manifestv1alpha2.ProviderStatus{}
 		manifestDecoder := serializer.NewCodecFactory(manifestctlr.ManifestScheme).UniversalDecoder()
 		_, _, err = manifestDecoder.Decode(di.Status.ProviderStatus.Raw, nil, status)
 		testutil.ExpectNoError(err)

--- a/test/integration/deployers/container_tests.go
+++ b/test/integration/deployers/container_tests.go
@@ -21,12 +21,7 @@ import (
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
-// RegisterTests registers all tests of this package
-func RegisterTests(f *framework.Framework) {
-	ManifestDeployerTests(f)
-}
-
-func ManifestDeployerTests(f *framework.Framework) {
+func ContainerDeployerTests(f *framework.Framework) {
 	var (
 		dumper     = f.Register()
 		exampleDir = path.Join(f.RootPath, "examples/deploy-items")

--- a/test/integration/deployers/manifest_tests.go
+++ b/test/integration/deployers/manifest_tests.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployers
+
+import (
+	"context"
+	"path"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	g "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+
+	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
+	manifest "github.com/gardener/landscaper/pkg/deployer/manifest"
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	"github.com/gardener/landscaper/test/framework"
+	"github.com/gardener/landscaper/test/utils"
+	"github.com/gardener/landscaper/test/utils/envtest"
+)
+
+func ManifestDeployerTests(f *framework.Framework) {
+	var (
+		dumper      = f.Register()
+		exampleDir  = path.Join(f.RootPath, "examples", "deploy-items")
+		testDataDir = path.Join(f.RootPath, "test", "testdata")
+	)
+
+	const (
+		timeout = 2 * time.Minute
+	)
+
+	ginkgo.Describe("Manifest Deployer", func() {
+
+		var (
+			ctx     context.Context
+			state   *envtest.State
+			cleanup framework.CleanupFunc
+		)
+
+		ginkgo.BeforeEach(func() {
+			ctx = context.Background()
+			var err error
+			state, cleanup, err = f.NewState(ctx)
+			utils.ExpectNoError(err)
+			dumper.AddNamespaces(state.Namespace)
+		})
+
+		ginkgo.AfterEach(func() {
+			defer ctx.Done()
+			g.Expect(cleanup(ctx)).ToNot(g.HaveOccurred())
+		})
+
+		ginkgo.It("should deploy Kubernetes objects through their v1alpha2 manifests", func() {
+			ginkgo.By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			target.Name = "my-cluster-target"
+			target.Namespace = state.Namespace
+			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+
+			di := &lsv1alpha1.DeployItem{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "40-DeployItem-Manifest-secret.yaml")))
+			di.SetName("")
+			di.SetGenerateName("secret-manifest-")
+			di.SetNamespace(state.Namespace)
+			di.Spec.Target = &lsv1alpha1.ObjectReference{
+				Name:      target.Name,
+				Namespace: target.Namespace,
+			}
+
+			ginkgo.By("Create Manifest (v1alpha2) deploy item")
+			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
+
+			ginkgo.By("Check presence of Kubernetes Objects")
+			config := &manifestv1alpha2.ProviderConfiguration{}
+			manifestDecoder := serializer.NewCodecFactory(manifest.ManifestScheme).UniversalDecoder()
+			_, _, err = manifestDecoder.Decode(di.Spec.Configuration.Raw, nil, config)
+			g.Expect(err).ToNot(g.HaveOccurred())
+
+			var objectsToBeDeleted []*unstructured.Unstructured
+
+			for _, m := range config.Manifests {
+				manifestObject := &unstructured.Unstructured{}
+				_, _, err = manifestDecoder.Decode(m.Manifest.Raw, nil, manifestObject)
+				g.Expect(err).ToNot(g.HaveOccurred())
+
+				apiObject := &unstructured.Unstructured{}
+				apiObject.GetObjectKind().SetGroupVersionKind(manifestObject.GetObjectKind().GroupVersionKind())
+				key := kutil.ObjectKey(manifestObject.GetName(), manifestObject.GetNamespace())
+				// if this returns without error it means the object exists in the API and thus the manifest has been applied
+				utils.ExpectNoError(f.Client.Get(ctx, key, apiObject))
+
+				objectsToBeDeleted = append(objectsToBeDeleted, manifestObject)
+			}
+
+			ginkgo.By("Delete Manifest (v1alpha2) deploy item")
+			utils.ExpectNoError(f.Client.Delete(ctx, di))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, di, timeout))
+
+			ginkgo.By("Check successful deletion Kubernetes objects")
+			for _, o := range objectsToBeDeleted {
+				key := kutil.ObjectKey(o.GetName(), o.GetNamespace())
+				apiObject := &unstructured.Unstructured{}
+				apiObject.GetObjectKind().SetGroupVersionKind(o.GetObjectKind().GroupVersionKind())
+				err = f.Client.Get(ctx, key, apiObject)
+				g.Expect(err).NotTo(g.BeNil())
+				g.Expect(apierrors.IsNotFound(err)).To(g.BeTrue())
+			}
+		})
+
+		ginkgo.It("should deploy Kubernetes objects through their v1alpha1 manifests", func() {
+			ginkgo.By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			target.Name = "my-cluster-target"
+			target.Namespace = state.Namespace
+			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+
+			di := &lsv1alpha1.DeployItem{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(testDataDir, "00-DeployItem-Manifest-v1alpha1.yaml")))
+			di.SetName("")
+			di.SetGenerateName("v1alpha1-manifest-")
+			di.SetNamespace(state.Namespace)
+			di.Spec.Target = &lsv1alpha1.ObjectReference{
+				Name:      target.Name,
+				Namespace: target.Namespace,
+			}
+
+			ginkgo.By("Create Manifest (v1alpha1) deploy item")
+			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
+
+			ginkgo.By("Check presence of Kubernetes objects")
+			config := &manifestv1alpha1.ProviderConfiguration{}
+			manifestDecoder := serializer.NewCodecFactory(manifest.ManifestScheme).UniversalDecoder()
+			_, _, err = manifestDecoder.Decode(di.Spec.Configuration.Raw, nil, config)
+			g.Expect(err).ToNot(g.HaveOccurred())
+
+			for _, m := range config.Manifests {
+				manifestObject := &unstructured.Unstructured{}
+				_, _, err = manifestDecoder.Decode(m.Raw, nil, manifestObject)
+				g.Expect(err).ToNot(g.HaveOccurred())
+
+				apiObject := &unstructured.Unstructured{}
+				apiObject.GetObjectKind().SetGroupVersionKind(manifestObject.GetObjectKind().GroupVersionKind())
+				key := kutil.ObjectKey(manifestObject.GetName(), manifestObject.GetNamespace())
+				// if this returns without error it means the object exists in the API and thus the manifest has been applied
+				utils.ExpectNoError(f.Client.Get(ctx, key, apiObject))
+			}
+
+			ginkgo.By("Delete Manifest (v1alpha1) deploy item")
+			utils.ExpectNoError(f.Client.Delete(ctx, di))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, di, timeout))
+		})
+	})
+}

--- a/test/integration/deployers/register.go
+++ b/test/integration/deployers/register.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployers
+
+import (
+	"github.com/gardener/landscaper/test/framework"
+)
+
+// RegisterTests registers all tests of this package
+func RegisterTests(f *framework.Framework) {
+	ContainerDeployerTests(f)
+	ManifestDeployerTests(f)
+}

--- a/test/testdata/00-DeployItem-Manifest-v1alpha1.yaml
+++ b/test/testdata/00-DeployItem-Manifest-v1alpha1.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: my-secret
+spec:
+  type: landscaper.gardener.cloud/kubernetes-manifest
+
+  target:
+    name: my-cluster
+    namespace: default
+
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    kind: ProviderConfiguration
+
+    manifests: # list of kubernetes manifests
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: my-namespace
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: my-secret
+        namespace: my-namespace
+      stringData:
+        config: my-val

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/validation/validation.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/validation/validation.go
@@ -10,11 +10,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/gardener/landscaper/apis/deployer/manifest"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 )
 
 // ValidateProviderConfiguration validates a manifest provider configuration.
-func ValidateProviderConfiguration(config *manifest.ProviderConfiguration) error {
+func ValidateProviderConfiguration(config *manifestv1alpha2.ProviderConfiguration) error {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateManifestList(field.NewPath(""), config.Manifests)...)
 	allErrs = append(allErrs, ValidateTimeout(field.NewPath("deleteTimeout"), config.DeleteTimeout)...)
@@ -23,7 +23,7 @@ func ValidateProviderConfiguration(config *manifest.ProviderConfiguration) error
 }
 
 // ValidateManifestList validates a list of manifests.
-func ValidateManifestList(fldPath *field.Path, list []manifest.Manifest) field.ErrorList {
+func ValidateManifestList(fldPath *field.Path, list []manifestv1alpha2.Manifest) field.ErrorList {
 	var allErrs field.ErrorList
 	for i, m := range list {
 		allErrs = append(allErrs, ValidateManifest(fldPath.Index(i), m)...)
@@ -32,7 +32,7 @@ func ValidateManifestList(fldPath *field.Path, list []manifest.Manifest) field.E
 }
 
 // ValidateManifest validates a manifest.
-func ValidateManifest(fldPath *field.Path, manifest manifest.Manifest) field.ErrorList {
+func ValidateManifest(fldPath *field.Path, manifest manifestv1alpha2.Manifest) field.ErrorList {
 	var allErrs field.ErrorList
 	if manifest.Manifest == nil || len(manifest.Manifest.Raw) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("manifest"), "manifest must be defined"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area manifest-deployer
/kind cleanup
/priority 4

**What this PR does / why we need it**:

The manifest-deployer has been using a mixture of v1alpha1 and internal API objects so far. With this PR it will use v1alpha2 objects exclusively. This will also fix the problem with the returned `ProviderStatus` object having the wrong version `manifest.deployer.landscaper.gardener.cloud/__internal`.
An integration test for the manifest deployer and checks if it can deal with v1alpha2 and v1alpha1 `ProviderConfiguration` alike and is meant to detect possible API conversion issues.

**Which issue(s) this PR fixes**:
Fixes #152

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The manifest-deployer internally uses v1alpha2 objects exclusively.
Fixes the wrong version of the Status object, it will be manifest.deployer.landscaper.gardener.cloud/v1alpha2 now.
Integration test for the manifest-deployer to check if it can handle both, v1alpha1 and v1alpha2 ProviderConfigurations.
```
