### PR TITLE
Allows setting Landscaper cluster kubeconfig in all deployer charts and blueprints

### DIFF
--- a/.landscaper/container-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/container-deployer/blueprint/blueprint.yaml
@@ -15,6 +15,7 @@ imports:
     type: string
 - name: values
   schema:
+    description: "values for the container-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/container-deployer/values.yaml`"
     type: object
 
 deployExecutions:

--- a/.landscaper/container-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/container-deployer/blueprint/blueprint.yaml
@@ -4,6 +4,9 @@ kind: Blueprint
 imports:
 - name: cluster
   targetType: landscaper.gardener.cloud/kubernetes-cluster
+- name: landscaperCluster
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+  required: false
 - name: releaseName
   schema:
     type: string
@@ -39,11 +42,18 @@ deployExecutions:
     {{ $imgresource := getResource .cd "name" "container-deployer-image" }}
     {{ $imgrepo := ociRefRepo $imgresource.access.imageReference }}
     {{ $imgtag := ociRefVersion $imgresource.access.imageReference }}
-    
-    {{ $image := dict "image" .imports.values.image }}
     {{ $imgref := dict "repository" $imgrepo "tag" $imgtag }}
-    {{ $newimg := dict "image" $imgref }}
-    {{ $newval := dict "values" $newimg }}
 
-    {{ $val := mergeOverwrite $values $newval }}   
+    {{ $newvals := dict "image" $imgref }}
+
+    {{ if .imports.landscaperCluster  }}
+    {{ $lsClusterKubeconfig := .imports.landscaperCluster.spec.config.kubeconfig }}
+    {{ $newKubeconfig := dict "kubeconfig" $lsClusterKubeconfig }}
+    {{ $newLsClusterKubeconfig := dict "landscaperClusterKubeconfig" $newKubeconfig }}
+    {{ $_ := set $newvals "deployer" $newLsClusterKubeconfig }}
+    {{ end }}
+
+    {{ $mergevals := dict "values" $newvals }}
+
+    {{ $val := mergeOverwrite $values $mergevals }}
     {{ toYaml $val | indent 4 }}

--- a/.landscaper/helm-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/helm-deployer/blueprint/blueprint.yaml
@@ -15,6 +15,7 @@ imports:
     type: string
 - name: values
   schema:
+    description: "values for the helm-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/helm-deployer/values.yaml`"
     type: object
 
 deployExecutions:

--- a/.landscaper/helm-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/helm-deployer/blueprint/blueprint.yaml
@@ -4,6 +4,9 @@ kind: Blueprint
 imports:
 - name: cluster
   targetType: landscaper.gardener.cloud/kubernetes-cluster
+- name: landscaperCluster
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+  required: false
 - name: releaseName
   schema:
     type: string
@@ -39,11 +42,14 @@ deployExecutions:
     {{ $imgresource := getResource .cd "name" "helm-deployer-image" }}
     {{ $imgrepo := ociRefRepo $imgresource.access.imageReference }}
     {{ $imgtag := ociRefVersion $imgresource.access.imageReference }}
-    
-    {{ $image := dict "image" .imports.values.image }}
     {{ $imgref := dict "repository" $imgrepo "tag" $imgtag }}
-    {{ $newimg := dict "image" $imgref }}
-    {{ $newval := dict "values" $newimg }}
 
-    {{ $val := mergeOverwrite $values $newval }}   
+    {{ $lsClusterKubeconfig := .imports.landscaperCluster.spec.config.kubeconfig }}
+    {{ $newKubeconfig := dict "kubeconfig" $lsClusterKubeconfig }}
+    {{ $newLsClusterKubeconfig := dict "landscaperClusterKubeconfig" $newKubeconfig }}
+
+    {{ $newvals := dict "image" $imgref "deployer" $newLsClusterKubeconfig }}
+    {{ $mergevals := dict "values" $newvals }}
+
+    {{ $val := mergeOverwrite $values $mergevals }}
     {{ toYaml $val | indent 4 }}

--- a/.landscaper/helm-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/helm-deployer/blueprint/blueprint.yaml
@@ -44,11 +44,15 @@ deployExecutions:
     {{ $imgtag := ociRefVersion $imgresource.access.imageReference }}
     {{ $imgref := dict "repository" $imgrepo "tag" $imgtag }}
 
