### PR TITLE
add tests for deployer blueprint deployments

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -46,3 +46,7 @@ component-cli ca resources add ${LS_CA_PATH} \
 
 printf "> Add Landscaper CA to ctf\n"
 component-cli ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
+
+# also upload the components to a open source repo
+# todo: remove as soon as the default component repository is public
+component-cli ctf push --repo-ctx="eu.gcr.io/gardener-project/development" "${CTF_PATH}"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,12 @@ test:
 
 .PHONY: integration-test
 integration-test:
-	@go test -timeout=1h -mod=vendor $(REPO_ROOT)/test/integration --v -ginkgo.v -ginkgo.progress --kubeconfig $(KUBECONFIG) --ls-version $(EFFECTIVE_VERSION) --registry-config=$(REGISTRY_CONFIG) --disable-cleanup=$(DISABLE_CLEANUP)
+	@go test -timeout=1h -mod=vendor $(REPO_ROOT)/test/integration --v -ginkgo.v -ginkgo.progress \
+		--kubeconfig $(KUBECONFIG) \
+		--ls-version $(EFFECTIVE_VERSION) \
+		--registry-config=$(REGISTRY_CONFIG) \
+		--disable-cleanup=$(DISABLE_CLEANUP)
+
 
 .PHONY: verify
 verify: check

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -108,6 +108,7 @@ func (o *options) run(ctx context.Context) error {
 				return err
 			}
 			config.OCI = o.config.Registry.OCI
