### PR TITLE
depend on publish-trait, rather than on injected steps

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -60,7 +60,7 @@ landscaper:
         integration-test:
           execute:
           - integration-test
-          depends:
+          trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
     pull-request:
@@ -82,6 +82,6 @@ landscaper:
         integration-test:
           execute:
           - integration-test
-          depends:
+          trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'


### PR DESCRIPTION
**What this PR does / why we need it**:
prepare switching to kaniko as default-builder