### PR TITLE
make webhookserver and controller image tags configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ HELM_DEPLOYER_CONTROLLER_IMAGE_REPOSITORY      := $(REGISTRY)/helm-deployer-cont
 MANIFEST_DEPLOYER_CONTROLLER_IMAGE_REPOSITORY  := $(REGISTRY)/manifest-deployer-controller
 MOCK_DEPLOYER_CONTROLLER_IMAGE_REPOSITORY      := $(REGISTRY)/mock-deployer-controller
 
+DISABLE_CLEANUP := false
+
 .PHONY: install-requirements
 install-requirements:
 	@go install -mod=vendor $(REPO_ROOT)/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
@@ -46,7 +48,7 @@ test:
 
 .PHONY: integration-test
 integration-test:
-	@go test -timeout=1h -mod=vendor $(REPO_ROOT)/test/integration --v -ginkgo.v -ginkgo.progress --kubeconfig $(KUBECONFIG) --ls-version $(EFFECTIVE_VERSION) --registry-config=$(REGISTRY_CONFIG)
+	@go test -timeout=1h -mod=vendor $(REPO_ROOT)/test/integration --v -ginkgo.v -ginkgo.progress --kubeconfig $(KUBECONFIG) --ls-version $(EFFECTIVE_VERSION) --registry-config=$(REGISTRY_CONFIG) --disable-cleanup=$(DISABLE_CLEANUP)
 
 .PHONY: verify
 verify: check

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -72,6 +72,9 @@ type ExecutionStatus struct {
 	// Conditions contains the actual condition of a execution
 	Conditions []Condition `json:"conditions,omitempty"`
 
+	// LastError describes the last error that occurred.
+	LastError *Error `json:"lastError,omitempty"`
+
 	// ExportReference references the object that contains the exported values.
 	// only used for operation purpose.
 	// +optional

--- a/apis/core/v1alpha1/helper/error.go
+++ b/apis/core/v1alpha1/helper/error.go
@@ -68,6 +68,26 @@ func NewWrappedError(err error, operation, reason, message string, codes ...lsv1
 	}
 }
 