+			config.TargetSelector = addDefaultTargetSelector(config.TargetSelector)
 			containerctlr.DefaultConfiguration(config)
 			if err := containerctlr.AddControllerToManager(mgr, mgr, config); err != nil {
 				return fmt.Errorf("unable to add container deployer: %w", err)
@@ -118,6 +119,7 @@ func (o *options) run(ctx context.Context) error {
 				return err
 			}
 			config.OCI = o.config.Registry.OCI
+			config.TargetSelector = addDefaultTargetSelector(config.TargetSelector)
 			if err := helmctlr.AddControllersToManager(mgr, config); err != nil {
 				return fmt.Errorf("unable to add helm deployer: %w", err)
 			}
@@ -126,6 +128,7 @@ func (o *options) run(ctx context.Context) error {
 			if err := o.deployer.GetDeployerConfiguration(deployerName, config); err != nil {
 				return err
 			}
+			config.TargetSelector = addDefaultTargetSelector(config.TargetSelector)
 			if err := manifestctlr.AddControllerToManager(mgr, config); err != nil {
 				return fmt.Errorf("unable to add helm deployer: %w", err)
 			}
@@ -134,6 +137,7 @@ func (o *options) run(ctx context.Context) error {
 			if err := o.deployer.GetDeployerConfiguration(deployerName, config); err != nil {
 				return err
 			}
+			config.TargetSelector = addDefaultTargetSelector(config.TargetSelector)
 			if err := mockctlr.AddControllerToManager(mgr, config); err != nil {
 				return fmt.Errorf("unable to add mock deployer: %w", err)
 			}

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	manifestinstall "github.com/gardener/landscaper/apis/deployer/manifest/install"
@@ -45,6 +47,11 @@ type Manifest struct {
 	Target                *lsv1alpha1.Target
 	ProviderConfiguration *manifestv1alpha2.ProviderConfiguration
 	ProviderStatus        *manifestv1alpha2.ProviderStatus
+}
+
+// NewDeployItemBuilder creates a new deployitem builder for manifest deployitems
+func NewDeployItemBuilder() *utils.DeployItemBuilder {
+	return utils.NewDeployItemBuilder(string(Type)).Scheme(ManifestScheme)
 }
 
 // New creates a new internal manifest item

--- a/pkg/landscaper/constants/constants.go
+++ b/pkg/landscaper/constants/constants.go
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+// NotUseDefaultDeployerAnnotation is the installation annotation that refuses the internal deployer to reconcile
+// the installation.
+const NotUseDefaultDeployerAnnotation = "landscaper.gardener.cloud/not-internal"

--- a/pkg/utils/builders.go
+++ b/pkg/utils/builders.go
@@ -11,10 +11,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 )
 
 // DeployItemBuilder is a helper struct to build deploy items
@@ -117,15 +117,8 @@ func (b *DeployItemBuilder) Build() (*lsv1alpha1.DeployItem, error) {
 		return nil, err
 	}
 
-	// set the apiversion and kind
-	gvk, err := apiutil.GVKForObject(b.ProviderConfiguration, b.scheme)
+	ext, err := kutil.ConvertToRawExtension(b.ProviderConfiguration, b.scheme)
 	if err != nil {
-		return nil, fmt.Errorf("unable to to get gvk for provider configuration: %w", err)
-	}
-	b.ProviderConfiguration.GetObjectKind().SetGroupVersionKind(gvk)
-
-	ext := &runtime.RawExtension{}
-	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&b.ProviderConfiguration, ext, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -262,6 +262,23 @@ func HasLabelWithValue(obj metav1.Object, lab string, value string) bool {
 	return val == value
 }
 
+// ConvertToRawExtension converts a object to a raw extension.
+// The type of the object is automatically set given the scheme.
+func ConvertToRawExtension(from runtime.Object, scheme *runtime.Scheme) (*runtime.RawExtension, error) {
+	// set the apiversion and kind
+	gvk, err := apiutil.GVKForObject(from, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("unable to to get gvk for provider configuration: %w", err)
+	}
+	from.GetObjectKind().SetGroupVersionKind(gvk)
+
+	ext := &runtime.RawExtension{}
+	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&from, ext, nil); err != nil {
+		return nil, err
+	}
+	return ext, nil
+}
+
 // GenerateKubeconfigBytes generates a kubernetes kubeconfig config object from a rest config
 // and encodes it as yaml.
 func GenerateKubeconfigBytes(restConfig *rest.Config) ([]byte, error) {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -36,6 +36,10 @@ import (
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
+// OpenSourceRepositoryContext is the base url of the repository context for the gardener open source components.
+// There all landscaper blueprints/components are available.
+const OpenSourceRepositoryContext = "eu.gcr.io/gardener-project/development"
+
 type Options struct {
 	fs               *flag.FlagSet
 	KubeconfigPath   string

--- a/test/integration/core/registry.go
+++ b/test/integration/core/registry.go
@@ -79,7 +79,7 @@ func RegistryTest(f *framework.Framework) {
 			ginkgo.By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, false)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, false)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprints
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/onsi/ginkgo"
+	g "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	helmv1alpha1 "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1"
+	"github.com/gardener/landscaper/pkg/deployer/helm"
+
+	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
+	"github.com/gardener/landscaper/pkg/deployer/container"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
+	mockv1alpha1 "github.com/gardener/landscaper/apis/deployer/mock/v1alpha1"
+	"github.com/gardener/landscaper/pkg/deployer/manifest"
+	"github.com/gardener/landscaper/pkg/deployer/mock"
+	"github.com/gardener/landscaper/pkg/landscaper/constants"
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
+
+	commonutils "github.com/gardener/landscaper/pkg/utils"
+	"github.com/gardener/landscaper/test/framework"
+	"github.com/gardener/landscaper/test/utils"
+	"github.com/gardener/landscaper/test/utils/envtest"
+)
+
+func DeployerBlueprintTests(f *framework.Framework) {
+	ginkgo.Describe("Deployer Blueprint", func() {
+
+		phase := lsv1alpha1.ExecutionPhaseSucceeded
+		TestDeployerBlueprint(f, testDefinition{
+			Name:                    "MockDeployer",
+			ComponentDescriptorName: "github.com/gardener/landscaper/mock-deployer",
+			BlueprintResourceName:   "mock-deployer-blueprint",
+			DeployItemBuilder: mock.NewDeployItemBuilder().
+				ProviderConfig(&mockv1alpha1.ProviderConfiguration{
+					Phase: &phase,
+				}),
+		})
+
+		TestDeployerBlueprint(f, testDefinition{
+			Name:                    "ManifestDeployer",
+			ComponentDescriptorName: "github.com/gardener/landscaper/mock-deployer",
+			BlueprintResourceName:   "mock-deployer-blueprint",
+			DeployItem: func(state *envtest.State, target *lsv1alpha1.Target) (*lsv1alpha1.DeployItem, error) {
+				secret, _ := kutil.ConvertToRawExtension(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: state.Namespace},
+					Data: map[string][]byte{
+						"key": []byte("val"),
+					},
+				}, scheme.Scheme)
+				return manifest.NewDeployItemBuilder().
+					Key(state.Namespace, "my-di").
+					Target(target.Namespace, target.Name).
+					ProviderConfig(&manifestv1alpha2.ProviderConfiguration{
+						Manifests: []manifestv1alpha2.Manifest{
+							{
+								Policy:   manifestv1alpha2.ManagePolicy,
+								Manifest: secret,
+							},
+						},
+					}).Build()
+			},
+		})
+
+		TestDeployerBlueprint(f, testDefinition{
+			Name:                    "ContainerDeployer",
+			ComponentDescriptorName: "github.com/gardener/landscaper/container-deployer",
+			BlueprintResourceName:   "container-deployer-blueprint",
+			DeployItemBuilder: container.NewDeployItemBuilder().
+				ProviderConfig(&containerv1alpha1.ProviderConfiguration{
+					Image:   "alpine:latest",
+					Command: []string{"sh", "-c"},
+					Args:    []string{"echo test"},
+				}),
+		})
+
+		TestDeployerBlueprint(f, testDefinition{
+			Name:                    "HelmDeployer",
+			ComponentDescriptorName: "github.com/gardener/landscaper/helm-deployer",
+			BlueprintResourceName:   "helm-deployer-blueprint",
+			DeployItem: func(state *envtest.State, target *lsv1alpha1.Target) (*lsv1alpha1.DeployItem, error) {
+				return helm.NewDeployItemBuilder().
+					Key(state.Namespace, "my-di").
+					Target(target.Namespace, target.Name).
+					ProviderConfig(&helmv1alpha1.ProviderConfiguration{
+						Name:      "my-chart",
+						Namespace: state.Namespace,
+						Chart: helmv1alpha1.Chart{
+							Ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0",
+						},
+					}).Build()
+			},
+		})
+	})
+}
+
+type testDefinition struct {
+	Name                    string
+	ComponentDescriptorName string
+	BlueprintResourceName   string
+	DeployItem              func(state *envtest.State, target *lsv1alpha1.Target) (*lsv1alpha1.DeployItem, error)
+	DeployItemBuilder       *commonutils.DeployItemBuilder
+}
+
+func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
+	var (
+		dumper = f.Register()
+
+		ctx     context.Context
+		state   *envtest.State
+		cleanup framework.CleanupFunc
+
+		name                    = td.Name
+		componentDescriptorName = td.ComponentDescriptorName
+		blueprintResourceName   = td.BlueprintResourceName
+	)
+
+	ginkgo.BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		state, cleanup, err = f.NewState(ctx)
+		utils.ExpectNoError(err)
+		dumper.AddNamespaces(state.Namespace)
+	})
+
+	ginkgo.AfterEach(func() {
+		defer ctx.Done()
+		g.Expect(cleanup(ctx)).ToNot(g.HaveOccurred())
+	})
+
+	ginkgo.It(fmt.Sprintf("[%s] should deploy a deployer with its blueprint", name), func() {
+		ginkgo.By("Create Target for the installation")
+		target := &lsv1alpha1.Target{}
+		target.Name = "my-cluster-target"
+		target.Namespace = state.Namespace
+		target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+		utils.ExpectNoError(err)
+		utils.ExpectNoError(state.Create(ctx, f.Client, target))
+
+		ginkgo.By("Create Configuration for the installation")
+		cm := &corev1.ConfigMap{}
+		cm.Name = "deployer-config"
+		cm.Namespace = state.Namespace
+		cm.Data = map[string]string{
+			"releaseName":      "my-deployer",
+			"releaseNamespace": state.Namespace,
+			// todo: add own target selector to not interfere with other tests
+			"values": "{}",
+		}
+		utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+		cmRef := lsv1alpha1.ObjectReference{
+			Name:      cm.Name,
+			Namespace: cm.Namespace,
+		}
+
+		// build installation
+		inst := &lsv1alpha1.Installation{}
+		inst.Name = "deployer"
+		inst.Namespace = state.Namespace
+		inst.Annotations = map[string]string{
+			constants.NotUseDefaultDeployerAnnotation: "true",
+		}
+		inst.Spec.ComponentDescriptor = &lsv1alpha1.ComponentDescriptorDefinition{
+			Reference: &lsv1alpha1.ComponentDescriptorReference{
+				RepositoryContext: &cdv2.RepositoryContext{
+					Type:    cdv2.OCIRegistryType,
+					BaseURL: framework.OpenSourceRepositoryContext,
+				},
+				ComponentName: componentDescriptorName,
+				Version:       f.LsVersion,
+			},
+		}
+		inst.Spec.Blueprint.Reference = &lsv1alpha1.RemoteBlueprintReference{
+			ResourceName: blueprintResourceName,
+		}
+		inst.Spec.Imports.Targets = []lsv1alpha1.TargetImportExport{
+			{
+				Name:   "cluster",
+				Target: "#" + target.Name,
+			},
+		}
+		inst.Spec.Imports.Data = []lsv1alpha1.DataImport{
+			{
+				Name: "releaseName",
+				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
+					ObjectReference: cmRef,
+					Key:             "releaseName",
+				},
+			},
+			{
+				Name: "releaseNamespace",
+				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
+					ObjectReference: cmRef,
+					Key:             "releaseNamespace",
+				},
+			},
+			{
+				Name: "values",
+				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
+					ObjectReference: cmRef,
+					Key:             "values",
+				},
+			},
+		}
+
+		utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+		utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
+
+		ginkgo.By("Testing the deployer with a simple deployitem")
+
+		var di *lsv1alpha1.DeployItem
+		if td.DeployItemBuilder != nil {
+			di, err = td.DeployItemBuilder.
+				Key(state.Namespace, "deployer-di-test").
+				Target(target.Namespace, target.Name).
+				Build()
+			utils.ExpectNoError(err)
+		} else if td.DeployItem != nil {
+			di, err = td.DeployItem(state, target)
+			utils.ExpectNoError(err)
+		}
+		g.Expect(di).ToNot(g.BeNil())
+		utils.ExpectNoError(state.Create(ctx, f.Client, di))
+
+		utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
+
+		utils.ExpectNoError(utils.DeleteObject(ctx, f.Client, di, 2*time.Minute))
+		utils.ExpectNoError(utils.DeleteObject(ctx, f.Client, inst, 2*time.Minute))
+	})
+}