+    {{ $newvals := dict "image" $imgref }}
+
+    {{ if .imports.landscaperCluster  }}
     {{ $lsClusterKubeconfig := .imports.landscaperCluster.spec.config.kubeconfig }}
     {{ $newKubeconfig := dict "kubeconfig" $lsClusterKubeconfig }}
     {{ $newLsClusterKubeconfig := dict "landscaperClusterKubeconfig" $newKubeconfig }}
+    {{ $_ := set $newvals "deployer" $newLsClusterKubeconfig }}
+    {{ end }}
 
-    {{ $newvals := dict "image" $imgref "deployer" $newLsClusterKubeconfig }}
     {{ $mergevals := dict "values" $newvals }}
 
     {{ $val := mergeOverwrite $values $mergevals }}

--- a/.landscaper/manifest-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/manifest-deployer/blueprint/blueprint.yaml
@@ -4,6 +4,9 @@ kind: Blueprint
 imports:
 - name: cluster
   targetType: landscaper.gardener.cloud/kubernetes-cluster
+- name: landscaperCluster
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+  required: false
 - name: releaseName
   schema:
     type: string
@@ -39,11 +42,18 @@ deployExecutions:
     {{ $imgresource := getResource .cd "name" "manifest-deployer-image" }}
     {{ $imgrepo := ociRefRepo $imgresource.access.imageReference }}
     {{ $imgtag := ociRefVersion $imgresource.access.imageReference }}
-    
-    {{ $image := dict "image" .imports.values.image }}
     {{ $imgref := dict "repository" $imgrepo "tag" $imgtag }}
-    {{ $newimg := dict "image" $imgref }}
-    {{ $newval := dict "values" $newimg }}
 
-    {{ $val := mergeOverwrite $values $newval }}   
+    {{ $newvals := dict "image" $imgref }}
+
+    {{ if .imports.landscaperCluster  }}
+    {{ $lsClusterKubeconfig := .imports.landscaperCluster.spec.config.kubeconfig }}
+    {{ $newKubeconfig := dict "kubeconfig" $lsClusterKubeconfig }}
+    {{ $newLsClusterKubeconfig := dict "landscaperClusterKubeconfig" $newKubeconfig }}
+    {{ $_ := set $newvals "deployer" $newLsClusterKubeconfig }}
+    {{ end }}
+
+    {{ $mergevals := dict "values" $newvals }}
+
+    {{ $val := mergeOverwrite $values $mergevals }}
     {{ toYaml $val | indent 4 }}

--- a/.landscaper/manifest-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/manifest-deployer/blueprint/blueprint.yaml
@@ -15,6 +15,7 @@ imports:
     type: string
 - name: values
   schema:
+    description: "values for the manifest-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/manifest-deployer/values.yaml`"
     type: object
 
 deployExecutions:

--- a/.landscaper/mock-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/mock-deployer/blueprint/blueprint.yaml
@@ -15,6 +15,7 @@ imports:
     type: string
 - name: values
   schema:
+    description: "values for the mock-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/mock-deployer/values.yaml`"
     type: object
 
 deployExecutions:

--- a/.landscaper/mock-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/mock-deployer/blueprint/blueprint.yaml
@@ -4,6 +4,9 @@ kind: Blueprint
 imports:
 - name: cluster
   targetType: landscaper.gardener.cloud/kubernetes-cluster
+- name: landscaperCluster
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+  required: false
 - name: releaseName
   schema:
     type: string
@@ -39,12 +42,19 @@ deployExecutions:
     {{ $imgresource := getResource .cd "name" "mock-deployer-image" }}
     {{ $imgrepo := ociRefRepo $imgresource.access.imageReference }}
     {{ $imgtag := ociRefVersion $imgresource.access.imageReference }}
-    
-    {{ $image := dict "image" .imports.values.image }}
     {{ $imgref := dict "repository" $imgrepo "tag" $imgtag }}
-    {{ $newimg := dict "image" $imgref }}
-    {{ $newval := dict "values" $newimg }}
 
-    {{ $val := mergeOverwrite $values $newval }}   
+    {{ $newvals := dict "image" $imgref }}
+
+    {{ if .imports.landscaperCluster  }}
+    {{ $lsClusterKubeconfig := .imports.landscaperCluster.spec.config.kubeconfig }}
+    {{ $newKubeconfig := dict "kubeconfig" $lsClusterKubeconfig }}
+    {{ $newLsClusterKubeconfig := dict "landscaperClusterKubeconfig" $newKubeconfig }}
+    {{ $_ := set $newvals "deployer" $newLsClusterKubeconfig }}
+    {{ end }}
+
+    {{ $mergevals := dict "values" $newvals }}
+
+    {{ $val := mergeOverwrite $values $mergevals }}
     {{ toYaml $val | indent 4 }}
    

