### PR TITLE
update chart version for ingress-nginx

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@
 ### Development
 - [Local Setup](./development/local-setup.md)
 - [Extend the API](./development/extend-the-api.md)
+- [Creating Tutorial Resources](./development/tutorials.md)
 
 ### API Reference
 - [Types](./technical/types.md)

--- a/docs/development/tutorials.md
+++ b/docs/development/tutorials.md
@@ -1,0 +1,35 @@
+# Adding new tutorials
+
+Most of the present tutorials provide additional resources that should be provided on Gardeners GCR repository - after all, following through the tutorials can be a lot easier if users can rely on already present component-descriptors and blueprints in GCR that they can simply reuse.
+
+To make uploading the resources simple, reliable and repeatable, we provided the script `hack/upload-tutorial-resources.sh`.
+
+# Using upload-tutorial-resources.sh
+
+## Component descriptors
+
+The script features an array `component_descriptors` which contains the pathes to all component descriptors that should get uploaded to a registry. Elements are seperated by newlines. Since the repository-context and version information are part of the component-descriptor, all it takes in this array is really just the path to the directory containing the `component-descriptor.yaml` file.
+
+If you add a new tutorial resource with a component-descriptor, make sure you add it to this array.
+
+## Blueprints
+
+Like for component-descriptors, the script has an array `blueprints`... which is a bit more complicated this time.
+
+Elements are seperated by newlines, but each element consist of three fields, seperated by semi-cola `;`. The first field is the repository path, the second field is the local path to the directory containing the `blueprint.yaml`. The third field is a version number which will be used if there is no version number in the `blueprint.yaml` itself.
+
+Example:
+
+```
+"eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/echo-server;./docs/tutorials/resources/echo-server/blueprint;v0.1.1"
+```
+
+This line will upload the Blueprint found in `./docs/tutorials/resources/echo-server/blueprint` as an OCI artifact to `eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/echo-server:v0.1.1`.
+
+### Blueprint version numbers
+
+Blueprints contain no version information - this is explicitely not part of the Blueprint specification. Thus, the version tag must be provided in the array described above or it can be provided in the `blueprint.yaml` file.
+
+Just to make developing tutorial resources easier (i.e. if you change an existing Blueprint, you do not have to change the `upload-tutorial-resources.sh` script), the script will look into the `blueprint.yaml` for a comment `# TUTORIAL_BLUEPRINT_VERSION: v0.2.0` and use this version tag to upload the Blueprint to the OCI registry.
+
+**WARNING:** This is only meant to simplify the development of tutorial resources. It is not part of the Blueprint specification and MUST NOT be used in production.

--- a/docs/tutorials/01-create-simple-blueprint.md
+++ b/docs/tutorials/01-create-simple-blueprint.md
@@ -46,7 +46,7 @@ helm pull ingress-nginx/ingress-nginx --untar --destination /tmp
 
 # upload the helm chart to an OCI registry
 export OCI_REGISTRY="eu.gcr.io" # <-- replace this with the URL of your own OCI registry
-export CHART_REF="$OCI_REGISTRY/mychart/reference:my-version" # e.g. eu.gcr.io.gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+export CHART_REF="$OCI_REGISTRY/mychart/reference:my-version" # e.g. eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
 export HELM_EXPERIMENTAL_OCI=1
 helm registry login -u myuser $OCI_REGISTRY
 helm chart save /tmp/ingress-nginx $CHART_REF
@@ -56,6 +56,8 @@ helm chart push $CHART_REF
 ## Step 2: Define the Component Descriptor
 
 A Component Descriptor contains references and locations to all _resources_ that are used by Landscaper to deploy and install an application. In this example, the only kind of _resources_ is a `helm` chart (that of the nginx-ingress controller that we uploaded to an OCI registry in the previous step) but it could also be `oci images` or even `node modules`.
