### PR TITLE
Fix force-reconcile deadlock in execution controller

### DIFF
--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -106,14 +106,6 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 
 	o.exec.Status.ObservedGeneration = o.exec.Generation
 
-	if !lsv1alpha1helper.IsCompletedExecutionPhase(phase) {
-		return nil
-	}
-
-	if err := o.collectAndUpdateExports(ctx, executionItems); err != nil {
-		return lsv1alpha1helper.NewWrappedError(err, op, "CollectAndUpdateExports", err.Error())
-	}
-
 	// remove force annotation
 	if o.forceReconcile {
 		old := o.exec.DeepCopy()
@@ -121,6 +113,14 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 		if err := o.Client().Patch(ctx, o.exec, client.MergeFrom(old)); err != nil {
 			return lsv1alpha1helper.NewWrappedError(err, op, "RemoveForceReconcileAnnotation", err.Error())
 		}
+	}
+
+	if !lsv1alpha1helper.IsCompletedExecutionPhase(phase) {
+		return nil
+	}
+
+	if err := o.collectAndUpdateExports(ctx, executionItems); err != nil {
+		return lsv1alpha1helper.NewWrappedError(err, op, "CollectAndUpdateExports", err.Error())
 	}
 
 	o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR fixes a bug were the execution controller and the deploy items controller compete on the `reconcile` annotation.
The execution constantly sets the reconcile annotation on the deploy item if the execution has the `force-reconcile` annotation. This reconcile only stops when all deployitems items are successfully reconciled.

The deployer now constantly tries to remove the reconcile annotation which ends in reconcile errors so that the deploy item can never be set to `Succeeded`.

```
Operation cannot be fulfilled on deployitems.landscaper.gardener.cloud \"my-deployitem\": the object has been modified; please apply your changes to the latest version and try again
```

This PR fixes that deadlock by removing the force annotation as soon as all deployitems are successfully updated.
Similar can still happen if the deployitems can never be updated. There should be a follow up tracked in this issue https://github.com/gardener/landscaper/issues/204 .


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that caused the a deadlink the `force-reconcile` logic of the execution controller and the deployers.
```
