### PR TITLE
add simple local cluster setup script

### DIFF
--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -13,10 +13,9 @@ Further details could be found in
 
 1. [Principles of Kubernetes](https://kubernetes.io/docs/concepts/), and its [components](https://kubernetes.io/docs/concepts/overview/components/)
 1. [Kubernetes Development Guide](https://github.com/kubernetes/community/tree/master/contributors/devel)
-1. [Architecture of Gardener](https://github.com/gardener/documentation/wiki/Architecture)
 
-This setup is based on [kind](https://github.com/kubernetes-sigs/kind). 
-Docker for Desktop, [minikube](https://github.com/kubernetes/minikube) or [k3d](https://github.com/rancher/k3d) are also supported.
+This setup is based on [k3d](https://github.com/rancher/k3d).
+Docker for Desktop, [minikube](https://github.com/kubernetes/minikube) or [kind](https://github.com/kubernetes-sigs/kind) are also supported.
 
 ## Installing Golang environment
 
@@ -65,11 +64,15 @@ brew install git
 On other OS, please check the [Git installation documentation](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 
-## Installing Kind
+## Installing K3d
 
 You'll need to have [Docker](https://docs.docker.com/get-docker/) installed and running.
 
-Follow the [kind quickstart guide](https://kind.sigs.k8s.io/docs/user/quick-start/) to start a kubernetes cluster .
+Follow the [k3s installation guide](https://k3d.io/#installation) to start a kubernetes cluster.
+
+:warning: note that with the default k8s cluster installation some development resources like target may not work as on some os's docker is running in VM with different network access.
+We therefore recommend to use our local setup script in [hack/setup-local-env.sh](../../hack/setup-local-env.sh) which automatically setups a local environment. 
+In that environment controllers running in- and outside of the cluster can access the apiserver. (Note that this script modifies the `/etc/hosts` file which may require root permissions)
 
 ## [MacOS only] Install GNU core utilities
 

--- a/hack/resources/k3d-cluster-config.yaml
+++ b/hack/resources/k3d-cluster-config.yaml
@@ -1,0 +1,7 @@
+# k3d configuration file, saved as e.g. /home/me/myk3dcluster.yaml
+apiVersion: k3d.io/v1alpha2 # this will change in the future as we make everything more stable
+kind: Simple # internally, we also have a Cluster config, which is not yet available externally
+kubeAPI: # same as `--api-port myhost.my.domain:6445` (where the name would resolve to 127.0.0.1)
+  host: "host.k3d.internal" # important for the `server` setting in the kubeconfig
+  hostIP: "0.0.0.0" # where the Kubernetes API will be listening on
+  hostPort: "6445" # where the Kubernetes API listening port will be mapped to on your host system


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/priority 3

**What this PR does / why we need it**:

Added a script that automatically creates a dev environment with k3d.
That environment has a kubeconfig where controllers running inside or outside the cluster can communicate with the apiserver.
Therefore we no longer need specific targets.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
A script has been added that will automatically create a local development environment with k3s.
```