+
+If a Helm chart is referenced through a component descriptor, the version of the chart in the component descriptor should match the version of the chart itself. Since we are using version v3.29.0 of the _ingress-nginx_ Helm chart in this tutorial, the component descriptor references it accordingly.
 
 For more information about the component descriptor and the usage of the different fields, refer to the [component descriptor documentation](https://github.com/gardener/component-spec).
 
@@ -74,11 +76,11 @@ component:
   resources:
   - type: helm
     name: ingress-nginx-chart
-    version: v0.1.0
+    version: v3.29.0
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io.gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      imageReference: eu.gcr.io.gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
 ```
 
 ## Step 3: Create a Blueprint
@@ -302,7 +304,7 @@ spec:
   config:
     apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
     chart:
-      ref: eu.gcr.io/myproject/charts/nginx-ingress:v0.1.0
+      ref: eu.gcr.io/myproject/charts/nginx-ingress:v3.29.0
     exportsFromManifests:
     - jsonPath: .Values.controller.ingressClass
       key: ingressClass
@@ -361,11 +363,11 @@ component:
   resources:  
   - type: helm
     name: ingress-nginx-chart
-    version: v0.1.0
+    version: v3.29.0
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
   - type: blueprint
     name: ingress-nginx-blueprint
     relation: local
@@ -562,7 +564,7 @@ spec:
   - config:
       apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
       chart:
-        ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+        ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
       exportsFromManifests:
       - jsonPath: .Values.controller.ingressClass
         key: ingressClass
@@ -602,7 +604,7 @@ spec:
   config:
     apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
     chart:
-      ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
     exportsFromManifests:
     - jsonPath: .Values.controller.ingressClass
       key: ingressClass

--- a/docs/tutorials/resources/aggregated/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/aggregated/blueprint/blueprint.yaml
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This version number is parsed by hack/upload-tutorial-resources.sh - it is not part of any official blueprint
+#
+# TUTORIAL_BLUEPRINT_VERSION: v0.2.0
+
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 

--- a/docs/tutorials/resources/echo-server/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/echo-server/blueprint/blueprint.yaml
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This version number is parsed by hack/upload-tutorial-resources.sh - it is not part of any official blueprint
+#
+# TUTORIAL_BLUEPRINT_VERSION: v0.2.0
+
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 

--- a/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/blueprint.yaml
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This version number is parsed by hack/upload-tutorial-resources.sh - it is not part of any official blueprint
+#
+# TUTORIAL_BLUEPRINT_VERSION: v0.2.0
+
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 

--- a/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This version number is parsed by hack/upload-tutorial-resources.sh - it is not part of any official blueprint
+#
+# TUTORIAL_BLUEPRINT_VERSION: v0.3.1
+
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 

--- a/docs/tutorials/resources/ingress-nginx/component-descriptor.yaml
+++ b/docs/tutorials/resources/ingress-nginx/component-descriptor.yaml
@@ -7,7 +7,7 @@ meta:
 
 component:
   name: github.com/gardener/landscaper/ingress-nginx
-  version: v0.3.0
+  version: v0.3.1
 
   provider: internal
 
@@ -21,15 +21,15 @@ component:
   resources:
   - type: blueprint
     name: ingress-nginx-blueprint
-    version: v0.3.0
+    version: v0.3.1
     relation: local
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:v0.3.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:v0.3.1
   - type: helm
     name: ingress-nginx-chart
-    version: v0.1.0
+    version: v3.29.0
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0

--- a/docs/tutorials/resources/ingress-nginx/installation.yaml
+++ b/docs/tutorials/resources/ingress-nginx/installation.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/ingress-nginx
-      version: v0.3.0
+      version: v0.3.1
 
   blueprint:
     ref:

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/CHANGELOG.md
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/CHANGELOG.md
@@ -4,6 +4,46 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 ### Unreleased
 
+### 3.29.0
+
+- [X] [#6945](https://github.com/kubernetes/ingress-nginx/pull/7020) Add option to specify job label for ServiceMonitor
+
+### 3.28.0
+
+- [ ] [#6900](https://github.com/kubernetes/ingress-nginx/pull/6900) Support existing PSPs
+
+### 3.27.0
+
+- Update ingress-nginx v0.45.0
+
+### 3.26.0
+
+- [X] [#6979](https://github.com/kubernetes/ingress-nginx/pull/6979) Changed servicePort value for metrics
+
+### 3.25.0
+
+- [X] [#6957](https://github.com/kubernetes/ingress-nginx/pull/6957) Add ability to specify automountServiceAccountToken
+
+### 3.24.0
+
+- [X] [#6908](https://github.com/kubernetes/ingress-nginx/pull/6908) Add volumes to default-backend deployment
+
+### 3.23.0
+
+- Update ingress-nginx v0.44.0
+
+### 3.22.0
+
+- [X] [#6802](https://github.com/kubernetes/ingress-nginx/pull/6802) Add value for configuring a custom Diffie-Hellman parameters file
+- [X] [#6815](https://github.com/kubernetes/ingress-nginx/pull/6815) Allow use of numeric namespaces in helm chart
+
+### 3.21.0
+
+- [X] [#6783](https://github.com/kubernetes/ingress-nginx/pull/6783) Add custom annotations to ScaledObject
+- [X] [#6761](https://github.com/kubernetes/ingress-nginx/pull/6761) Adding quotes in the serviceAccount name in Helm values
+- [X] [#6767](https://github.com/kubernetes/ingress-nginx/pull/6767) Remove ClusterRole when scope option is enabled
+- [X] [#6785](https://github.com/kubernetes/ingress-nginx/pull/6785) Update kube-webhook-certgen image to v1.5.1
+
 ### 3.20.1
 
 - Do not create KEDA in case of DaemonSets.
@@ -11,7 +51,7 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 ### 3.20.0
 
-- [] [#6730](https://github.com/kubernetes/ingress-nginx/pull/6730) Do not create HPA for defaultBackend if not enabled.
+- [X] [#6730](https://github.com/kubernetes/ingress-nginx/pull/6730) Do not create HPA for defaultBackend if not enabled.
 
 ### 3.19.0
 

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/Chart.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/Chart.yaml
@@ -1,9 +1,8 @@
 annotations:
   artifacthub.io/changes: |
-    - Do not create KEDA in case of DaemonSets.
-    - Fix KEDA v2 definition
+    - Add ability to specify jobLabel for ServiceMonitor
 apiVersion: v2
-appVersion: 0.43.0
+appVersion: 0.45.0
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -17,4 +16,4 @@ name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
 type: application
-version: 3.20.1
+version: 3.29.0

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/NOTES.txt
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/NOTES.txt
@@ -29,7 +29,7 @@ Get the application URL by running these commands:
 
 An example Ingress that makes use of the controller:
 
-  apiVersion: networking.k8s.io/v1
+  apiVersion: networking.k8s.io/v1beta1
   kind: Ingress
   metadata:
     annotations:
@@ -42,10 +42,8 @@ An example Ingress that makes use of the controller:
         http:
           paths:
             - backend:
-                service:
-                  name: exampleService
-                  port:
-                    number: 80
+                serviceName: exampleService
+                servicePort: 80
               path: /
     # This section is only required if TLS is to be enabled for the Ingress
     tls:

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -22,6 +22,10 @@ rules:
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
+    {{- with .Values.controller.admissionWebhooks.existingPsp }}
+    - {{ . }}
+    {{- else }}
     - {{ include "ingress-nginx.fullname" . }}-admission
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ingress-nginx.fullname" . }}-admission
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled (empty .Values.controller.admissionWebhooks.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ingress-nginx.fullname" . }}-admission
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -31,7 +31,7 @@ webhooks:
       - v1beta1
     clientConfig:
       service:
-        namespace: {{ .Release.Namespace }}
+        namespace: {{ .Release.Namespace | quote }}
         name: {{ include "ingress-nginx.controller.fullname" . }}-admission
         path: /networking/v1beta1/ingresses
     {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/clusterrole.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/clusterrole.yaml
@@ -40,7 +40,6 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - extensions

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-configmap.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-configmap.yaml
@@ -15,6 +15,9 @@ data:
 {{- if or .Values.controller.proxySetHeaders .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-proxy-headers
 {{- end }}
+{{- if .Values.dhParam }}
+  ssl-dh-param: {{ printf "%s/%s" .Release.Namespace (include "ingress-nginx.controller.fullname" .) }}
+{{- end }}
 {{- range $key, $value := .Values.controller.config }}
     {{ $key | nindent 2 }}: {{ $value | quote }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-keda.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-keda.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}
-
+  {{- if .Values.controller.keda.scaledObject.annotations }}
+  annotations: {{ toYaml .Values.controller.keda.scaledObject.annotations | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
 {{- if eq .Values.controller.keda.apiVersion "keda.k8s.io/v1alpha1" }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-prometheusrules.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-prometheusrules.yaml
@@ -4,7 +4,7 @@ kind: PrometheusRule
 metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
 {{- if .Values.controller.metrics.prometheusRule.namespace }}
-  namespace: {{ .Values.controller.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.controller.metrics.prometheusRule.namespace | quote }}
 {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-psp.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.podSecurityPolicy.enabled (empty .Values.controller.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-role.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-role.yaml
@@ -31,7 +31,6 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - extensions
@@ -75,14 +74,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - endpoints
-    verbs:
-      - create
-      - get
-      - update
-  - apiGroups:
-      - ""
-    resources:
       - events
     verbs:
       - create
@@ -91,6 +82,10 @@ rules:
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
+    {{- with .Values.controller.existingPsp }}
+    resourceNames:  [{{ . }}]
+    {{- else }}
     resourceNames:  [{{ include "ingress-nginx.fullname" . }}]
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-rolebinding.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-rolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -6,4 +6,5 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ template "ingress-nginx.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
 {{- if .Values.controller.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace | quote }}
 {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
@@ -22,6 +22,9 @@ spec:
     {{- if .Values.controller.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml .Values.controller.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
     {{- end }}
+{{- if .Values.controller.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.controller.metrics.serviceMonitor.jobLabel | quote }}
+{{- end }}
 {{- if .Values.controller.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector: {{ toYaml .Values.controller.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
 {{ else }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-deployment.yaml
@@ -88,6 +88,9 @@ spec:
             - name: http
               containerPort: {{ .Values.defaultBackend.port }}
               protocol: TCP
+        {{- if .Values.defaultBackend.extraVolumeMounts }}
+          volumeMounts: {{- toYaml .Values.defaultBackend.extraVolumeMounts | nindent 12 }}
+        {{- end }}
         {{- if .Values.defaultBackend.resources }}
           resources: {{ toYaml .Values.defaultBackend.resources | nindent 12 }}
         {{- end }}
@@ -102,4 +105,7 @@ spec:
       affinity: {{ toYaml .Values.defaultBackend.affinity | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 60
+    {{- if .Values.defaultBackend.extraVolumes }}
+      volumes: {{ toYaml .Values.defaultBackend.extraVolumes | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-psp.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
+{{- if and .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled (empty .Values.defaultBackend.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-role.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-role.yaml
@@ -10,5 +10,9 @@ rules:
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
+    {{- with .Values.defaultBackend.existingPsp }}
+    resourceNames:  [{{ . }}]
+    {{- else }}
     resourceNames:  [{{ include "ingress-nginx.fullname" . }}-backend]
+    {{- end }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-rolebinding.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-rolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-serviceaccount.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/default-backend-serviceaccount.yaml
@@ -6,4 +6,5 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.defaultBackend.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/dh-param-secret.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/templates/dh-param-secret.yaml
@@ -1,0 +1,10 @@
+{{- with .Values.dhParam -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ingress-nginx.controller.fullname" $ }}
+  labels:
+    {{- include "ingress-nginx.labels" $ | nindent 4 }}
+data:
+  dhparam.pem: {{ . }}
+{{- end }}

--- a/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/values.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/chart/ingress-nginx/values.yaml
@@ -1,5 +1,5 @@
 ## nginx configuration
-## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/controllers/nginx/configuration.md
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/index.md
 ##
 
 ## Overrides for generated resource names
@@ -11,12 +11,15 @@ controller:
   name: controller
   image:
     repository: k8s.gcr.io/ingress-nginx/controller
-    tag: "v0.43.0"
-    digest: sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713
+    tag: "v0.45.0"
+    digest: sha256:c4390c53f348c3bd4e60a5dd6a11c35799ae78c49388090140b9d72ccede1755
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
     allowPrivilegeEscalation: true
+
+  # Use an existing PSP instead of creating one
+  existingPsp: ""
 
   # Configures the ports the nginx-controller listens on
   containerPort:
@@ -315,6 +318,11 @@ controller:
     pollingInterval: 30
     cooldownPeriod: 300
     restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
     triggers: []
  #     - type: prometheus
  #       metadata:
@@ -468,6 +476,9 @@ controller:
     namespaceSelector: {}
     objectSelector: {}
 
+    # Use an existing PSP instead of creating one
+    existingPsp: ""
+
     service:
       annotations: {}
       # clusterIP: ""
@@ -481,7 +492,7 @@ controller:
       enabled: true
       image:
         repository: docker.io/jettech/kube-webhook-certgen
-        tag: v1.5.0
+        tag: v1.5.1
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
       ##
@@ -510,7 +521,7 @@ controller:
 
       # loadBalancerIP: ""
       loadBalancerSourceRanges: []
-      servicePort: 9913
+      servicePort: 10254
       type: ClusterIP
       # externalTrafficPolicy: ""
       # nodePort: ""
@@ -518,6 +529,8 @@ controller:
     serviceMonitor:
       enabled: false
       additionalLabels: {}
+      # The label to use to retrieve the job name from.
+      # jobLabel: "app.kubernetes.io/name"
       namespace: ""
       namespaceSelector: {}
       # Default: scrape .Release.Namespace only
@@ -604,11 +617,15 @@ defaultBackend:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
 
+  # Use an existing PSP instead of creating one
+  existingPsp: ""
+
   extraArgs: {}
 
   serviceAccount:
     create: true
-    name:
+    name: ""
+    automountServiceAccountToken: true
   ## Additional environment variables to set for defaultBackend pods
   extraEnvs: []
 
@@ -672,6 +689,16 @@ defaultBackend:
   #   cpu: 10m
   #   memory: 20Mi
 
+  extraVolumeMounts: []
+  ## Additional volumeMounts to the default backend container.
+  #  - name: copy-portal-skins
+  #   mountPath: /var/lib/lemonldap-ng/portal/skins
+
+  extraVolumes: []
+  ## Additional volumes to the default backend pod.
+  #  - name: copy-portal-skins
+  #    emptyDir: {}
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -708,7 +735,8 @@ podSecurityPolicy:
 
 serviceAccount:
   create: true
-  name:
+  name: ""
+  automountServiceAccountToken: true
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -726,3 +754,8 @@ tcp: {}
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
+
+# A base64ed Diffie-Hellman parameter
+# This can be generated with: openssl dhparam 4096 2> /dev/null | base64
+# Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+dhParam:

--- a/docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml
@@ -1,11 +1,14 @@
+meta:
+  schemaVersion: v2
+
 component:
-  componentReferences: []
   name: github.com/gardener/landscaper/local/ingress-nginx
   provider: internal
   repositoryContexts:
   - baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
     type: ociRegistry
+  version: v0.3.1
+
+  componentReferences: []
   sources: []
-  version: v0.2.0
-meta:
-  schemaVersion: v2
+  resources: []

--- a/docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
@@ -1,7 +1,7 @@
 ---
 type: helm
 name: ingress-nginx-chart
-version: v0.1.0
+version: v3.29.0
 relation: external
 input:
   type: "dir"

--- a/docs/tutorials/resources/local-ingress-nginx/installation.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/installation.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/local/ingress-nginx
-      version: v0.2.0
+      version: v0.3.1
   blueprint:
     ref:
       resourceName: ingress-nginx-blueprint

--- a/docs/tutorials/resources/local-ingress-nginx/resources.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/resources.yaml
@@ -11,7 +11,7 @@ input:
 ---
 type: helm
 name: ingress-nginx-chart
-version: v0.1.0
+version: v3.29.0
 relation: external
 input:
   type: "dir"

--- a/hack/upload-tutorial-resources.sh
+++ b/hack/upload-tutorial-resources.sh
@@ -6,10 +6,6 @@
 
 set -e
 
-BLUEPRINT_INGRESS_NGINX_VERSION="v0.2.1"
-BLUEPRINT_ECHO_SERVER_VERSION="v0.1.1"
-BLUEPRINT_AGGREGATED_VERSION="v0.1.1"
-
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
@@ -35,20 +31,37 @@ component_descriptors=(
   "./docs/tutorials/resources/echo-server"
   "./docs/tutorials/resources/aggregated"
   "./docs/tutorials/resources/local-ingress-nginx"
+  "./docs/tutorials/resources/external-jsonschema/echo-server"
 )
 
 function prepare_local_nginx_resources() {
+  cp ./docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml ./docs/tutorials/resources/local-ingress-nginx/component-descriptor.yam_
   landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx  ./docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
   landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx  ./docs/tutorials/resources/local-ingress-nginx/blueprint-resource.yaml
+}
+
+function prepare_external_json_schema_resourcess() {
+  cp ./docs/tutorials/resources/external-jsonschema/echo-server/component-descriptor.yaml ./docs/tutorials/resources/external-jsonschema/echo-server/component-descriptor.yam_
+  landscaper-cli components-cli ca resources add ./docs/tutorials/resources/external-jsonschema/echo-server  ./docs/tutorials/resources/external-jsonschema/echo-server/blueprint-resource.yaml
 }
 
 function cleanup_local_nginx_resources() {
   if [ -d ./docs/tutorials/resources/local-ingress-nginx/blobs ]; then
     rm -rf ./docs/tutorials/resources/local-ingress-nginx/blobs
   fi
+  mv -f ./docs/tutorials/resources/local-ingress-nginx/component-descriptor.yam_ ./docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml
+}
+
+function cleanup_external_json_schema_resourcess() {
+  if [ -d ./docs/tutorials/resources/external-jsonschema/echo-server/blobs ]; then
+    rm -rf ./docs/tutorials/resources/external-jsonschema/echo-server/blobs
+  fi
+  mv -f ./docs/tutorials/resources/external-jsonschema/echo-server/component-descriptor.yam_ ./docs/tutorials/resources/external-jsonschema/echo-server/component-descriptor.yaml
 }
 
 prepare_local_nginx_resources
+prepare_external_json_schema_resourcess
+
 for i in "${blueprints[@]}"; do
   IFS=';' read ref blueprints_path version <<< "${i}"
 
@@ -64,4 +77,6 @@ done
 for i in "${component_descriptors[@]}"; do
   landscaper-cli components-cli ca remote push $i
 done
+
 cleanup_local_nginx_resources
+cleanup_external_json_schema_resourcess

--- a/hack/upload-tutorial-resources.sh
+++ b/hack/upload-tutorial-resources.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,23 +20,48 @@ then
     exit
 fi
 
+# this array consists of <oci-path of blueprint>;<local path of blueprint>;<default version tag>
+# the version tag can be set inline in the blueprint.yaml file itself by the comment line
+# # TUTORIAL_BLUEPRINT_VERSION: <my version>
+# this is the default that we fall back on in case the version information is not maintained
+# in the blueprint file
 blueprints=(
-  "eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:${BLUEPRINT_INGRESS_NGINX_VERSION},./docs/tutorials/resources/ingress-nginx/blueprint"
-  "eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/echo-server:${BLUEPRINT_ECHO_SERVER_VERSION},./docs/tutorials/resources/echo-server/blueprint"
-  "eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:${BLUEPRINT_AGGREGATED_VERSION},./docs/tutorials/resources/aggregated/blueprint"
+  "eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx;./docs/tutorials/resources/ingress-nginx/blueprint;v0.2.1"
+  "eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/echo-server;./docs/tutorials/resources/echo-server/blueprint;v0.1.1"
+  "eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated;./docs/tutorials/resources/aggregated/blueprint;v0.1.1"
 )
 component_descriptors=(
   "./docs/tutorials/resources/ingress-nginx"
   "./docs/tutorials/resources/echo-server"
   "./docs/tutorials/resources/aggregated"
+  "./docs/tutorials/resources/local-ingress-nginx"
 )
 
+function prepare_local_nginx_resources() {
+  landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx  ./docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
+  landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx  ./docs/tutorials/resources/local-ingress-nginx/blueprint-resource.yaml
+}
+
+function cleanup_local_nginx_resources() {
+  if [ -d ./docs/tutorials/resources/local-ingress-nginx/blobs ]; then
+    rm -rf ./docs/tutorials/resources/local-ingress-nginx/blobs
+  fi
+}
+
+prepare_local_nginx_resources
 for i in "${blueprints[@]}"; do
-  IFS=',' read ref blueprints_path <<< "${i}"
+  IFS=';' read ref blueprints_path version <<< "${i}"
 
-  landscaper-cli blueprint push ${ref} ${blueprints_path}
+  set +e
+  inline_version_string=$(grep "^# TUTORIAL_BLUEPRINT_VERSION" $blueprints_path/blueprint.yaml)
+  if [ -n "$inline_version_string" ]; then
+    version=${inline_version_string#*:}
+  fi
+  set -e
+
+  landscaper-cli blueprint push ${ref}:${version// /} ${blueprints_path}
 done
-
 for i in "${component_descriptors[@]}"; do
-  landscaper-cli cd push ${i}
+  landscaper-cli components-cli ca remote push $i
 done
+cleanup_local_nginx_resources

--- a/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
+++ b/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
@@ -42,7 +42,7 @@ var _ = Describe("GetChart", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		chartAccess := &helmv1alpha1.Chart{
-			Ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0",
+			Ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0",
 		}
 
 		chart, err := chartresolver.GetChart(ctx, logtesting.NullLogger{}, ociClient, chartAccess)

--- a/pkg/deployer/helm/chartresolver/testdata/01-component-descriptor.yaml
+++ b/pkg/deployer/helm/chartresolver/testdata/01-component-descriptor.yaml
@@ -24,8 +24,8 @@ component:
       imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:v0.2.1
   - type: helm
     name: ingress-nginx-chart
-    version: v0.1.0
+    version: v3.29.0
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0

--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Helm Deployer", func() {
 
 		// create helm provider config
 		providerConfig := &helmv1alpha1.ProviderConfiguration{}
-		providerConfig.Chart.Ref = "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0"
+		providerConfig.Chart.Ref = "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0"
 		providerConfig.Name = "ingress-test"
 		providerConfig.Namespace = state.Namespace
 		providerConfig.HealthChecks = helmv1alpha1.HealthChecksConfiguration{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority 3

**What this PR does / why we need it**:

The ingress-nginx Helm chart that is included in the tutorials and used for (among others) for integration tests will be upgraded to to the latest version 3.29.0. The component-descriptors now include the Helm chart version instead of just _v0.1.0_.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
- Helm chart for ingress-nginx upgraded to 3.29.0.
- hack/update-tutorial-resources.sh script now includes all new tutorial resources
```