--- a/test/integration/deployers/blueprints/register.go
+++ b/test/integration/deployers/blueprints/register.go
@@ -2,18 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package deployers
+package blueprints
 
 import (
 	"github.com/gardener/landscaper/test/framework"
-	"github.com/gardener/landscaper/test/integration/deployers/blueprints"
-	"github.com/gardener/landscaper/test/integration/deployers/helmcharts"
 )
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	ContainerDeployerTests(f)
-	ManifestDeployerTests(f)
-	helmcharts.RegisterTests(f)
-	blueprints.RegisterTests(f)
+	DeployerBlueprintTests(f)
 }

--- a/test/integration/deployers/container_tests.go
+++ b/test/integration/deployers/container_tests.go
@@ -23,14 +23,11 @@ import (
 )
 
 func ContainerDeployerTests(f *framework.Framework) {
-	var (
-		dumper     = f.Register()
-		exampleDir = path.Join(f.RootPath, "examples/deploy-items")
-	)
-
 	ginkgo.Describe("Container Deployer", func() {
-
 		var (
+			dumper     = f.Register()
+			exampleDir = path.Join(f.RootPath, "examples/deploy-items")
+
 			ctx     context.Context
 			state   *envtest.State
 			cleanup framework.CleanupFunc
@@ -55,7 +52,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 
@@ -82,7 +79,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 
@@ -120,7 +117,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 
@@ -153,7 +150,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/deployers/helmcharts/chartstests.go
+++ b/test/integration/deployers/helmcharts/chartstests.go
@@ -125,7 +125,7 @@ func deployDeployItemAndWaitForSuccess(
 	chartDir string,
 	valuesFile string) *lsv1alpha1.DeployItem {
 
-	target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, deployerName, f.RestConfig, true)
+	target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, deployerName, f.RestConfig, true)
 	utils.ExpectNoError(err)
 	utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/deployers/manifest_tests.go
+++ b/test/integration/deployers/manifest_tests.go
@@ -28,22 +28,20 @@ import (
 )
 
 func ManifestDeployerTests(f *framework.Framework) {
-	var (
-		dumper      = f.Register()
-		exampleDir  = path.Join(f.RootPath, "examples", "deploy-items")
-		testDataDir = path.Join(f.RootPath, "test", "testdata")
-	)
-
-	const (
-		timeout = 2 * time.Minute
-	)
-
 	ginkgo.Describe("Manifest Deployer", func() {
 
 		var (
+			dumper      = f.Register()
+			exampleDir  = path.Join(f.RootPath, "examples", "deploy-items")
+			testDataDir = path.Join(f.RootPath, "test", "testdata")
+
 			ctx     context.Context
 			state   *envtest.State
 			cleanup framework.CleanupFunc
+		)
+
+		const (
+			timeout = 2 * time.Minute
 		)
 
 		ginkgo.BeforeEach(func() {
@@ -64,7 +62,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 
@@ -124,7 +122,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
-			target, err := utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/deployitems/pickup_timeout.go
+++ b/test/integration/deployitems/pickup_timeout.go
@@ -46,14 +46,11 @@ func namespacedName(meta metav1.ObjectMeta) types.NamespacedName {
 }
 
 func PickupTimeoutTests(f *framework.Framework) {
-	var (
-		dumper      = f.Register()
-		testdataDir = path.Join(f.RootPath, "test", "integration", "deployitems", "testdata")
-	)
-
 	ginkgo.Describe("Deploy Item Pickup Timeout", func() {
-
 		var (
+			dumper      = f.Register()
+			testdataDir = path.Join(f.RootPath, "test", "integration", "deployitems", "testdata")
+
 			ctx     context.Context
 			state   *envtest.State
 			cleanup framework.CleanupFunc

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/integration/core"
 	"github.com/gardener/landscaper/test/integration/deployers"
-	"github.com/gardener/landscaper/test/integration/helmcharts"
 	"github.com/gardener/landscaper/test/integration/tutorial"
 	"github.com/gardener/landscaper/test/integration/webhook"
 	"github.com/gardener/landscaper/test/utils"
@@ -51,7 +50,6 @@ func TestConfig(t *testing.T) {
 
 	tutorial.RegisterTests(f)
 	webhook.RegisterTests(f)
-	helmcharts.RegisterTests(f)
 	core.RegisterTests(f)
 	deployers.RegisterTests(f)
 	deployitems.RegisterTests(f)

--- a/test/integration/tutorial/aggregated-blueprint.go
+++ b/test/integration/tutorial/aggregated-blueprint.go
@@ -44,7 +44,7 @@ func AggregatedBlueprint(f *framework.Framework) {
 			ginkgo.By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
-			target, err = utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err = utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/tutorial/external-jsonschema.go
+++ b/test/integration/tutorial/external-jsonschema.go
@@ -46,7 +46,7 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			ginkgo.By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
-			target, err = utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err = utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -45,7 +45,7 @@ func NginxIngressTest(f *framework.Framework) {
 			ginkgo.By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
-			target, err = utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err = utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 
@@ -113,7 +113,7 @@ func NginxIngressTest(f *framework.Framework) {
 			ginkgo.By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
-			target, err = utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err = utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/integration/tutorial/simple-import.go
+++ b/test/integration/tutorial/simple-import.go
@@ -47,7 +47,7 @@ func SimpleImport(f *framework.Framework) {
 			ginkgo.By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
-			target, err = utils.CreateInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			target, err = utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, f.Client, target))
 

--- a/test/utils/resources.go
+++ b/test/utils/resources.go
@@ -213,10 +213,10 @@ func CreateKubernetesTarget(namespace, name string, restConfig *rest.Config) (*l
 	return target, nil
 }
 
-// CreateInternalKubernetesTarget creates a new target of type kubernetes
+// BuildInternalKubernetesTarget creates a new target of type kubernetes
 // whereas the hostname of the cluster will be set to the cluster internal host.
 // It is expected that the controller runs inside the same cluster where it also deploys to.
-func CreateInternalKubernetesTarget(ctx context.Context, kubeClient client.Client, namespace, name string, restConfig *rest.Config, internal bool) (*lsv1alpha1.Target, error) {
+func BuildInternalKubernetesTarget(ctx context.Context, kubeClient client.Client, namespace, name string, restConfig *rest.Config, internal bool) (*lsv1alpha1.Target, error) {
 	if internal {
 		oldHost := restConfig.Host
 		defer func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind test
/priority 3

**What this PR does / why we need it**:

Adds tests for the deployer blueprints.
The tests deploy the deployer using the blueprint and then testing the deployed deployer with a sample deployitem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Integration test for deployer blueprints have been added.
```
