### PR TITLE
Integration test logging to include start/end timestamps

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -247,7 +247,11 @@ func (f *Framework) NewState(ctx context.Context) (*envtest.State, CleanupFunc, 
 // that is called by ginkgo before and after each test
 func (f *Framework) Register() *Dumper {
 	dumper := NewDumper(f.logger, f.Client, f.ClientSet, f.LsNamespace)
+	ginkgo.BeforeEach(func() {
+		dumper.startTime = time.Now()
+	})
 	ginkgo.AfterEach(func() {
+		dumper.endTime = time.Now()
 		if !ginkgo.CurrentGinkgoTestDescription().Failed {
 			return
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 4

**What this PR does / why we need it**:

This PR changes the log collection in the integration test framework not to collect every log taken since the beginning of the all tests but only since a specific timestamp which will be set to the start-time of each individual test for each individual test. It makes reading the logs much easier because it eliminates duplicated output.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Elimination of duplication of logs from integration tests.
```
