### PR TITLE
update base image to use latest alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,9 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 #### BASE ####
-FROM eu.gcr.io/gardenlinux/gardenlinux:184.0 AS base
+FROM alpine:3.13.5 AS base
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confnew" install ca-certificates \
-    && rm -rf /var/lib/apt /var/cache/apt
+RUN apk add --no-cache ca-certificates
 
 #### Landscaper Controller ####
 FROM base as landscaper-controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/priority 3

**What this PR does / why we need it**:

This PR switches the base image for all controllers to use the latest alpine linux.
This is to address outdated packages and vulnerabilities found in the gardenlinux image.
In addition, it does not contain berkley db which is in gardenlinux.

**Which issue(s) this PR fixes**:
Fixes #195 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The base image has been switched to the latest alpine linux
```
