### PR TITLE
Fix initialisation with default context

### DIFF
--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -134,8 +134,9 @@ func (c *controller) initPrerequisites(ctx context.Context, inst *lsv1alpha1.Ins
 	}
 
 	// default repository context if not defined
+	defaultRepoContext := c.lsConfig.RepositoryContext
 	if inst.Spec.ComponentDescriptor != nil && inst.Spec.ComponentDescriptor.Reference != nil && inst.Spec.ComponentDescriptor.Reference.RepositoryContext == nil {
-		inst.Spec.ComponentDescriptor.Reference.RepositoryContext = c.lsConfig.RepositoryContext
+		inst.Spec.ComponentDescriptor.Reference.RepositoryContext = defaultRepoContext
 	}
 
 	cdRef := installations.GeReferenceFromComponentDescriptorDefinition(inst.Spec.ComponentDescriptor)
@@ -153,7 +154,7 @@ func (c *controller) initPrerequisites(ctx context.Context, inst *lsv1alpha1.Ins
 			currOp, "InitInstallation", err.Error())
 	}
 
-	instOp, err := installations.NewInstallationOperationFromOperation(ctx, c.Interface, internalInstallation)
+	instOp, err := installations.NewInstallationOperationFromOperation(ctx, c.Interface, internalInstallation, defaultRepoContext)
 	if err != nil {
 		err = fmt.Errorf("unable to create installation operation: %w", err)
 		return nil, lsv1alpha1helper.NewWrappedError(err,

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -126,7 +126,7 @@ func (c *controller) eligibleToUpdate(ctx context.Context, op *installations.Ope
 	}
 
 	validator := imports.NewValidator(op)
-	run, err := validator.OutdatedImports(ctx, op.Inst)
+	run, err := validator.OutdatedImports(ctx)
 	if err != nil {
 		return run, err
 	}
@@ -134,7 +134,7 @@ func (c *controller) eligibleToUpdate(ctx context.Context, op *installations.Ope
 		return false, nil
 	}
 
-	return validator.CheckDependentInstallations(ctx, op.Inst)
+	return validator.CheckDependentInstallations(ctx)
 }
 
 // Update redeploys subinstallations and deploy items.

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Delete", func() {
 		inInstA, err := installations.CreateInternalInstallation(context.TODO(), op, state.Installations[state.Namespace+"/a"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstA)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstA, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = installationsctl.EnsureDeletion(ctx, instOp)
@@ -82,7 +82,7 @@ var _ = Describe("Delete", func() {
 		inInstRoot, err := installations.CreateInternalInstallation(context.TODO(), op, state.Installations[state.Namespace+"/root"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstRoot)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstRoot, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = installationsctl.EnsureDeletion(ctx, instOp)
@@ -108,7 +108,7 @@ var _ = Describe("Delete", func() {
 		inInstB, err := installations.CreateInternalInstallation(context.TODO(), op, state.Installations[state.Namespace+"/b"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = installationsctl.EnsureDeletion(ctx, instOp)
@@ -126,7 +126,7 @@ var _ = Describe("Delete", func() {
 		inInstB, err := installations.CreateInternalInstallation(context.TODO(), op, state.Installations[state.Namespace+"/a"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = installationsctl.EnsureDeletion(ctx, instOp)

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Context", func() {
 		instRoot, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/root"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, instRoot)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, instRoot, nil)
 		Expect(err).ToNot(HaveOccurred())
 		lCtx := instOp.Context()
 
@@ -68,7 +68,7 @@ var _ = Describe("Context", func() {
 		inst, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test2/a"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst, nil)
 		Expect(err).ToNot(HaveOccurred())
 		lCtx := instOp.Context()
 
@@ -84,7 +84,7 @@ var _ = Describe("Context", func() {
 		inst, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/b"])
 		Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst)
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst, nil)
 		Expect(err).ToNot(HaveOccurred())
 		lCtx := instOp.Context()
 

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -7,6 +7,8 @@ package installations_test
 import (
 	"context"
 
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr/testing"
 	. "github.com/onsi/ginkgo"
@@ -92,6 +94,24 @@ var _ = Describe("Context", func() {
 		Expect(lCtx.Siblings).To(HaveLen(3))
 
 		Expect(lCtx.Parent.Info.Name).To(Equal("root"))
+	})
+
+	It("initialize root installations with default context", func() {
+		ctx := context.Background()
+		defer ctx.Done()
+
+		defaultRepoContext := cdv2.RepositoryContext{
+			Type:    "local",
+			BaseURL: "../testdata/registry",
+		}
+
+		inst, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test4/root-test40"])
+		Expect(err).ToNot(HaveOccurred())
+
+		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst, &defaultRepoContext)
+		Expect(err).ToNot(HaveOccurred())
+		repoContextOfOtherRoot := instOp.Context().Siblings[0].Info.Spec.ComponentDescriptor.Reference.RepositoryContext
+		Expect(repoContextOfOtherRoot).ToNot(BeNil())
 	})
 
 })

--- a/pkg/landscaper/installations/imports/helper.go
+++ b/pkg/landscaper/installations/imports/helper.go
@@ -20,7 +20,7 @@ func CheckCompletedSiblingDependentsOfParent(ctx context.Context, op *installati
 	if parent == nil {
 		return true, nil
 	}
-	parentsOperation, err := installations.NewInstallationOperationFromOperation(ctx, op, parent)
+	parentsOperation, err := installations.NewInstallationOperationFromOperation(ctx, op, parent, op.DefaultRepoContext)
 	if err != nil {
 		return false, fmt.Errorf("unable to create parent operation: %w", err)
 	}

--- a/pkg/landscaper/installations/imports/outdated_test.go
+++ b/pkg/landscaper/installations/imports/outdated_test.go
@@ -65,7 +65,7 @@ var _ = Describe("OutdatedImports", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
-		outdated, err := val.OutdatedImports(ctx, inInstA)
+		outdated, err := val.OutdatedImports(ctx)
 		Expect(err).To(Succeed())
 		Expect(outdated).To(BeTrue())
 	})
@@ -89,7 +89,7 @@ var _ = Describe("OutdatedImports", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
-		outdated, err := val.OutdatedImports(ctx, inInstB)
+		outdated, err := val.OutdatedImports(ctx)
 		Expect(err).To(Succeed())
 		Expect(outdated).To(BeTrue())
 	})
@@ -109,7 +109,7 @@ var _ = Describe("OutdatedImports", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
-		outdated, err := val.OutdatedImports(ctx, inInstB)
+		outdated, err := val.OutdatedImports(ctx)
 		Expect(err).To(Succeed())
 		Expect(outdated).To(BeFalse())
 	})
@@ -131,7 +131,7 @@ var _ = Describe("OutdatedImports", func() {
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			val := imports.NewValidator(op)
-			outdated, err := val.OutdatedImports(ctx, inInstRoot)
+			outdated, err := val.OutdatedImports(ctx)
 			Expect(err).To(Succeed())
 			Expect(outdated).To(BeTrue())
 		})
@@ -149,7 +149,7 @@ var _ = Describe("OutdatedImports", func() {
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			val := imports.NewValidator(op)
-			outdated, err := val.OutdatedImports(ctx, inInstRoot)
+			outdated, err := val.OutdatedImports(ctx)
 			Expect(err).To(Succeed())
 			Expect(outdated).To(BeFalse())
 		})

--- a/pkg/landscaper/installations/imports/validation_test.go
+++ b/pkg/landscaper/installations/imports/validation_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Validation", func() {
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			val := imports.NewValidator(op)
-			ok, err := val.CheckDependentInstallations(ctx, inInstA)
+			ok, err := val.CheckDependentInstallations(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeFalse())
 		})

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -91,7 +91,7 @@ var _ = Describe("SubInstallation", func() {
 
 			inst, err := installations.New(&lsv1alpha1.Installation{}, blue)
 			Expect(err).ToNot(HaveOccurred())
-			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst)
+			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			si := subinstallations.New(instOp)

--- a/pkg/landscaper/installations/testdata/state/test4/00-root.yaml
+++ b/pkg/landscaper/installations/testdata/state/test4/00-root.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root-test40
+  namespace: test4
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      componentName: example.com/root
+      version: 1.0.0
+
+  blueprint:
+    ref:
+      resourceName: root
+

--- a/pkg/landscaper/installations/testdata/state/test4/01-root.yaml
+++ b/pkg/landscaper/installations/testdata/state/test4/01-root.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root-test41
+  namespace: test4
+spec:
+
+  componentDescriptor:
+    ref:
+      componentName: example.com/root
+      version: 1.0.0
+
+  blueprint:
+    ref:
+      resourceName: root
+

--- a/test/utils/resources.go
+++ b/test/utils/resources.go
@@ -88,7 +88,7 @@ func CreateTestInstallationResources(op lsoperation.Interface, cfg TestInstallat
 
 	rootIntInst, err := installations.New(rootInst, rootBlueprint)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	rootInstOp, err := installations.NewInstallationOperationFromOperation(context.TODO(), op, rootIntInst)
+	rootInstOp, err := installations.NewInstallationOperationFromOperation(context.TODO(), op, rootIntInst, nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	return rootInst, rootIntInst, rootBlueprint, rootInstOp


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority 3

**What this PR does / why we need it**:
Fixes problems with root installations with no repository context.

**Which issue(s) this PR fixes**:

Assume Landscaper is configured with a default repository context. If there is a root installation without a repository context deployed, all subsequently deployed root installations will fail. The reason is that for processing new root installations, all already existing root installation are instantiated and this fails for those without a repository context.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
