### PR TITLE
add health helper functions and restructure utils

### DIFF
--- a/apis/core/v1alpha1/health/health.go
+++ b/apis/core/v1alpha1/health/health.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package health
+
+import (
+	"fmt"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+)
+
+var (
+	installationConditionTypesTrue = []lsv1alpha1.ConditionType{
+		lsv1alpha1.EnsureSubInstallationsCondition,
+		lsv1alpha1.ReconcileExecutionCondition,
+		lsv1alpha1.CreateImportsCondition,
+		lsv1alpha1.CreateExportsCondition,
+		lsv1alpha1.EnsureExecutionsCondition,
+		lsv1alpha1.ValidateExportCondition,
+	}
+
+	installationConditionTypesFalse = []lsv1alpha1.ConditionType{
+		lsv1alpha1.ValidateImportsCondition,
+	}
+)
+
+// CheckInstallation checks if the given Installation is healthy
+// An installation is healthy if
+// * Its observed generation is up-to-date
+// * No annotation landscaper.gardener.cloud/operation is set
+// * No lastError is in the status
+// * A last operation in state succeeded is present
+// * landscaperv1alpha1.ComponentPhaseSucceeded
+func CheckInstallation(installation *lsv1alpha1.Installation) error {
+	if installation.Status.ObservedGeneration < installation.Generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", installation.Status.ObservedGeneration, installation.Generation)
+	}
+
+	if installation.Status.LastError != nil {
+		return fmt.Errorf("last errors is set: %s", installation.Status.LastError.Message)
+	}
+
+	if installation.Status.Phase != lsv1alpha1.ComponentPhaseSucceeded {
+		return fmt.Errorf("installation phase is not suceeded, but %s", installation.Status.Phase)
+	}
+
+	if op, ok := installation.Annotations[lsv1alpha1.OperationAnnotation]; ok {
+		return fmt.Errorf("landscaper operation %q is not yet picked up by controller", op)
+	}
+
+	for _, conditionType := range installationConditionTypesTrue {
+		condition := lsv1alpha1helper.GetCondition(installation.Status.Conditions, conditionType)
+		if condition == nil {
+			// conditions vary based on what is configured in the installation
+			continue
+		}
+
+		if err := checkConditionState(string(conditionType), string(lsv1alpha1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
+			return err
+		}
+	}
+
+	for _, conditionType := range installationConditionTypesFalse {
+		condition := lsv1alpha1helper.GetCondition(installation.Status.Conditions, conditionType)
+		if condition == nil {
+			continue
+		}
+
+		if err := checkConditionState(string(conditionType), string(lsv1alpha1.ConditionFalse), string(condition.Status), condition.Reason, condition.Message); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkConditionState(conditionType string, expected, actual, reason, message string) error {
+	if expected != actual {
+		return fmt.Errorf("condition %q has invalid status %s (expected %s) due to %s: %s",
+			conditionType, actual, expected, reason, message)
+	}
+	return nil
+}

--- a/test/integration/core/registry.go
+++ b/test/integration/core/registry.go
@@ -27,6 +27,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
@@ -105,9 +106,9 @@ func RegistryTest(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, inst, lsv1alpha1.ComponentPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
 
-			deployItems, err := utils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
 			gomega.Expect(deployItems).To(gomega.HaveLen(1))
 			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))

--- a/test/integration/deployers/container_tests.go
+++ b/test/integration/deployers/container_tests.go
@@ -16,6 +16,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
@@ -70,7 +71,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 
 			ginkgo.By("Create container deploy item")
 			utils.ExpectNoError(state.Create(ctx, f.Client, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			ginkgo.By("Delete container deploy item")
 			utils.ExpectNoError(f.Client.Delete(ctx, di))
@@ -98,7 +99,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 
 			ginkgo.By("Create erroneous container deploy item")
 			utils.ExpectNoError(state.Create(ctx, f.Client, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseFailed, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseFailed, 2*time.Minute))
 
 			ginkgo.By("update the DeployItem and set a valid image")
 			utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKey(di.Name, di.Namespace), di))
@@ -108,7 +109,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			di.Spec.Configuration = updatedDi.Spec.Configuration
 			utils.ExpectNoError(f.Client.Update(ctx, di))
 
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			ginkgo.By("Delete container deploy item")
 			utils.ExpectNoError(f.Client.Delete(ctx, di))
@@ -135,11 +136,11 @@ func ContainerDeployerTests(f *framework.Framework) {
 
 			ginkgo.By("Create container deploy item")
 			utils.ExpectNoError(state.Create(ctx, f.Client, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			// expect that the export contains a valid json with { "my-val": true }
 			g.Expect(di.Status.ExportReference).ToNot(g.BeNil())
-			exportData, err := utils.GetDeployItemExport(ctx, f.Client, di)
+			exportData, err := lsutils.GetDeployItemExport(ctx, f.Client, di)
 			utils.ExpectNoError(err)
 			g.Expect(exportData).To(g.MatchJSON(`{ "my-val": true }`))
 
@@ -168,21 +169,21 @@ func ContainerDeployerTests(f *framework.Framework) {
 
 			ginkgo.By("Create container deploy item")
 			utils.ExpectNoError(state.Create(ctx, f.Client, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			// expect that the export contains a valid json with { "counter": 1 }
 			g.Expect(di.Status.ExportReference).ToNot(g.BeNil())
-			exportData, err := utils.GetDeployItemExport(ctx, f.Client, di)
+			exportData, err := lsutils.GetDeployItemExport(ctx, f.Client, di)
 			utils.ExpectNoError(err)
 			g.Expect(exportData).To(g.MatchJSON(`{ "counter": 1 }`))
 
 			ginkgo.By("Rerun the deployitem")
 			metav1.SetMetaDataAnnotation(&di.ObjectMeta, lsv1alpha1.OperationAnnotation, string(lsv1alpha1.ReconcileOperation))
 			utils.ExpectNoError(f.Client.Update(ctx, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 			// expect that the export contains a valid json with { "counter": 2 }
 			g.Expect(di.Status.ExportReference).ToNot(g.BeNil())
-			exportData, err = utils.GetDeployItemExport(ctx, f.Client, di)
+			exportData, err = lsutils.GetDeployItemExport(ctx, f.Client, di)
 			utils.ExpectNoError(err)
 			g.Expect(exportData).To(g.MatchJSON(`{ "counter": 2 }`))
 

--- a/test/integration/deployers/manifest_tests.go
+++ b/test/integration/deployers/manifest_tests.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 
 	manifestv1alpha1 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1"
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
@@ -79,7 +80,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 
 			ginkgo.By("Create Manifest (v1alpha2) deploy item")
 			utils.ExpectNoError(state.Create(ctx, f.Client, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
 
 			ginkgo.By("Check presence of Kubernetes Objects")
 			config := &manifestv1alpha2.ProviderConfiguration{}
@@ -139,7 +140,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 
 			ginkgo.By("Create Manifest (v1alpha1) deploy item")
 			utils.ExpectNoError(state.Create(ctx, f.Client, di))
-			utils.ExpectNoError(utils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
+			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
 
 			ginkgo.By("Check presence of Kubernetes objects")
 			config := &manifestv1alpha1.ProviderConfiguration{}

--- a/test/integration/helmcharts/chartstests.go
+++ b/test/integration/helmcharts/chartstests.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gardener/landscaper/pkg/deployer/helm"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
@@ -132,7 +133,7 @@ func deployDeployItemAndWaitForSuccess(
 	di := forgeHelmDeployItem(chartDir, valuesFile, deployerName, target, f.LsVersion)
 	utils.ExpectNoError(state.Create(ctx, f.Client, di))
 	By("Waiting for the DeployItem to succeed")
-	utils.ExpectNoError(utils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
+	utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
 	By("Waiting for the corresponding Deployment to become ready")
 
 	// check deployment image version

--- a/test/integration/tutorial/aggregated-blueprint.go
+++ b/test/integration/tutorial/aggregated-blueprint.go
@@ -16,6 +16,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 )
@@ -61,9 +62,9 @@ func AggregatedBlueprint(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, aggInst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, aggInst, lsv1alpha1.ComponentPhaseSucceeded, 4*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, aggInst, 4*time.Minute))
 
-			subInstallations, err := utils.GetSubInstallationsOfInstallation(ctx, f.Client, aggInst)
+			subInstallations, err := lsutils.GetSubInstallationsOfInstallation(ctx, f.Client, aggInst)
 			utils.ExpectNoError(err)
 			g.Expect(subInstallations).To(g.HaveLen(2))
 			g.Expect(subInstallations[0].Status.Phase).To(g.Equal(lsv1alpha1.ComponentPhaseSucceeded))

--- a/test/integration/tutorial/external-jsonschema.go
+++ b/test/integration/tutorial/external-jsonschema.go
@@ -17,6 +17,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 )
@@ -62,9 +63,9 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, inst, lsv1alpha1.ComponentPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
 
-			deployItems, err := utils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
 			g.Expect(deployItems).To(g.HaveLen(1))
 			g.Expect(deployItems[0].Status.Phase).To(g.Equal(lsv1alpha1.ExecutionPhaseSucceeded))

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -17,6 +17,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 )
@@ -63,9 +64,9 @@ func NginxIngressTest(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, inst, lsv1alpha1.ComponentPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
 
-			deployItems, err := utils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
 			gomega.Expect(deployItems).To(gomega.HaveLen(1))
 			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
@@ -131,9 +132,9 @@ func NginxIngressTest(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, inst, lsv1alpha1.ComponentPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
 
-			deployItems, err := utils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
 			gomega.Expect(deployItems).To(gomega.HaveLen(1))
 			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))

--- a/test/integration/tutorial/simple-import.go
+++ b/test/integration/tutorial/simple-import.go
@@ -17,6 +17,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 )
@@ -64,7 +65,7 @@ func SimpleImport(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, nginxInst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, nginxInst, lsv1alpha1.ComponentPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, nginxInst, 2*time.Minute))
 
 			ginkgo.By("Create echo server Installation")
 			inst := &lsv1alpha1.Installation{}
@@ -73,9 +74,9 @@ func SimpleImport(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
 
 			// wait for installation to finish
-			utils.ExpectNoError(utils.WaitForInstallationToBeInPhase(ctx, f.Client, inst, lsv1alpha1.ComponentPhaseSucceeded, 2*time.Minute))
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
 
-			deployItems, err := utils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
 			g.Expect(deployItems).To(g.HaveLen(1))
 			g.Expect(deployItems[0].Status.Phase).To(g.Equal(lsv1alpha1.ExecutionPhaseSucceeded))

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/health/health.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/health/health.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package health
+
+import (
+	"fmt"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+)
+
+var (
+	installationConditionTypesTrue = []lsv1alpha1.ConditionType{
+		lsv1alpha1.EnsureSubInstallationsCondition,
+		lsv1alpha1.ReconcileExecutionCondition,
+		lsv1alpha1.CreateImportsCondition,
+		lsv1alpha1.CreateExportsCondition,
+		lsv1alpha1.EnsureExecutionsCondition,
+		lsv1alpha1.ValidateExportCondition,
+	}
+
+	installationConditionTypesFalse = []lsv1alpha1.ConditionType{
+		lsv1alpha1.ValidateImportsCondition,
+	}
+)
+
+// CheckInstallation checks if the given Installation is healthy
+// An installation is healthy if
+// * Its observed generation is up-to-date
+// * No annotation landscaper.gardener.cloud/operation is set
+// * No lastError is in the status
+// * A last operation is state succeeded is present
+// * landscaperv1alpha1.ComponentPhaseSucceeded
+func CheckInstallation(installation *lsv1alpha1.Installation) error {
+	if installation.Status.ObservedGeneration < installation.Generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", installation.Status.ObservedGeneration, installation.Generation)
+	}
+
+	if installation.Status.LastError != nil {
+		return fmt.Errorf("last errors is set: %s", installation.Status.LastError.Message)
+	}
+
+	if installation.Status.Phase != lsv1alpha1.ComponentPhaseSucceeded {
+		return fmt.Errorf("installation phase is not suceeded, but %s", installation.Status.Phase)
+	}
+
+	if op, ok := installation.Annotations[lsv1alpha1.OperationAnnotation]; ok {
+		return fmt.Errorf("landscaper operation %q is not yet picked up by controller", op)
+	}
+
+	for _, conditionType := range installationConditionTypesTrue {
+		condition := lsv1alpha1helper.GetCondition(installation.Status.Conditions, conditionType)
+		if condition == nil {
+			// conditions vary based on what is configured in the installation
+			continue
+		}
+
+		if err := checkConditionState(string(conditionType), string(lsv1alpha1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
+			return err
+		}
+	}
+
+	for _, conditionType := range installationConditionTypesFalse {
+		condition := lsv1alpha1helper.GetCondition(installation.Status.Conditions, conditionType)
+		if condition == nil {
+			continue
+		}
+
+		if err := checkConditionState(string(conditionType), string(lsv1alpha1.ConditionFalse), string(condition.Status), condition.Reason, condition.Message); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkConditionState(conditionType string, expected, actual, reason, message string) error {
+	if expected != actual {
+		return fmt.Errorf("condition %q has invalid status %s (expected %s) due to %s: %s",
+			conditionType, actual, expected, reason, message)
+	}
+	return nil
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -121,6 +121,7 @@ var UnrecoverableErrorCodes = []ErrorCode{
 	ErrorConfigurationProblem,
 	ErrorInternalProblem,
 	ErrorHealthCheckTimeout,
+	ErrorTimeout,
 }
 
 // Condition holds the information about the state of a resource.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -86,6 +86,7 @@ github.com/gardener/landscaper/apis/config/v1alpha1
 github.com/gardener/landscaper/apis/core
 github.com/gardener/landscaper/apis/core/install
 github.com/gardener/landscaper/apis/core/v1alpha1
+github.com/gardener/landscaper/apis/core/v1alpha1/health
 github.com/gardener/landscaper/apis/core/v1alpha1/helper
 github.com/gardener/landscaper/apis/core/validation
 github.com/gardener/landscaper/apis/deployer/container


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority 3

**What this PR does / why we need it**:

adds a dedicated health helper package to the v1alpha1 apis.
This is mostly copied from https://github.com/gardener/gardener/pull/3757/files so credit goes to @danielfoehrKn .

Also restructured the other helper functions in the landscaper code.


**Special notes for your reviewer**:

@danielfoehrKn I also tried to add the waiting function to the apis package but would have introduced a dependency towards the controller-runtime which we should avoid.
But at least the health helper could be shared

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
A dedicated health helper has been introduced that can be used to determine if a Installation is healhty.
```
