### PR TITLE
Fix target annotation and label propagation

### DIFF
--- a/pkg/landscaper/installations/executions/template/template.go
+++ b/pkg/landscaper/installations/executions/template/template.go
@@ -135,14 +135,14 @@ func (o *Templater) TemplateSubinstallationExecutions(opts DeployExecutionOption
 
 	// add blueprint and component descriptor ref information to the input values
 	if opts.Installation != nil {
-		blueprintDef, err := serializeObject(opts.Installation.Spec.Blueprint)
+		blueprintDef, err := utils.JSONSerializeToGenericObject(opts.Installation.Spec.Blueprint)
 		if err != nil {
 			return nil, fmt.Errorf("unable to serialize the blueprint definition")
 		}
 		values["blueprint"] = blueprintDef
 
 		if opts.Installation.Spec.ComponentDescriptor != nil {
-			cdDef, err := serializeObject(opts.Installation.Spec.ComponentDescriptor)
+			cdDef, err := utils.JSONSerializeToGenericObject(opts.Installation.Spec.ComponentDescriptor)
 			if err != nil {
 				return nil, fmt.Errorf("unable to serialize the component descriptor definition")
 			}
@@ -191,14 +191,14 @@ func (o *Templater) TemplateDeployExecutions(opts DeployExecutionOptions) ([]lsv
 
 	// add blueprint and component descriptor ref information to the input values
 	if opts.Installation != nil {
-		blueprintDef, err := serializeObject(opts.Installation.Spec.Blueprint)
+		blueprintDef, err := utils.JSONSerializeToGenericObject(opts.Installation.Spec.Blueprint)
 		if err != nil {
 			return nil, fmt.Errorf("unable to serialize the blueprint definition")
 		}
 		values["blueprint"] = blueprintDef
 
 		if opts.Installation.Spec.ComponentDescriptor != nil {
-			cdDef, err := serializeObject(opts.Installation.Spec.ComponentDescriptor)
+			cdDef, err := utils.JSONSerializeToGenericObject(opts.Installation.Spec.ComponentDescriptor)
 			if err != nil {
 				return nil, fmt.Errorf("unable to serialize the component descriptor definition")
 			}
@@ -278,18 +278,6 @@ func serializeComponentDescriptorList(cd *cdv2.ComponentDescriptorList) (interfa
 		return nil, nil
 	}
 	data, err := codec.Encode(cd)
-	if err != nil {
-		return nil, err
-	}
-	var val interface{}
-	if err := json.Unmarshal(data, &val); err != nil {
-		return nil, err
-	}
-	return val, nil
-}
-
-func serializeObject(in interface{}) (interface{}, error) {
-	data, err := json.Marshal(in)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -524,7 +523,7 @@ func (o *Operation) createOrUpdateTargetImport(ctx context.Context, src string, 
 		return err
 	}
 	target := &lsv1alpha1.Target{}
-	if _, _, err := serializer.NewCodecFactory(api.LandscaperScheme).UniversalDecoder().Decode(data, nil, target); err != nil {
+	if _, _, err := api.Decoder.Decode(data, nil, target); err != nil {
 		return err
 	}
 	intTarget, err := dataobjects.NewFromTarget(target)

--- a/pkg/landscaper/installations/operation_test.go
+++ b/pkg/landscaper/installations/operation_test.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package installations_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/api"
+	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
+	"github.com/gardener/landscaper/pkg/landscaper/installations"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/utils"
+	testutils "github.com/gardener/landscaper/test/utils"
+)
+
+var _ = Describe("Operation", func() {
+
+	var (
+		kubeClient client.Client
+		op         *installations.Operation
+	)
+
+	BeforeEach(func() {
+		kubeClient = fake.NewClientBuilder().WithScheme(api.LandscaperScheme).Build()
+		commonOp := operation.NewOperation(logr.Discard(), kubeClient, api.LandscaperScheme, nil)
+		op = &installations.Operation{
+			Inst: &installations.Installation{
+				InstallationBase: installations.InstallationBase{Info: &lsv1alpha1.Installation{}},
+				Blueprint:        &blueprints.Blueprint{Info: &lsv1alpha1.Blueprint{}},
+			},
+			Interface: commonOp,
+		}
+	})
+
+	Context("CreateOrUpdateExports", func() {
+
+		It("should sync a target", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			target := &lsv1alpha1.Target{}
+			target.Annotations = map[string]string{
+				"ann": "val1",
+			}
+			target.Labels = map[string]string{
+				"lab": "val2",
+			}
+			target.Spec.Type = "test-type"
+			target.Spec.Configuration = lsv1alpha1.NewAnyJSON([]byte("true"))
+			targetObj, err := utils.JSONSerializeToGenericObject(target)
+			testutils.ExpectNoError(err)
+
+			op.Inst.Info.Name = "test"
+			op.Inst.Info.Namespace = "default"
+			op.Inst.Blueprint.Info.Imports = []lsv1alpha1.ImportDefinition{
+				{
+					FieldValueDefinition: lsv1alpha1.FieldValueDefinition{
+						Name:       "my-import",
+						TargetType: "test-type",
+					},
+				},
+			}
+			op.Inst.Imports = map[string]interface{}{
+				"my-import": targetObj,
+			}
+
+			testutils.ExpectNoError(op.CreateOrUpdateImports(ctx))
+
+			targetList := &lsv1alpha1.TargetList{}
+			testutils.ExpectNoError(kubeClient.List(ctx, targetList))
+			Expect(targetList.Items).To(HaveLen(1))
+			Expect(targetList.Items[0].Annotations).To(HaveKeyWithValue("ann", "val1"))
+			Expect(targetList.Items[0].Labels).To(HaveKeyWithValue("lab", "val2"))
+			Expect(targetList.Items[0].Spec.Type).To(Equal(lsv1alpha1.TargetType("test-type")))
+			Expect(targetList.Items[0].Spec.Configuration.RawMessage).To(Equal(json.RawMessage("true")))
+		})
+
+	})
+
+})

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -46,6 +47,19 @@ func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
 	}
 
 	return values
+}
+
+// JSONSerializeToGenericObject converts a typed struct to an generic interface using json serialization.
+func JSONSerializeToGenericObject(in interface{}) (interface{}, error) {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	var val interface{}
+	if err := json.Unmarshal(data, &val); err != nil {
+		return nil, err
+	}
+	return val, nil
 }
 
 // StringIsOneOf checks whether in is one of s.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area landscaper
/kind bug
/priority 3

**What this PR does / why we need it**:
Fixes a bug where the targets annotations and labels are not correctly synced.

Also added a unit tests for the complete target sync.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/199

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Annotations and labels defined on targets are now correctly synced to an installations context.
```
