### PR TITLE
Not fetching the blueprint of installations if not needed

### DIFF
--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -30,7 +30,7 @@ func (c *Controller) handleDelete(ctx context.Context, inst *lsv1alpha1.Installa
 }
 
 func EnsureDeletion(ctx context.Context, op *installations.Operation) error {
-	op.Inst.Info.Status.Phase = lsv1alpha1.ComponentPhaseDeleting
+	op.Inst.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseDeleting
 	// check if suitable for deletion
 	// todo: replacements and internal deletions
 	if checkIfSiblingImports(op) {
@@ -51,16 +51,16 @@ func EnsureDeletion(ctx context.Context, op *installations.Operation) error {
 		return WaitingForDeletionError
 	}
 
-	controllerutil.RemoveFinalizer(op.Inst.Info, lsv1alpha1.LandscaperFinalizer)
-	return op.Client().Update(ctx, op.Inst.Info)
+	controllerutil.RemoveFinalizer(op.Inst.GetInfo(), lsv1alpha1.LandscaperFinalizer)
+	return op.Client().Update(ctx, op.Inst.GetInfo())
 }
 
 func deleteExecution(ctx context.Context, op *installations.Operation) (bool, error) {
-	if op.Inst.Info.Status.ExecutionReference == nil {
+	if op.Inst.GetInfo().Status.ExecutionReference == nil {
 		return true, nil
 	}
 	exec := &lsv1alpha1.Execution{}
-	if err := op.Client().Get(ctx, op.Inst.Info.Status.ExecutionReference.NamespacedName(), exec); err != nil {
+	if err := op.Client().Get(ctx, op.Inst.GetInfo().Status.ExecutionReference.NamespacedName(), exec); err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -77,7 +77,7 @@ func deleteExecution(ctx context.Context, op *installations.Operation) (bool, er
 
 func deleteSubInstallations(ctx context.Context, op *installations.Operation) (bool, error) {
 	op.CurrentOperation = "DeleteSubInstallation"
-	subInsts, err := subinstallations.New(op).GetSubInstallations(ctx, op.Inst.Info)
+	subInsts, err := subinstallations.New(op).GetSubInstallations(ctx, op.Inst.GetInfo())
 	if err != nil {
 		return false, err
 	}
@@ -98,12 +98,12 @@ func deleteSubInstallations(ctx context.Context, op *installations.Operation) (b
 
 func checkIfSiblingImports(op *installations.Operation) bool {
 	for _, sibling := range op.Context().Siblings {
-		for _, dataImports := range op.Inst.Info.Spec.Exports.Data {
+		for _, dataImports := range op.Inst.GetInfo().Spec.Exports.Data {
 			if sibling.IsImportingData(dataImports.DataRef) {
 				return true
 			}
 		}
-		for _, targetImport := range op.Inst.Info.Spec.Exports.Targets {
+		for _, targetImport := range op.Inst.GetInfo().Spec.Exports.Targets {
 			if sibling.IsImportingData(targetImport.Target) {
 				return true
 			}

--- a/pkg/landscaper/installations/context.go
+++ b/pkg/landscaper/installations/context.go
@@ -26,7 +26,7 @@ type Context struct {
 
 	// Siblings are installations with the same parent.
 	// The installation has access to the exports of theses components
-	Siblings []InstallationBaseInterface
+	Siblings []*InstallationBase
 }
 
 // SetInstallationContext determines the current context and updates the operation context.
@@ -59,7 +59,7 @@ func (o *Operation) DetermineInstallationContext(ctx context.Context) (*Context,
 	}
 
 	// get the parent by owner reference
-	parent, err := GetParent(ctx, o, o.Inst)
+	parent, err := GetParent(ctx, o, o.Inst.InstallationBase)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (o *Operation) DetermineInstallationContext(ctx context.Context) (*Context,
 
 // GetParent returns the parent of a installation.
 // It returns nil if the installation has no parent
-func GetParent(ctx context.Context, op operation.Interface, inst InstallationBaseInterface) (*Installation, error) {
+func GetParent(ctx context.Context, op operation.Interface, inst *InstallationBase) (*Installation, error) {
 	if IsRootInstallation(inst.GetInfo()) {
 		return nil, nil
 	}
@@ -110,7 +110,7 @@ func GetParent(ctx context.Context, op operation.Interface, inst InstallationBas
 
 // GetParentBase returns the parent of an installation base.
 // It returns nil if the installation has no parent
-func GetParentBase(ctx context.Context, op operation.Interface, inst InstallationBaseInterface) (InstallationBaseInterface, error) {
+func GetParentBase(ctx context.Context, op operation.Interface, inst *InstallationBase) (*InstallationBase, error) {
 	if IsRootInstallation(inst.GetInfo()) {
 		return nil, nil
 	}

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Context", func() {
 		Expect(lCtx.Parent).ToNot(BeNil())
 		Expect(lCtx.Siblings).To(HaveLen(3))
 
-		Expect(lCtx.Parent.Info.Name).To(Equal("root"))
+		Expect(lCtx.Parent.GetInfo().Name).To(Equal("root"))
 	})
 
 	It("initialize root installations with default context", func() {
@@ -110,7 +110,7 @@ var _ = Describe("Context", func() {
 
 		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inst, &defaultRepoContext)
 		Expect(err).ToNot(HaveOccurred())
-		repoContextOfOtherRoot := instOp.Context().Siblings[0].Info.Spec.ComponentDescriptor.Reference.RepositoryContext
+		repoContextOfOtherRoot := instOp.Context().Siblings[0].GetInfo().Spec.ComponentDescriptor.Reference.RepositoryContext
 		Expect(repoContextOfOtherRoot).ToNot(BeNil())
 	})
 

--- a/pkg/landscaper/installations/executions/complete.go
+++ b/pkg/landscaper/installations/executions/complete.go
@@ -17,12 +17,12 @@ import (
 )
 
 func (o *ExecutionOperation) CombinedState(ctx context.Context, inst *installations.Installation) (lsv1alpha1.ExecutionPhase, error) {
-	if inst.Info.Status.ExecutionReference == nil {
+	if inst.GetInfo().Status.ExecutionReference == nil {
 		return "", nil
 	}
 
 	exec := &lsv1alpha1.Execution{}
-	if err := o.Client().Get(ctx, inst.Info.Status.ExecutionReference.NamespacedName(), exec); err != nil {
+	if err := o.Client().Get(ctx, inst.GetInfo().Status.ExecutionReference.NamespacedName(), exec); err != nil {
 		return "", err
 	}
 
@@ -34,17 +34,17 @@ func (o *ExecutionOperation) CombinedState(ctx context.Context, inst *installati
 }
 
 func (o *ExecutionOperation) HandleUpdate(ctx context.Context, inst *installations.Installation) error {
-	if inst.Info.Status.ExecutionReference == nil {
+	if inst.GetInfo().Status.ExecutionReference == nil {
 		return nil
 	}
 
 	exec := &lsv1alpha1.Execution{}
-	if err := o.Client().Get(ctx, inst.Info.Status.ExecutionReference.NamespacedName(), exec); err != nil {
+	if err := o.Client().Get(ctx, inst.GetInfo().Status.ExecutionReference.NamespacedName(), exec); err != nil {
 		return err
 	}
 
 	if exec.Status.Phase == lsv1alpha1.ExecutionPhaseFailed {
-		inst.Info.Status.Phase = lsv1alpha1.ComponentPhaseFailed
+		inst.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseFailed
 		return nil
 	}
 
@@ -54,7 +54,7 @@ func (o *ExecutionOperation) HandleUpdate(ctx context.Context, inst *installatio
 // GetExportedValues returns the exported values of the execution
 func (o *ExecutionOperation) GetExportedValues(ctx context.Context, inst *installations.Installation) (*dataobjects.DataObject, error) {
 	exec := &lsv1alpha1.Execution{}
-	if err := o.Client().Get(ctx, kutil.ObjectKey(inst.Info.Name, inst.Info.Namespace), exec); err != nil {
+	if err := o.Client().Get(ctx, kutil.ObjectKey(inst.GetInfo().Name, inst.GetInfo().Namespace), exec); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -63,7 +63,7 @@ func (o *ExecutionOperation) GetExportedValues(ctx context.Context, inst *instal
 
 	doName := lsv1alpha1helper.GenerateDataObjectName(lsv1alpha1helper.DataObjectSourceFromExecution(exec), "")
 	rawDO := &lsv1alpha1.DataObject{}
-	if err := o.Client().Get(ctx, kutil.ObjectKey(doName, o.Inst.Info.Namespace), rawDO); err != nil {
+	if err := o.Client().Get(ctx, kutil.ObjectKey(doName, o.Inst.GetInfo().Namespace), rawDO); err != nil {
 		return nil, err
 	}
 

--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -42,7 +42,7 @@ func NewConstructor(op *installations.Operation) *Constructor {
 // Construct loads the exported data from the execution and the subinstallations.
 func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject, []*dataobjects.Target, error) {
 	var (
-		fldPath         = field.NewPath(fmt.Sprintf("(inst: %s)", c.Inst.Info.Name)).Child("internalExports")
+		fldPath         = field.NewPath(fmt.Sprintf("(inst: %s)", c.Inst.GetInfo().Name)).Child("internalExports")
 		internalExports = map[string]interface{}{
 			"deployitems": struct{}{},
 			"dataobjects": struct{}{},
@@ -71,7 +71,7 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 
 	stateHdlr := template.KubernetesStateHandler{
 		KubeClient: c.Client(),
-		Inst:       c.Inst.Info,
+		Inst:       c.Inst.GetInfo(),
 	}
 	exports, err := template.New(gotemplate.New(c.BlobResolver, stateHdlr), spiff.New(stateHdlr)).
 		TemplateExportExecutions(c.Inst.Blueprint, internalExports)
@@ -104,9 +104,9 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 	}
 
 	// Resolve export mapping for all internalExports
-	dataObjects := make([]*dataobjects.DataObject, len(c.Inst.Info.Spec.Exports.Data))
+	dataObjects := make([]*dataobjects.DataObject, len(c.Inst.GetInfo().Spec.Exports.Data))
 	dataExportsPath := fldPath.Child("exports").Child("data")
-	for i, dataExport := range c.Inst.Info.Spec.Exports.Data {
+	for i, dataExport := range c.Inst.GetInfo().Spec.Exports.Data {
 		dataExportPath := dataExportsPath.Child(dataExport.Name)
 		data, ok := exports[dataExport.Name]
 		if !ok {
@@ -119,9 +119,9 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 		dataObjects[i] = do
 	}
 
-	targets := make([]*dataobjects.Target, len(c.Inst.Info.Spec.Exports.Targets))
+	targets := make([]*dataobjects.Target, len(c.Inst.GetInfo().Spec.Exports.Targets))
 	targetExportsPath := fldPath.Child("exports").Child("targets")
-	for i, targetExport := range c.Inst.Info.Spec.Exports.Targets {
+	for i, targetExport := range c.Inst.GetInfo().Spec.Exports.Targets {
 		targetExportPath := targetExportsPath.Child(targetExport.Name)
 		data, ok := exports[targetExport.Name]
 		if !ok {
@@ -140,9 +140,9 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 }
 
 func (c *Constructor) aggregateDataObjectsInContext(ctx context.Context) (map[string]interface{}, error) {
-	installationContext := lsv1alpha1helper.DataObjectSourceFromInstallation(c.Inst.Info)
+	installationContext := lsv1alpha1helper.DataObjectSourceFromInstallation(c.Inst.GetInfo())
 	dataObjectList := &lsv1alpha1.DataObjectList{}
-	if err := c.Client().List(ctx, dataObjectList, client.InNamespace(c.Inst.Info.Namespace), client.MatchingLabels{lsv1alpha1.DataObjectContextLabel: installationContext}); err != nil {
+	if err := c.Client().List(ctx, dataObjectList, client.InNamespace(c.Inst.GetInfo().Namespace), client.MatchingLabels{lsv1alpha1.DataObjectContextLabel: installationContext}); err != nil {
 		return nil, err
 	}
 
@@ -159,9 +159,9 @@ func (c *Constructor) aggregateDataObjectsInContext(ctx context.Context) (map[st
 }
 
 func (c *Constructor) aggregateTargetsInContext(ctx context.Context) (map[string]interface{}, error) {
-	installationContext := lsv1alpha1helper.DataObjectSourceFromInstallation(c.Inst.Info)
+	installationContext := lsv1alpha1helper.DataObjectSourceFromInstallation(c.Inst.GetInfo())
 	targetList := &lsv1alpha1.TargetList{}
-	if err := c.Client().List(ctx, targetList, client.InNamespace(c.Inst.Info.Namespace), client.MatchingLabels{lsv1alpha1.DataObjectContextLabel: installationContext}); err != nil {
+	if err := c.Client().List(ctx, targetList, client.InNamespace(c.Inst.GetInfo().Namespace), client.MatchingLabels{lsv1alpha1.DataObjectContextLabel: installationContext}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/landscaper/installations/exports/constructor_test.go
+++ b/pkg/landscaper/installations/exports/constructor_test.go
@@ -250,7 +250,7 @@ var _ = Describe("Constructor", func() {
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			target := &lsv1alpha1.Target{}
-			targetName := lsv1alpha1helper.GenerateDataObjectName(lsv1alpha1helper.DataObjectSourceFromInstallation(inInstRoot.Info), "root.z")
+			targetName := lsv1alpha1helper.GenerateDataObjectName(lsv1alpha1helper.DataObjectSourceFromInstallation(inInstRoot.GetInfo()), "root.z")
 			key := kutil.ObjectKey(targetName, "test4")
 			Expect(fakeClient.Get(ctx, key, target)).To(Succeed())
 			target.Spec.Type = "unknownType"

--- a/pkg/landscaper/installations/helper.go
+++ b/pkg/landscaper/installations/helper.go
@@ -60,8 +60,8 @@ func CreateInternalInstallations(ctx context.Context, op lsoperation.Interface, 
 }
 
 // CreateInternalInstallationBases creates internal installation bases for a list of ComponentInstallations
-func CreateInternalInstallationBases(installations ...*lsv1alpha1.Installation) ([]InstallationBaseInterface, error) {
-	internalInstallations := make([]InstallationBaseInterface, len(installations))
+func CreateInternalInstallationBases(installations ...*lsv1alpha1.Installation) ([]*InstallationBase, error) {
+	internalInstallations := make([]*InstallationBase, len(installations))
 	for i, inst := range installations {
 		inInst := CreateInternalInstallationBase(inst)
 		internalInstallations[i] = inInst
@@ -103,12 +103,12 @@ func CreateInternalInstallation(ctx context.Context, op lsoperation.Interface, i
 }
 
 // CreateInternalInstallationBase creates an internal installation base for an Installation
-func CreateInternalInstallationBase(inst *lsv1alpha1.Installation) InstallationBaseInterface {
+func CreateInternalInstallationBase(inst *lsv1alpha1.Installation) *InstallationBase {
 	return NewInstallationBase(inst)
 }
 
 // GetDataImport fetches the data import from the cluster.
-func GetDataImport(ctx context.Context, kubeClient client.Client, contextName string, inst InstallationBaseInterface,
+func GetDataImport(ctx context.Context, kubeClient client.Client, contextName string, inst *InstallationBase,
 	dataImport lsv1alpha1.DataImport) (*dataobjects.DataObject, *v1.OwnerReference, error) {
 	var rawDataObject *lsv1alpha1.DataObject
 	// get deploy item from current context

--- a/pkg/landscaper/installations/helper_test.go
+++ b/pkg/landscaper/installations/helper_test.go
@@ -78,12 +78,12 @@ var _ = g.Describe("helper", func() {
 			Expect(kubeClient.Create(ctx, data)).To(Succeed())
 
 			inst := &Installation{
-				InstallationBaseInterface: &InstallationBase{
+				InstallationBase: &InstallationBase{
 					Info: &lsv1alpha1.Installation{},
 				},
 			}
 			inst.GetInfo().Namespace = data.Namespace
-			do, owner, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
+			do, owner, err := GetDataImport(ctx, kubeClient, "", inst.InstallationBase, lsv1alpha1.DataImport{
 				Name:    "imp",
 				DataRef: "#test-do",
 			})
@@ -97,12 +97,12 @@ var _ = g.Describe("helper", func() {
 			defer ctx.Done()
 
 			inst := &Installation{
-				InstallationBaseInterface: &InstallationBase{
+				InstallationBase: &InstallationBase{
 					Info: &lsv1alpha1.Installation{},
 				},
 			}
 			inst.GetInfo().Namespace = "default"
-			_, _, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
+			_, _, err := GetDataImport(ctx, kubeClient, "", inst.InstallationBase, lsv1alpha1.DataImport{
 				Name:    "imp",
 				DataRef: "#test-do",
 			})
@@ -120,7 +120,7 @@ var _ = g.Describe("helper", func() {
 			}
 			Expect(kubeClient.Create(ctx, cm)).To(Succeed())
 
-			do, owner, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+			do, owner, err := GetDataImport(ctx, kubeClient, "", &InstallationBase{}, lsv1alpha1.DataImport{
 				Name: "imp",
 				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
 					ObjectReference: lsv1alpha1.ObjectReference{
@@ -146,7 +146,7 @@ var _ = g.Describe("helper", func() {
 			}
 			Expect(kubeClient.Create(ctx, cm)).To(Succeed())
 
-			_, _, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+			_, _, err := GetDataImport(ctx, kubeClient, "", &InstallationBase{}, lsv1alpha1.DataImport{
 				Name: "imp",
 				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
 					ObjectReference: lsv1alpha1.ObjectReference{
@@ -170,7 +170,7 @@ var _ = g.Describe("helper", func() {
 			}
 			Expect(kubeClient.Create(ctx, secret)).To(Succeed())
 
-			do, owner, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+			do, owner, err := GetDataImport(ctx, kubeClient, "", &InstallationBase{}, lsv1alpha1.DataImport{
 				Name: "imp",
 				SecretRef: &lsv1alpha1.SecretReference{
 					ObjectReference: lsv1alpha1.ObjectReference{
@@ -196,7 +196,7 @@ var _ = g.Describe("helper", func() {
 			}
 			Expect(kubeClient.Create(ctx, secret)).To(Succeed())
 
-			_, _, err := GetDataImport(ctx, kubeClient, "", &Installation{}, lsv1alpha1.DataImport{
+			_, _, err := GetDataImport(ctx, kubeClient, "", &InstallationBase{}, lsv1alpha1.DataImport{
 				Name: "imp",
 				SecretRef: &lsv1alpha1.SecretReference{
 					ObjectReference: lsv1alpha1.ObjectReference{

--- a/pkg/landscaper/installations/helper_test.go
+++ b/pkg/landscaper/installations/helper_test.go
@@ -78,7 +78,9 @@ var _ = g.Describe("helper", func() {
 			Expect(kubeClient.Create(ctx, data)).To(Succeed())
 
 			inst := &Installation{
-				Info: &lsv1alpha1.Installation{},
+				InstallationBase: InstallationBase{
+					Info: &lsv1alpha1.Installation{},
+				},
 			}
 			inst.Info.Namespace = data.Namespace
 			do, owner, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
@@ -95,7 +97,9 @@ var _ = g.Describe("helper", func() {
 			defer ctx.Done()
 
 			inst := &Installation{
-				Info: &lsv1alpha1.Installation{},
+				InstallationBase: InstallationBase{
+					Info: &lsv1alpha1.Installation{},
+				},
 			}
 			inst.Info.Namespace = "default"
 			_, _, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{

--- a/pkg/landscaper/installations/helper_test.go
+++ b/pkg/landscaper/installations/helper_test.go
@@ -78,11 +78,11 @@ var _ = g.Describe("helper", func() {
 			Expect(kubeClient.Create(ctx, data)).To(Succeed())
 
 			inst := &Installation{
-				InstallationBase: InstallationBase{
+				InstallationBaseInterface: &InstallationBase{
 					Info: &lsv1alpha1.Installation{},
 				},
 			}
-			inst.Info.Namespace = data.Namespace
+			inst.GetInfo().Namespace = data.Namespace
 			do, owner, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
 				Name:    "imp",
 				DataRef: "#test-do",
@@ -97,11 +97,11 @@ var _ = g.Describe("helper", func() {
 			defer ctx.Done()
 
 			inst := &Installation{
-				InstallationBase: InstallationBase{
+				InstallationBaseInterface: &InstallationBase{
 					Info: &lsv1alpha1.Installation{},
 				},
 			}
-			inst.Info.Namespace = "default"
+			inst.GetInfo().Namespace = "default"
 			_, _, err := GetDataImport(ctx, kubeClient, "", inst, lsv1alpha1.DataImport{
 				Name:    "imp",
 				DataRef: "#test-do",

--- a/pkg/landscaper/installations/imports/constructor.go
+++ b/pkg/landscaper/installations/imports/constructor.go
@@ -35,7 +35,7 @@ func NewConstructor(op *installations.Operation) *Constructor {
 // The imported data is added to installation resource.
 func (c *Constructor) Construct(ctx context.Context, inst *installations.Installation) error {
 	var (
-		fldPath = field.NewPath(inst.Info.Name)
+		fldPath = field.NewPath(inst.GetInfo().Name)
 		imports = make(map[string]interface{})
 	)
 
@@ -103,7 +103,7 @@ func (c *Constructor) Construct(ctx context.Context, inst *installations.Install
 		return errors.New("neither a target nor a schema is defined")
 	}
 
-	inst.Imports = imports
+	inst.SetImports(imports)
 	return nil
 }
 
@@ -125,7 +125,7 @@ func (c *Constructor) templateDataMappings(fldPath *field.Path, importedDataObje
 	}
 
 	values := make(map[string]interface{})
-	for key, dataMapping := range c.Inst.Info.Spec.ImportDataMappings {
+	for key, dataMapping := range c.Inst.GetInfo().Spec.ImportDataMappings {
 		impPath := fldPath.Child(key)
 
 		tmpl, err := spiffyaml.Unmarshal(key, dataMapping.RawMessage)

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -68,8 +68,8 @@ var _ = Describe("Constructor", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 		c := imports.NewConstructor(op)
 		Expect(c.Construct(ctx, inInstB)).To(Succeed())
-		Expect(inInstB.Imports).ToNot(BeNil())
-		Expect(inInstB.Imports).To(Equal(expectedConfig))
+		Expect(inInstB.GetImports()).ToNot(BeNil())
+		Expect(inInstB.GetImports()).To(Equal(expectedConfig))
 	})
 
 	It("should construct the imported config from a sibling and the indirect parent import", func() {
@@ -88,9 +88,9 @@ var _ = Describe("Constructor", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 		c := imports.NewConstructor(op)
 		Expect(c.Construct(ctx, inInstC)).To(Succeed())
-		Expect(inInstC.Imports).ToNot(BeNil())
+		Expect(inInstC.GetImports()).ToNot(BeNil())
 
-		Expect(inInstC.Imports).To(Equal(expectedConfig))
+		Expect(inInstC.GetImports()).To(Equal(expectedConfig))
 	})
 
 	It("should construct the imported config from a manual created data object", func() {
@@ -108,9 +108,9 @@ var _ = Describe("Constructor", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 		c := imports.NewConstructor(op)
 		Expect(c.Construct(ctx, inInstRoot)).To(Succeed())
-		Expect(inInstRoot.Imports).ToNot(BeNil())
+		Expect(inInstRoot.GetImports()).ToNot(BeNil())
 
-		Expect(inInstRoot.Imports).To(Equal(expectedConfig))
+		Expect(inInstRoot.GetImports()).To(Equal(expectedConfig))
 	})
 
 	It("should construct the imported config from a secret", func() {
@@ -128,8 +128,8 @@ var _ = Describe("Constructor", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 		c := imports.NewConstructor(op)
 		Expect(c.Construct(ctx, inInstRoot)).To(Succeed())
-		Expect(inInstRoot.Imports).ToNot(BeNil())
-		Expect(inInstRoot.Imports).To(Equal(expectedConfig))
+		Expect(inInstRoot.GetImports()).ToNot(BeNil())
+		Expect(inInstRoot.GetImports()).To(Equal(expectedConfig))
 	})
 
 	It("should construct the imported config from a configmap", func() {
@@ -147,8 +147,8 @@ var _ = Describe("Constructor", func() {
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 		c := imports.NewConstructor(op)
 		Expect(c.Construct(ctx, inInstRoot)).To(Succeed())
-		Expect(inInstRoot.Imports).ToNot(BeNil())
-		Expect(inInstRoot.Imports).To(Equal(expectedConfig))
+		Expect(inInstRoot.GetImports()).ToNot(BeNil())
+		Expect(inInstRoot.GetImports()).To(Equal(expectedConfig))
 	})
 
 	Context("schema validation", func() {
@@ -167,8 +167,8 @@ var _ = Describe("Constructor", func() {
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			do := &lsv1alpha1.DataObject{}
-			do.Name = lsv1alpha1helper.GenerateDataObjectName(lsv1alpha1helper.DataObjectSourceFromInstallation(inInstRoot.Info), "root.a")
-			do.Namespace = inInstRoot.Info.Namespace
+			do.Name = lsv1alpha1helper.GenerateDataObjectName(lsv1alpha1helper.DataObjectSourceFromInstallation(inInstRoot.GetInfo()), "root.a")
+			do.Namespace = inInstRoot.GetInfo().Namespace
 			Expect(fakeClient.Get(ctx, kutil.ObjectKey(do.Name, do.Namespace), do)).To(Succeed())
 			do.Data.RawMessage = []byte("7")
 			Expect(fakeClient.Update(ctx, do)).To(Succeed())
@@ -191,9 +191,9 @@ var _ = Describe("Constructor", func() {
 
 			c := imports.NewConstructor(op)
 			Expect(c.Construct(ctx, inInstRoot)).To(Succeed())
-			Expect(inInstRoot.Imports).ToNot(BeNil())
+			Expect(inInstRoot.GetImports()).ToNot(BeNil())
 
-			Expect(inInstRoot.Imports).To(HaveKeyWithValue("root.a", MatchKeys(IgnoreExtras, Keys{
+			Expect(inInstRoot.GetImports()).To(HaveKeyWithValue("root.a", MatchKeys(IgnoreExtras, Keys{
 				"spec": MatchKeys(IgnoreExtras, Keys{
 					"type":   Equal("landscaper.gardener.cloud/mock"),
 					"config": Equal("val-e"),
@@ -212,9 +212,9 @@ var _ = Describe("Constructor", func() {
 
 			c := imports.NewConstructor(op)
 			Expect(c.Construct(ctx, inInstF)).To(Succeed())
-			Expect(inInstF.Imports).ToNot(BeNil())
+			Expect(inInstF.GetImports()).ToNot(BeNil())
 
-			Expect(inInstF.Imports).To(HaveKeyWithValue("f.a", MatchKeys(IgnoreExtras, Keys{
+			Expect(inInstF.GetImports()).To(HaveKeyWithValue("f.a", MatchKeys(IgnoreExtras, Keys{
 				"spec": MatchKeys(IgnoreExtras, Keys{
 					"type":   Equal("landscaper.gardener.cloud/mock"),
 					"config": Equal("val-e"),

--- a/pkg/landscaper/installations/imports/helper.go
+++ b/pkg/landscaper/installations/imports/helper.go
@@ -24,7 +24,7 @@ func CheckCompletedSiblingDependentsOfParent(ctx context.Context, op *installati
 	if err != nil {
 		return false, fmt.Errorf("unable to create parent operation: %w", err)
 	}
-	siblingsCompleted, err := CheckCompletedSiblingDependents(ctx, parentsOperation, parent)
+	siblingsCompleted, err := CheckCompletedSiblingDependents(ctx, parentsOperation, parent.InstallationBase)
 	if err != nil {
 		return false, err
 	}
@@ -33,7 +33,7 @@ func CheckCompletedSiblingDependentsOfParent(ctx context.Context, op *installati
 	}
 
 	// check its own parent
-	parentsParent, err := installations.GetParent(ctx, op, parent)
+	parentsParent, err := installations.GetParent(ctx, op, parent.InstallationBase)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to get parent of parent")
 	}
@@ -46,7 +46,7 @@ func CheckCompletedSiblingDependentsOfParent(ctx context.Context, op *installati
 
 // CheckCompletedSiblingDependents checks if siblings that the installation depends on (imports data) are completed
 func CheckCompletedSiblingDependents(ctx context.Context, op *installations.Operation,
-	inst installations.InstallationBaseInterface) (bool, error) {
+	inst *installations.InstallationBase) (bool, error) {
 	if inst == nil {
 		return true, nil
 	}
@@ -99,7 +99,7 @@ func CheckCompletedSiblingDependents(ctx context.Context, op *installations.Oper
 }
 
 // getImportSource returns a reference to the owner of a data import.
-func getImportSource(ctx context.Context, op *installations.Operation, inst installations.InstallationBaseInterface,
+func getImportSource(ctx context.Context, op *installations.Operation, inst *installations.InstallationBase,
 	dataImport lsv1alpha1.DataImport) (*lsv1alpha1.ObjectReference, error) {
 	status, err := inst.ImportStatus().GetData(dataImport.Name)
 	if err == nil && status.SourceRef != nil {

--- a/pkg/landscaper/installations/imports/types.go
+++ b/pkg/landscaper/installations/imports/types.go
@@ -14,7 +14,7 @@ type Validator struct {
 	*installations.Operation
 
 	parent   *installations.Installation
-	siblings []*installations.Installation
+	siblings []installations.InstallationBaseInterface
 }
 
 // Constructor is a struct that contains all values
@@ -25,5 +25,5 @@ type Constructor struct {
 	validator *Validator
 
 	parent   *installations.Installation
-	siblings []*installations.Installation
+	siblings []installations.InstallationBaseInterface
 }

--- a/pkg/landscaper/installations/imports/types.go
+++ b/pkg/landscaper/installations/imports/types.go
@@ -14,7 +14,7 @@ type Validator struct {
 	*installations.Operation
 
 	parent   *installations.Installation
-	siblings []installations.InstallationBaseInterface
+	siblings []*installations.InstallationBase
 }
 
 // Constructor is a struct that contains all values
@@ -25,5 +25,5 @@ type Constructor struct {
 	validator *Validator
 
 	parent   *installations.Installation
-	siblings []installations.InstallationBaseInterface
+	siblings []*installations.InstallationBase
 }

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -130,7 +130,7 @@ func (v *Validator) ImportsSatisfied(ctx context.Context, inst *installations.In
 
 func (v *Validator) checkDataImportIsOutdated(ctx context.Context, fldPath *field.Path, inst *installations.Installation, dataImport lsv1alpha1.DataImport) (bool, error) {
 	// get deploy item from current context
-	do, owner, err := installations.GetDataImport(ctx, v.Client(), v.Context().Name, inst, dataImport)
+	do, owner, err := installations.GetDataImport(ctx, v.Client(), v.Context().Name, inst.InstallationBase, dataImport)
 	if err != nil {
 		return false, fmt.Errorf("%s: unable to get data object for '%s': %w", fldPath.String(), dataImport.Name, err)
 	}
@@ -192,7 +192,7 @@ func (v *Validator) checkTargetImportIsOutdated(ctx context.Context, fldPath *fi
 
 func (v *Validator) checkDataImportIsSatisfied(ctx context.Context, fldPath *field.Path, inst *installations.Installation, dataImport lsv1alpha1.DataImport) error {
 	// get deploy item from current context
-	_, owner, err := installations.GetDataImport(ctx, v.Client(), v.Context().Name, inst, dataImport)
+	_, owner, err := installations.GetDataImport(ctx, v.Client(), v.Context().Name, inst.InstallationBase, dataImport)
 	if err != nil {
 		return fmt.Errorf("%s: unable to get data object for '%s': %w", fldPath.String(), dataImport.Name, err)
 	}
@@ -281,7 +281,7 @@ func (v *Validator) checkStateForSiblingDataExport(ctx context.Context, fldPath 
 	return nil
 }
 
-func (v *Validator) getSiblingForObjectReference(ref lsv1alpha1.ObjectReference) installations.InstallationBaseInterface {
+func (v *Validator) getSiblingForObjectReference(ref lsv1alpha1.ObjectReference) *installations.InstallationBase {
 	for _, sibling := range v.siblings {
 		if lsv1alpha1helper.ReferenceIsObject(ref, sibling.GetInfo()) {
 			return sibling

--- a/pkg/landscaper/installations/imports/validation_test.go
+++ b/pkg/landscaper/installations/imports/validation_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Validation", func() {
 		Expect(op.ResolveComponentDescriptors(ctx)).To(Succeed())
 
 		op.Context().Parent = inInstRoot
-		op.Context().Siblings = []installations.InstallationBaseInterface{inInstA}
+		op.Context().Siblings = []*installations.InstallationBase{inInstA.InstallationBase}
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
@@ -128,7 +128,7 @@ var _ = Describe("Validation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op.Context().Parent = inInstRoot
-		op.Context().Siblings = []installations.InstallationBaseInterface{inInstA}
+		op.Context().Siblings = []*installations.InstallationBase{inInstA.InstallationBase}
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
@@ -159,7 +159,11 @@ var _ = Describe("Validation", func() {
 		inInstRoot, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/root"])
 		Expect(err).ToNot(HaveOccurred())
 		op.Context().Parent = inInstRoot
-		op.Context().Siblings = []installations.InstallationBaseInterface{inInstA, inInstB, inInstC}
+		op.Context().Siblings = []*installations.InstallationBase{
+			inInstA.InstallationBase,
+			inInstB.InstallationBase,
+			inInstC.InstallationBase,
+		}
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
@@ -181,7 +185,7 @@ var _ = Describe("Validation", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			op.Context().Parent = inInstRoot
-			op.Context().Siblings = []installations.InstallationBaseInterface{inInstA}
+			op.Context().Siblings = []*installations.InstallationBase{inInstA.InstallationBase}
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			val := imports.NewValidator(op)

--- a/pkg/landscaper/installations/imports/validation_test.go
+++ b/pkg/landscaper/installations/imports/validation_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Validation", func() {
 
 		inInstA, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/a"])
 		Expect(err).ToNot(HaveOccurred())
-		inInstA.Info.Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
+		inInstA.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
 
 		inInstB, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/b"])
 		Expect(err).ToNot(HaveOccurred())
@@ -85,7 +85,7 @@ var _ = Describe("Validation", func() {
 		Expect(op.ResolveComponentDescriptors(ctx)).To(Succeed())
 
 		op.Context().Parent = inInstRoot
-		op.Context().Siblings = []*installations.Installation{inInstA}
+		op.Context().Siblings = []installations.InstallationBaseInterface{inInstA}
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
@@ -102,8 +102,8 @@ var _ = Describe("Validation", func() {
 
 		inInstRoot, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/root"])
 		Expect(err).ToNot(HaveOccurred())
-		inInstRoot.Info.Status.Phase = lsv1alpha1.ComponentPhaseInit
-		Expect(fakeClient.Status().Update(ctx, inInstRoot.Info))
+		inInstRoot.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseInit
+		Expect(fakeClient.Status().Update(ctx, inInstRoot.GetInfo()))
 
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
@@ -128,7 +128,7 @@ var _ = Describe("Validation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op.Context().Parent = inInstRoot
-		op.Context().Siblings = []*installations.Installation{inInstA}
+		op.Context().Siblings = []installations.InstallationBaseInterface{inInstA}
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
@@ -141,16 +141,16 @@ var _ = Describe("Validation", func() {
 		defer ctx.Done()
 		inInstA, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/a"])
 		Expect(err).ToNot(HaveOccurred())
-		inInstA.Info.Status.Phase = lsv1alpha1.ComponentPhaseProgressing
-		Expect(fakeClient.Update(ctx, inInstA.Info)).To(Succeed())
+		inInstA.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseProgressing
+		Expect(fakeClient.Update(ctx, inInstA.GetInfo())).To(Succeed())
 
 		inInstB, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/b"])
 		Expect(err).ToNot(HaveOccurred())
-		inInstB.Info.Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
+		inInstB.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
 
 		inInstC, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/c"])
 		Expect(err).ToNot(HaveOccurred())
-		inInstC.Info.Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
+		inInstC.GetInfo().Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
 
 		inInstD, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/d"])
 		Expect(err).ToNot(HaveOccurred())
@@ -159,7 +159,7 @@ var _ = Describe("Validation", func() {
 		inInstRoot, err := installations.CreateInternalInstallation(ctx, op, fakeInstallations["test1/root"])
 		Expect(err).ToNot(HaveOccurred())
 		op.Context().Parent = inInstRoot
-		op.Context().Siblings = []*installations.Installation{inInstA, inInstB, inInstC}
+		op.Context().Siblings = []installations.InstallationBaseInterface{inInstA, inInstB, inInstC}
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 		val := imports.NewValidator(op)
@@ -181,7 +181,7 @@ var _ = Describe("Validation", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			op.Context().Parent = inInstRoot
-			op.Context().Siblings = []*installations.Installation{inInstA}
+			op.Context().Siblings = []installations.InstallationBaseInterface{inInstA}
 			Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
 			val := imports.NewValidator(op)

--- a/pkg/landscaper/installations/installation.go
+++ b/pkg/landscaper/installations/installation.go
@@ -13,17 +13,6 @@ import (
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 )
 
-type InstallationBaseInterface interface {
-	ImportStatus() *ImportStatus
-	IsExportingData(name string) bool
-	IsExportingTarget(name string) bool
-	IsImportingData(name string) bool
-	MergeConditions(conditions ...lsv1alpha1.Condition)
-	GetInfo() *lsv1alpha1.Installation
-	GetImports() map[string]interface{}
-	SetImports(map[string]interface{})
-}
-
 // Installation is the internal representation of an installation without resolved blueprint.
 type InstallationBase struct {
 	Imports map[string]interface{}
@@ -33,7 +22,7 @@ type InstallationBase struct {
 }
 
 // New creates a new internal representation of an installation without blueprint
-func NewInstallationBase(inst *lsv1alpha1.Installation) InstallationBaseInterface {
+func NewInstallationBase(inst *lsv1alpha1.Installation) *InstallationBase {
 	internalInst := &InstallationBase{
 		Info: inst,
 		importsStatus: ImportStatus{
@@ -113,15 +102,15 @@ func (i *InstallationBase) MergeConditions(conditions ...lsv1alpha1.Condition) {
 
 // Installation is the internal representation of a installation
 type Installation struct {
-	InstallationBaseInterface
+	*InstallationBase
 	Blueprint *blueprints.Blueprint
 }
 
 // New creates a new internal representation of an installation with blueprint
 func New(inst *lsv1alpha1.Installation, blueprint *blueprints.Blueprint) (*Installation, error) {
 	internalInst := &Installation{
-		InstallationBaseInterface: NewInstallationBase(inst),
-		Blueprint:                 blueprint,
+		InstallationBase: NewInstallationBase(inst),
+		Blueprint:        blueprint,
 	}
 
 	return internalInst, nil

--- a/pkg/landscaper/installations/installation.go
+++ b/pkg/landscaper/installations/installation.go
@@ -7,27 +7,24 @@ package installations
 import (
 	"fmt"
 
-	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 )
 
-// Installation is the internal representation of a installation
-type Installation struct {
-	Imports   map[string]interface{}
-	Info      *lsv1alpha1.Installation
-	Blueprint *blueprints.Blueprint
+type InstallationBase struct {
+	Imports map[string]interface{}
+	Info    *lsv1alpha1.Installation
 
 	// indexes the import state with from/to as key
 	importsStatus ImportStatus
 }
 
-// New creates a new internal representation of an installation
-func New(inst *lsv1alpha1.Installation, blueprint *blueprints.Blueprint) (*Installation, error) {
-	internalInst := &Installation{
-		Info:      inst,
-		Blueprint: blueprint,
-
+// New creates a new internal representation of an installation without blueprint
+func NewInstallationBase(inst *lsv1alpha1.Installation) *InstallationBase {
+	internalInst := &InstallationBase{
+		Info: inst,
 		importsStatus: ImportStatus{
 			Data:   make(map[string]*lsv1alpha1.ImportStatus, len(inst.Status.Imports)),
 			Target: make(map[string]*lsv1alpha1.ImportStatus, len(inst.Status.Imports)),
@@ -38,12 +35,73 @@ func New(inst *lsv1alpha1.Installation, blueprint *blueprints.Blueprint) (*Insta
 		internalInst.importsStatus.set(importStatus)
 	}
 
-	return internalInst, nil
+	return internalInst
 }
 
 // ImportStatus returns the internal representation of the internal import state
-func (i *Installation) ImportStatus() *ImportStatus {
+func (i *InstallationBase) ImportStatus() *ImportStatus {
 	return &i.importsStatus
+}
+
+// IsExportingData checks if the current component exports a data object with the given name.
+func (i *InstallationBase) IsExportingData(name string) bool {
+	for _, def := range i.Info.Spec.Exports.Data {
+		if def.DataRef == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsExportingTarget checks if the current component exports a target with the given name.
+func (i *InstallationBase) IsExportingTarget(name string) bool {
+	for _, def := range i.Info.Spec.Exports.Targets {
+		if def.Target == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsImportingData checks if the current component imports a data object with the given name.
+func (i *InstallationBase) IsImportingData(name string) bool {
+	for _, def := range i.Info.Spec.Imports.Data {
+		if def.DataRef == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsImportingTarget checks if the current component imports a target with the given name.
+func (i *InstallationBase) IsImportingTarget(name string) bool {
+	for _, def := range i.Info.Spec.Imports.Targets {
+		if def.Target == name {
+			return true
+		}
+	}
+	return false
+}
+
+// MergeConditions updates or adds the given condition to the installation's condition.
+func (i *InstallationBase) MergeConditions(conditions ...lsv1alpha1.Condition) {
+	i.Info.Status.Conditions = lsv1alpha1helper.MergeConditions(i.Info.Status.Conditions, conditions...)
+}
+
+// Installation is the internal representation of a installation
+type Installation struct {
+	InstallationBase
+	Blueprint *blueprints.Blueprint
+}
+
+// New creates a new internal representation of an installation with blueprint
+func New(inst *lsv1alpha1.Installation, blueprint *blueprints.Blueprint) (*Installation, error) {
+	internalInst := &Installation{
+		InstallationBase: *NewInstallationBase(inst),
+		Blueprint:        blueprint,
+	}
+
+	return internalInst, nil
 }
 
 // GetImportDefinition return the import for a given key
@@ -64,49 +122,4 @@ func (i *Installation) GetExportDefinition(key string) (lsv1alpha1.ExportDefinit
 		}
 	}
 	return lsv1alpha1.ExportDefinition{}, fmt.Errorf("export with key %s not found", key)
-}
-
-// IsExportingData checks if the current component exports a data object with the given name.
-func (i *Installation) IsExportingData(name string) bool {
-	for _, def := range i.Info.Spec.Exports.Data {
-		if def.DataRef == name {
-			return true
-		}
-	}
-	return false
-}
-
-// IsExportingTarget checks if the current component exports a target with the given name.
-func (i *Installation) IsExportingTarget(name string) bool {
-	for _, def := range i.Info.Spec.Exports.Targets {
-		if def.Target == name {
-			return true
-		}
-	}
-	return false
-}
-
-// IsImportingData checks if the current component imports a data object with the given name.
-func (i *Installation) IsImportingData(name string) bool {
-	for _, def := range i.Info.Spec.Imports.Data {
-		if def.DataRef == name {
-			return true
-		}
-	}
-	return false
-}
-
-// IsImportingTarget checks if the current component imports a target with the given name.
-func (i *Installation) IsImportingTarget(name string) bool {
-	for _, def := range i.Info.Spec.Imports.Targets {
-		if def.Target == name {
-			return true
-		}
-	}
-	return false
-}
-
-// MergeConditions updates or adds the given condition to the installation's condition.
-func (i *Installation) MergeConditions(conditions ...lsv1alpha1.Condition) {
-	i.Info.Status.Conditions = lsv1alpha1helper.MergeConditions(i.Info.Status.Conditions, conditions...)
 }

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -163,7 +163,7 @@ func (o *Operation) GetImportedDataObjects(ctx context.Context) (map[string]*dat
 	dataObjects := map[string]*dataobjects.DataObject{}
 	for _, def := range o.Inst.GetInfo().Spec.Imports.Data {
 
-		do, _, err := GetDataImport(ctx, o.Client(), o.Context().Name, o.Inst, def)
+		do, _, err := GetDataImport(ctx, o.Client(), o.Context().Name, o.Inst.InstallationBase, def)
 		if err != nil {
 			return nil, err
 		}
@@ -578,7 +578,7 @@ func (o *Operation) GetExportForKey(ctx context.Context, key string) (*dataobjec
 	return dataobjects.NewFromDataObject(rawDO)
 }
 
-func importsAnyExport(exporter *Installation, importer InstallationBaseInterface) bool {
+func importsAnyExport(exporter *Installation, importer *InstallationBase) bool {
 	for _, export := range exporter.GetInfo().Spec.Exports.Data {
 		for _, def := range importer.GetInfo().Spec.Imports.Data {
 			if def.DataRef == export.DataRef {

--- a/pkg/landscaper/installations/subinstallations/helper.go
+++ b/pkg/landscaper/installations/subinstallations/helper.go
@@ -132,7 +132,7 @@ func (o *Operation) ValidateSubinstallations(installationTmpl []*lsv1alpha1.Inst
 
 // CombinedState returns the combined state of all subinstallations
 func (o *Operation) CombinedState(ctx context.Context, inst *installations.Installation) (lsv1alpha1.ComponentInstallationPhase, error) {
-	subinsts, err := o.GetSubInstallations(ctx, inst.Info)
+	subinsts, err := o.GetSubInstallations(ctx, inst.GetInfo())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority 3

**What this PR does / why we need it**:

A root installation fails if the resolution of the blueprint of a sibling installation fails. Therefore we reduced the cases in which the blueprint is resolved to those where it is really needed. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

We tested the fix against the failing landscaper installation for the dev landscape and the problems were resolved.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- root installation do not fail anymore if a sibling root installation fails to resolve its blueprint
```