--- a/charts/container-deployer/templates/deployment.yaml
+++ b/charts/container-deployer/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          {{- end }}
           {{- if .Values.deployer.verbosityLevel }}
           - "-v={{ .Values.deployer.verbosityLevel }}"
           {{- end }}
@@ -48,6 +51,10 @@ spec:
           {{- if .Values.deployer.oci }}
           - name: ociregistry
             mountPath: /app/ls/registry/
+          {{- end }}
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - name: landscaper-cluster-kubeconfig
+            mountPath: /app/ls/landscaper-cluster-kubeconfig
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -59,6 +66,15 @@ spec:
       - name: ociregistry
         secret:
           secretName: {{ include "deployer.fullname" . }}-registry
+      {{- end }}
+      {{- if .Values.deployer.landscaperClusterKubeconfig }}
+      - name: landscaper-cluster-kubeconfig
+        secret:
+          {{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+          secretName:  {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+          {{- else }}
+          secretName:  {{ .Values.deployer.landscaperClusterKubeconfig.secretRef }}
+          {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/container-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
+++ b/charts/container-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+  labels:
+    {{- include "deployer.labels" . | nindent 4 }}
+data:
+  kubeconfig: {{ .Values.deployer.landscaperClusterKubeconfig.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/container-deployer/values.yaml
+++ b/charts/container-deployer/values.yaml
@@ -7,6 +7,15 @@
 # Declare variables to be passed into your templates.
 
 deployer:
+  # If the deployer runs in a different cluster than the Landscaper instance, provide the kubeconfig
+  # to access the remote Landscaper cluster here (inline or via secretRef). When providing a
+  # secretRef, see ./templates/landscaper-cluster-kubeconfig-secret.yaml for the correct secret format.
+  # If no value is provided at all, the deployer will default to the in-cluster kubeconfig.
+  landscaperClusterKubeconfig: {}
+  #   secretRef: my-kubeconfig-secret
+  #   kubeconfig: |
+  #     <landscaper-cluster-kubeconfig>
+
 #  namespace: ""
   initContainer:
     repository: eu.gcr.io/gardener-project/landscaper/container-deployer-init

--- a/charts/helm-deployer/templates/deployment.yaml
+++ b/charts/helm-deployer/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          {{- end }}
           {{- if .Values.deployer.verbosityLevel }}
           - "-v={{ .Values.deployer.verbosityLevel }}"
           {{- end }}
@@ -48,6 +51,10 @@ spec:
           {{- if .Values.deployer.oci }}
           - name: ociregistry
             mountPath: /app/ls/registry/
+          {{- end }}
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - name: landscaper-cluster-kubeconfig
+            mountPath: /app/ls/landscaper-cluster-kubeconfig
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -59,6 +66,15 @@ spec:
       - name: ociregistry
         secret:
           secretName: {{ include "deployer.fullname" . }}-registries
+      {{- end }}
+      {{- if .Values.deployer.landscaperClusterKubeconfig }}
+      - name: landscaper-cluster-kubeconfig
+        secret:
+          {{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+          secretName:  {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+          {{- else }}
+          secretName:  {{ .Values.deployer.landscaperClusterKubeconfig.secretRef }}
+          {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/helm-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
+++ b/charts/helm-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+  labels:
+    {{- include "deployer.labels" . | nindent 4 }}
+data:
+  kubeconfig: {{ .Values.deployer.landscaperClusterKubeconfig.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/helm-deployer/values.yaml
+++ b/charts/helm-deployer/values.yaml
@@ -7,6 +7,15 @@
 # Declare variables to be passed into your templates.
 
 deployer:
+  # If the deployer runs in a different cluster than the Landscaper instance, provide the kubeconfig
+  # to access the remote Landscaper cluster here (inline or via secretRef). When providing a
+  # secretRef, see ./templates/landscaper-cluster-kubeconfig-secret.yaml for the correct secret format.
+  # If no value is provided at all, the deployer will default to the in-cluster kubeconfig.
+  landscaperClusterKubeconfig: {}
+  #   secretRef: my-kubeconfig-secret
+  #   kubeconfig: |
+  #     <landscaper-cluster-kubeconfig>
+
   namespace: ""
   oci: 
     allowPlainHttp: false

--- a/charts/manifest-deployer/templates/deployment.yaml
+++ b/charts/manifest-deployer/templates/deployment.yaml
@@ -42,16 +42,32 @@ spec:
       {{- if .Values.targetSelector }}
           args:
           - "--config=/app/ls/config/config.yaml"
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          {{- end }}
           {{- if .Values.deployer.verbosityLevel }}
           - "-v={{ .Values.deployer.verbosityLevel }}"
           {{- end }}
           volumeMounts:
           - name: config
             mountPath: /app/ls/config/
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - name: landscaper-cluster-kubeconfig
+            mountPath: /app/ls/landscaper-cluster-kubeconfig
+          {{- end }}
       volumes:
       - name: config
         secret:
           secretName: {{ include "deployer.fullname" . }}-config
+      {{- if .Values.deployer.landscaperClusterKubeconfig }}
+      - name: landscaper-cluster-kubeconfig
+        secret:
+          {{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+          secretName:  {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+          {{- else }}
+          secretName:  {{ .Values.deployer.landscaperClusterKubeconfig.secretRef }}
+          {{- end }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/manifest-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
+++ b/charts/manifest-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+  labels:
+    {{- include "deployer.labels" . | nindent 4 }}
+data:
+  kubeconfig: {{ .Values.deployer.landscaperClusterKubeconfig.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/manifest-deployer/values.yaml
+++ b/charts/manifest-deployer/values.yaml
@@ -7,6 +7,15 @@
 # Declare variables to be passed into your templates.
 
 deployer:
+  # If the deployer runs in a different cluster than the Landscaper instance, provide the kubeconfig
+  # to access the remote Landscaper cluster here (inline or via secretRef). When providing a
+  # secretRef, see ./templates/landscaper-cluster-kubeconfig-secret.yaml for the correct secret format.
+  # If no value is provided at all, the deployer will default to the in-cluster kubeconfig.
+  landscaperClusterKubeconfig: {}
+  #   secretRef: my-kubeconfig-secret
+  #   kubeconfig: |
+  #     <landscaper-cluster-kubeconfig>
+
   namespace: ""
 #  verbosityLevel: 9
 

--- a/charts/mock-deployer/templates/deployment.yaml
+++ b/charts/mock-deployer/templates/deployment.yaml
@@ -35,8 +35,27 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.deployer.landscaperClusterKubeconfig }}
+          - name: landscaper-cluster-kubeconfig
+            mountPath: /app/ls/landscaper-cluster-kubeconfig
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      {{- if .Values.deployer.landscaperClusterKubeconfig }}
+      - name: landscaper-cluster-kubeconfig
+        secret:
+          {{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+          secretName:  {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+          {{- else }}
+          secretName:  {{ .Values.deployer.landscaperClusterKubeconfig.secretRef }}
+          {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mock-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
+++ b/charts/mock-deployer/templates/landscaper-cluster-kubeconfig-secret.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.deployer.landscaperClusterKubeconfig.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deployer.fullname" . }}-landscaper-cluster-kubeconfig
+  labels:
+    {{- include "deployer.labels" . | nindent 4 }}
+data:
+  kubeconfig: {{ .Values.deployer.landscaperClusterKubeconfig.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/mock-deployer/values.yaml
+++ b/charts/mock-deployer/values.yaml
@@ -9,6 +9,15 @@
 replicaCount: 1
 
 deployer:
+  # If the deployer runs in a different cluster than the Landscaper instance, provide the kubeconfig
+  # to access the remote Landscaper cluster here (inline or via secretRef). When providing a
+  # secretRef, see ./templates/landscaper-cluster-kubeconfig-secret.yaml for the correct secret format.
+  # If no value is provided at all, the deployer will default to the in-cluster kubeconfig.
+  landscaperClusterKubeconfig: {}
+  #   secretRef: my-kubeconfig-secret
+  #   kubeconfig: |
+  #     <landscaper-cluster-kubeconfig>
+
   namespace: ""
 
 image:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/priority normal

**What this PR does / why we need it**:
Adds an option in the Helm deployer chart to provide the kubeconfig for a remote cluster where a Landscaper instance is running. This allows the deployer to be deployed in a different cluster than the Landscaper instance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We would provide this feature for the other deployers in subsequent PRs, once we have agreed on this one and merged it.

Co-authored by @enrico-kaack-comp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allows setting Landscaper cluster kubeconfig in all deployer charts and blueprints
```
