### PR TITLE
add git source to deployer components

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -10,8 +10,9 @@ set -o pipefail
 
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
+COMMIT_SHA="$(git --git-dir ${SOURCE_PATH}/.git rev-parse HEAD)"
 
-printf "> Building components with version ${VERSION}\n"
+printf "> Building components with version ${VERSION} - ${COMMIT_SHA}\n"
 
 REPO_CTX="${CURRENT_COMPONENT_REPOSITORY}"
 
@@ -27,7 +28,9 @@ function buildComponentArchive() {
     --component-name=github.com/gardener/landscaper/${COMPONENT_NAME} \
     --component-version=${VERSION} \
     --repo-ctx=${REPO_CTX} \
+    -s ${SOURCE_PATH}/.landscaper/sources.yaml \
     -r ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/resources.yaml \
+    COMMIT_SHA=${COMMIT_SHA} \
     VERSION=${VERSION}
 }
 

--- a/.landscaper/sources.yaml
+++ b/.landscaper/sources.yaml
@@ -1,0 +1,14 @@
+---
+name: github_com_gardener_landscaper
+type: git
+version: ${VERSION}
+labels:
+- name: cloud.gardener/cicd/source
+  value:
+    repository-classification: main
+access:
+  type: github
+  commit: ${COMMIT_SHA}
+  ref: refs/tags/${VERSION}
+  repoUrl: github.com/gardener/landscaper
+---


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind regression
/priority 3

**What this PR does / why we need it**:
add sources to the additional components

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
