### PR TITLE
Changed Ingress from v1beta1 to v1 in documentation and examples.

### DIFF
--- a/docs/tutorials/03-simple-import.md
+++ b/docs/tutorials/03-simple-import.md
@@ -117,7 +117,7 @@ deployItems:
           - protocol: TCP
             port: 80
             targetPort: 5678
-      - apiVersion: networking.k8s.io/v1beta1
+      - apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: {{ $name }}
@@ -132,8 +132,10 @@ deployItems:
               - path: /
                 pathType: Prefix
                 backend:
-                  serviceName: echo-server
-                  servicePort: 80
+                  service:
+                    name: echo-server
+                    port:
+                      number: 80
 ```
 
 Upload the blueprint into the oci registry.

--- a/docs/tutorials/05-external-jsonschema.md
+++ b/docs/tutorials/05-external-jsonschema.md
@@ -254,7 +254,7 @@ deployItems:
           - protocol: TCP
             port: 80
             targetPort: 5678
-      - apiVersion: networking.k8s.io/v1beta1
+      - apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: {{ $name }}
@@ -269,8 +269,10 @@ deployItems:
               - path: /
                 pathType: Prefix
                 backend:
-                  serviceName: echo-server
-                  servicePort: 80
+                  service:
+                    name: echo-server
+                    port:
+                      number: 80
 ```
 
 ```yaml

--- a/docs/tutorials/resources/echo-server/blueprint/defaultDeployExecution.yaml
+++ b/docs/tutorials/resources/echo-server/blueprint/defaultDeployExecution.yaml
@@ -51,7 +51,7 @@ deployItems:
           - protocol: TCP
             port: 80
             targetPort: 5678
-      - apiVersion: networking.k8s.io/v1beta1
+      - apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: {{ $name }}
@@ -66,6 +66,7 @@ deployItems:
               - path: /
                 pathType: Prefix
                 backend:
-                  serviceName: echo-server
-                  servicePort: 80
-
+                  service:
+                    name: echo-server
+                    port: 
+                      number: 80

--- a/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/defaultDeployExecution.yaml
+++ b/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/defaultDeployExecution.yaml
@@ -54,7 +54,7 @@ deployItems:
           - protocol: TCP
             port: 80
             targetPort: 5678
-      - apiVersion: networking.k8s.io/v1beta1
+      - apiVersion: networking.k8s.io/v1
         kind: Ingress
         metadata:
           name: {{ $name }}
@@ -69,6 +69,7 @@ deployItems:
               - path: /
                 pathType: Prefix
                 backend:
-                  serviceName: echo-server
-                  servicePort: 80
-
+                  service:
+                    name: echo-server
+                    port: 
+                      number: 80

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/NOTES.txt
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/NOTES.txt
@@ -29,7 +29,7 @@ Get the application URL by running these commands:
 
 An example Ingress that makes use of the controller:
 
-  apiVersion: networking.k8s.io/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     annotations:
@@ -42,8 +42,10 @@ An example Ingress that makes use of the controller:
         http:
           paths:
             - backend:
-                serviceName: exampleService
-                servicePort: 80
+                service:
+                  name: exampleService
+                  port:
+                    number: 80
               path: /
     # This section is only required if TLS is to be enabled for the Ingress
     tls:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup
/priority 5

**What this PR does / why we need it**:
The documentation and examples make use of _Ingress_ manifests with `apiVersion: networking.k8s.io/v1beta1`. Ingresses got moved to v1 since Kubernetes 1.19, have been deprecated in `v1beta1` since and will be removed from it in Kubernetes 1.22.
This PR changed the Ingresses in the documentation and in the examples to v1 with the API changes that came with it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Ingress resources in the documentation and in the examples are updated from v1beta1 to v1.
```