+// NewErrorOrNil creates a new landscaper internal error that wraps another error.
+// if no error is set the functions return nil.
+// The error is automatically set as error message.
+func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{
+		lsErr: lsv1alpha1.Error{
+			Operation:          operation,
+			Reason:             reason,
+			Message:            err.Error(),
+			LastTransitionTime: metav1.Now(),
+			LastUpdateTime:     metav1.Now(),
+			Codes:              codes,
+		},
+		err: err,
+	}
+}
+
 // IsError returns the landscaper if the given error is one.
 // If the err does not contain a landsacper error nil is returned.
 func IsError(err error) (*Error, bool) {
@@ -88,6 +108,9 @@ func IsError(err error) (*Error, bool) {
 
 // TryUpdateError tries to update the properties of the last error if the err is a internal landscaper error.
 func TryUpdateError(lastErr *lsv1alpha1.Error, err error) *lsv1alpha1.Error {
+	if err == nil {
+		return nil
+	}
 	if intErr, ok := IsError(err); ok {
 		return intErr.UpdatedError(lastErr)
 	}

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -81,15 +81,21 @@ type ExecutionSpec struct {
 
 // ExecutionStatus contains the current status of a execution.
 type ExecutionStatus struct {
-	// Phase is the current phase of the execution .
+	// Phase is the current phase of the execution.
 	Phase ExecutionPhase `json:"phase,omitempty"`
 
 	// ObservedGeneration is the most recent generation observed for this Execution.
 	// It corresponds to the Execution generation, which is updated on mutation by the landscaper.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// Conditions contains the actual condition of a execution
+	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
+
+	// LastError describes the last error that occurred.
+	// +optional
+	LastError *Error `json:"lastError,omitempty"`
 
 	// ExportReference references the object that contains the exported values.
 	// only used for operation purpose.
@@ -98,6 +104,7 @@ type ExecutionStatus struct {
 
 	// DeployItemReferences contain the state of all deploy items.
 	// The observed generation is here the generation of the Execution not the DeployItem.
+	// +optional
 	DeployItemReferences []VersionedNamedObjectReference `json:"deployItemRefs,omitempty"`
 }
 

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1240,6 +1240,7 @@ func autoConvert_v1alpha1_ExecutionStatus_To_core_ExecutionStatus(in *ExecutionS
 	out.Phase = core.ExecutionPhase(in.Phase)
 	out.ObservedGeneration = in.ObservedGeneration
 	out.Conditions = *(*[]core.Condition)(unsafe.Pointer(&in.Conditions))
+	out.LastError = (*core.Error)(unsafe.Pointer(in.LastError))
 	out.ExportReference = (*core.ObjectReference)(unsafe.Pointer(in.ExportReference))
 	out.DeployItemReferences = *(*[]core.VersionedNamedObjectReference)(unsafe.Pointer(&in.DeployItemReferences))
 	return nil
@@ -1254,6 +1255,7 @@ func autoConvert_core_ExecutionStatus_To_v1alpha1_ExecutionStatus(in *core.Execu
 	out.Phase = ExecutionPhase(in.Phase)
 	out.ObservedGeneration = in.ObservedGeneration
 	out.Conditions = *(*[]Condition)(unsafe.Pointer(&in.Conditions))
+	out.LastError = (*Error)(unsafe.Pointer(in.LastError))
 	out.ExportReference = (*ObjectReference)(unsafe.Pointer(in.ExportReference))
 	out.DeployItemReferences = *(*[]VersionedNamedObjectReference)(unsafe.Pointer(&in.DeployItemReferences))
 	return nil

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -671,6 +671,11 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LastError != nil {
+		in, out := &in.LastError, &out.LastError
+		*out = new(Error)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ExportReference != nil {
 		in, out := &in.ExportReference, &out.ExportReference
 		*out = new(ObjectReference)

--- a/apis/core/zz_generated.deepcopy.go
+++ b/apis/core/zz_generated.deepcopy.go
@@ -694,6 +694,11 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LastError != nil {
+		in, out := &in.LastError, &out.LastError
+		*out = new(Error)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ExportReference != nil {
 		in, out := &in.ExportReference, &out.ExportReference
 		*out = new(ObjectReference)

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -2600,7 +2600,7 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionStatus(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"phase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Phase is the current phase of the execution .",
+							Description: "Phase is the current phase of the execution.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2627,6 +2627,12 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionStatus(ref common.ReferenceCa
 							},
 						},
 					},
+					"lastError": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastError describes the last error that occurred.",
+							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.Error"),
+						},
+					},
 					"exportRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ExportReference references the object that contains the exported values. only used for operation purpose.",
@@ -2648,11 +2654,10 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"observedGeneration"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.VersionedNamedObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.VersionedNamedObjectReference"},
 	}
 }
 

--- a/charts/landscaper/templates/deployment-controller.yaml
+++ b/charts/landscaper/templates/deployment-controller.yaml
@@ -36,9 +36,9 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.controllerRepository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           {{- if .Values.serviceAccount.create }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           {{- end }}
           args:
           - "--config=/app/ls/config/config.yaml"

--- a/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/templates/deployment-webhooks.yaml
@@ -2,7 +2,7 @@
 
  SPDX-License-Identifier: Apache-2.0
 */}}
-{{- if not (has "all" .Values.disableWebhooks) }}
+{{- if not (has "all" .Values.webhooksServer.disableWebhooks) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,15 +36,15 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.webhookServerRepository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.webhooksServer.image.repository }}:{{ .Values.webhooksServer.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.webhooksServer.image.pullPolicy }}
           args:
           - "-v={{ .Values.landscaper.verbosity }}"
-          - --port={{ .Values.webhookConfig.servicePort }}
+          - --port={{ .Values.webhooksServer.servicePort }}
           - --webhook-service={{ .Release.Namespace }}/{{ include "landscaper.webhooks.fullname" . }}
-          - --webhook-service-port={{ .Values.webhookConfig.servicePort }}
-          {{- if .Values.disableWebhooks }}
-          - --disable-webhooks={{ .Values.disableWebhooks | join "," }}
+          - --webhook-service-port={{ .Values.webhooksServer.servicePort }}
+          {{- if .Values.webhooksServer.disableWebhooks }}
+          - --disable-webhooks={{ .Values.webhooksServer.disableWebhooks | join "," }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/landscaper/templates/rbac-webhooks.yaml
+++ b/charts/landscaper/templates/rbac-webhooks.yaml
@@ -4,7 +4,7 @@
 */}}
 
 {{- if .Values.serviceAccount.create -}}
-{{- if not (has "all" .Values.disableWebhooks) -}}
+{{- if not (has "all" .Values.webhooksServer.disableWebhooks) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/landscaper/templates/rolebinding.yaml
+++ b/charts/landscaper/templates/rolebinding.yaml
@@ -19,7 +19,7 @@ subjects:
   name: {{ include "landscaper.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
-{{- if not (has "all" .Values.disableWebhooks) }}
+{{- if not (has "all" .Values.webhooksServer.disableWebhooks) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/landscaper/templates/service.yaml
+++ b/charts/landscaper/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   selector:
     {{- include "landscaper.selectorLabels" . | nindent 4 }}
 ---
-{{- if not (has "all" .Values.disableWebhooks) }}
+{{- if not (has "all" .Values.webhooksServer.disableWebhooks) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,8 +29,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.webhookConfig.servicePort }}
-    targetPort: {{ .Values.webhookConfig.servicePort }}
+  - port: {{ .Values.webhooksServer.servicePort }}
+    targetPort: {{ .Values.webhooksServer.servicePort }}
     protocol: TCP
     name: webhook
   selector:

--- a/charts/landscaper/templates/serviceaccount.yaml
+++ b/charts/landscaper/templates/serviceaccount.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
-{{- if not (has "all" .Values.disableWebhooks) }}
+{{- if not (has "all" .Values.webhooksServer.disableWebhooks) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/landscaper/values.yaml
+++ b/charts/landscaper/values.yaml
@@ -39,18 +39,28 @@ landscaper:
 
 #  deployItemPickupTimeout: 5m
 
+image:
+   # Overrides the image tag whose default is the chart appVersion.
+#  tag: ""
+
 controller:
   replicaCount: 1
+  image:
+    repository: eu.gcr.io/gardener-project/landscaper/landscaper-controller
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the .Values.image.tag or chart appVersion.
+    #tag: ""
 
 webhooksServer:
   replicaCount: 1
+  image:
+    repository: eu.gcr.io/gardener-project/landscaper/landscaper-webhooks-server
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the .Values.image.tag or the chart appVersion.
+    #tag: ""
 
-image:
-  controllerRepository: eu.gcr.io/gardener-project/landscaper/landscaper-controller
-  webhookServerRepository: eu.gcr.io/gardener-project/landscaper/landscaper-webhooks-server
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  #tag: ""
+  servicePort: 9443 # required unless disableWebhooks contains "all"
+  disableWebhooks: [] # options: installation, deployitem, execution, all
 
 imagePullSecrets: []
 nameOverride: ""
@@ -99,8 +109,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-webhookConfig: # required unless disableWebhooks contains "all"
-  servicePort: 9443
-
-disableWebhooks: [] # options: installation, deployitem, execution, all

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1760,6 +1760,7 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <p>
 (<em>Appears on:</em>
 <a href="#landscaper.gardener.cloud/v1alpha1.DeployItemStatus">DeployItemStatus</a>, 
+<a href="#landscaper.gardener.cloud/v1alpha1.ExecutionStatus">ExecutionStatus</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>
@@ -1943,7 +1944,7 @@ ExecutionPhase
 </em>
 </td>
 <td>
-<p>Phase is the current phase of the execution .</p>
+<p>Phase is the current phase of the execution.</p>
 </td>
 </tr>
 <tr>
@@ -1954,6 +1955,7 @@ int64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ObservedGeneration is the most recent generation observed for this Execution.
 It corresponds to the Execution generation, which is updated on mutation by the landscaper.</p>
 </td>
@@ -1968,7 +1970,22 @@ It corresponds to the Execution generation, which is updated on mutation by the 
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Conditions contains the actual condition of a execution</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastError</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.Error">
+Error
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastError describes the last error that occurred.</p>
 </td>
 </tr>
 <tr>
@@ -1996,6 +2013,7 @@ only used for operation purpose.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>DeployItemReferences contain the state of all deploy items.
 The observed generation is here the generation of the Execution not the DeployItem.</p>
 </td>

--- a/docs/gettingstarted/install-landscaper-controller.md
+++ b/docs/gettingstarted/install-landscaper-controller.md
@@ -35,8 +35,14 @@ For a very simple setup, internal deployers (`helm`, `manifest` and `container`)
 The following snippet shows a sample `values.yaml` file that is used to parameterize the Helm chart:
 
 ```yaml
-image:
-  tag: image version # .e.g. 0.0.0-dev-8bf4b8150f96fed8868618c56787b81fa4e095e6
+controller:
+  image:
+    tag: image version # .e.g. 0.0.0-dev-8bf4b8150f96fed8868618c56787b81fa4e095e6
+
+webhookServer:
+#  disableWebhooks: all # disables specific webhooks. If all are disabled the webhook server is not deployed
+  image:
+    tag: image version # .e.g. 0.0.0-dev-8bf4b8150f96fed8868618c56787b81fa4e095e6
 
 landscaper:
   cache: {} # Landscaper caches pulled OCI artefacts on disk and optionally in-memory

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -187,15 +187,46 @@ spec:
                 required:
                 - name
                 type: object
+              lastError:
+                description: LastError describes the last error that occurred.
+                properties:
+                  codes:
+                    description: Well-defined error codes in case the condition reports a problem.
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about the transition.
+                    type: string
+                  operation:
+                    description: Operation describes the operator where the error occurred.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                required:
+                - lastTransitionTime
+                - lastUpdateTime
+                - message
+                - operation
+                - reason
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed for this Execution. It corresponds to the Execution generation, which is updated on mutation by the landscaper.
                 format: int64
                 type: integer
               phase:
-                description: Phase is the current phase of the execution .
+                description: Phase is the current phase of the execution.
                 type: string
-            required:
-            - observedGeneration
             type: object
         required:
         - spec

--- a/pkg/landscaper/execution/execution.go
+++ b/pkg/landscaper/execution/execution.go
@@ -44,7 +44,7 @@ func (o *Operation) UpdateStatus(ctx context.Context, phase lsv1alpha1.Execution
 	return nil
 }
 
-// CreateOrUpdateDataObject creates or updates a dataobject from a object reference
+// CreateOrUpdateExportReference creates or updates a dataobject from a object reference
 func (o *Operation) CreateOrUpdateExportReference(ctx context.Context, values interface{}) error {
 	do := dataobjects.New().
 		SetNamespace(o.exec.Namespace).

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 		err := eOp.Reconcile(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 	})
 
@@ -149,7 +149,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 		err := eOp.Reconcile(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 		Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
 	})
 

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -72,6 +72,9 @@ type ExecutionStatus struct {
 	// Conditions contains the actual condition of a execution
 	Conditions []Condition `json:"conditions,omitempty"`
 
+	// LastError describes the last error that occurred.
+	LastError *Error `json:"lastError,omitempty"`
+
 	// ExportReference references the object that contains the exported values.
 	// only used for operation purpose.
 	// +optional

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/health/health.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/health/health.go
@@ -31,7 +31,7 @@ var (
 // * Its observed generation is up-to-date
 // * No annotation landscaper.gardener.cloud/operation is set
 // * No lastError is in the status
-// * A last operation is state succeeded is present
+// * A last operation in state succeeded is present
 // * landscaperv1alpha1.ComponentPhaseSucceeded
 func CheckInstallation(installation *lsv1alpha1.Installation) error {
 	if installation.Status.ObservedGeneration < installation.Generation {

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/error.go
@@ -68,6 +68,26 @@ func NewWrappedError(err error, operation, reason, message string, codes ...lsv1
 	}
 }
 
+// NewErrorOrNil creates a new landscaper internal error that wraps another error.
+// if no error is set the functions return nil.
+// The error is automatically set as error message.
+func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{
+		lsErr: lsv1alpha1.Error{
+			Operation:          operation,
+			Reason:             reason,
+			Message:            err.Error(),
+			LastTransitionTime: metav1.Now(),
+			LastUpdateTime:     metav1.Now(),
+			Codes:              codes,
+		},
+		err: err,
+	}
+}
+
 // IsError returns the landscaper if the given error is one.
 // If the err does not contain a landsacper error nil is returned.
 func IsError(err error) (*Error, bool) {
@@ -88,6 +108,9 @@ func IsError(err error) (*Error, bool) {
 
 // TryUpdateError tries to update the properties of the last error if the err is a internal landscaper error.
 func TryUpdateError(lastErr *lsv1alpha1.Error, err error) *lsv1alpha1.Error {
+	if err == nil {
+		return nil
+	}
 	if intErr, ok := IsError(err); ok {
 		return intErr.UpdatedError(lastErr)
 	}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -81,15 +81,21 @@ type ExecutionSpec struct {
 
 // ExecutionStatus contains the current status of a execution.
 type ExecutionStatus struct {
-	// Phase is the current phase of the execution .
+	// Phase is the current phase of the execution.
 	Phase ExecutionPhase `json:"phase,omitempty"`
 
 	// ObservedGeneration is the most recent generation observed for this Execution.
 	// It corresponds to the Execution generation, which is updated on mutation by the landscaper.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// Conditions contains the actual condition of a execution
+	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
+
+	// LastError describes the last error that occurred.
+	// +optional
+	LastError *Error `json:"lastError,omitempty"`
 
 	// ExportReference references the object that contains the exported values.
 	// only used for operation purpose.
@@ -98,6 +104,7 @@ type ExecutionStatus struct {
 
 	// DeployItemReferences contain the state of all deploy items.
 	// The observed generation is here the generation of the Execution not the DeployItem.
+	// +optional
 	DeployItemReferences []VersionedNamedObjectReference `json:"deployItemRefs,omitempty"`
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1240,6 +1240,7 @@ func autoConvert_v1alpha1_ExecutionStatus_To_core_ExecutionStatus(in *ExecutionS
 	out.Phase = core.ExecutionPhase(in.Phase)
 	out.ObservedGeneration = in.ObservedGeneration
 	out.Conditions = *(*[]core.Condition)(unsafe.Pointer(&in.Conditions))
+	out.LastError = (*core.Error)(unsafe.Pointer(in.LastError))
 	out.ExportReference = (*core.ObjectReference)(unsafe.Pointer(in.ExportReference))
 	out.DeployItemReferences = *(*[]core.VersionedNamedObjectReference)(unsafe.Pointer(&in.DeployItemReferences))
 	return nil
@@ -1254,6 +1255,7 @@ func autoConvert_core_ExecutionStatus_To_v1alpha1_ExecutionStatus(in *core.Execu
 	out.Phase = ExecutionPhase(in.Phase)
 	out.ObservedGeneration = in.ObservedGeneration
 	out.Conditions = *(*[]Condition)(unsafe.Pointer(&in.Conditions))
+	out.LastError = (*Error)(unsafe.Pointer(in.LastError))
 	out.ExportReference = (*ObjectReference)(unsafe.Pointer(in.ExportReference))
 	out.DeployItemReferences = *(*[]VersionedNamedObjectReference)(unsafe.Pointer(&in.DeployItemReferences))
 	return nil

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -671,6 +671,11 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LastError != nil {
+		in, out := &in.LastError, &out.LastError
+		*out = new(Error)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ExportReference != nil {
 		in, out := &in.ExportReference, &out.ExportReference
 		*out = new(ObjectReference)

--- a/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -694,6 +694,11 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LastError != nil {
+		in, out := &in.LastError, &out.LastError
+		*out = new(Error)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ExportReference != nil {
 		in, out := &in.ExportReference, &out.ExportReference
 		*out = new(ObjectReference)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/priority 3

**What this PR does / why we need it**:

It is now possible to configure the webhook server image and controller image separately.
the old `image.tag` is still valid.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @achimweigel @robertgraeff 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
It is now possible to configure the webhook server image and controller image separately.
```
