### PR TITLE
add init and wait container handling in container deployer helm chart

### DIFF
--- a/.landscaper/container-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/container-deployer/blueprint/blueprint.yaml
@@ -52,6 +52,18 @@ deployExecutions:
     {{ $newvals := dict "image" $imgref }}
     {{ $deployerVal := dict }}
 
+    {{ $initResource := getResource .cd "name" "container-init-image" }}
+    {{ $initImgRepo := ociRefRepo $initResource.access.imageReference }}
+    {{ $initImgTag := ociRefVersion $initResource.access.imageReference }}
+    {{ $initImgRef := dict "repository" $initImgRepo "tag" $initImgTag }}
+    {{ $_ := set $deployerVal "initContainer" $initImgRef }}
+
+    {{ $waitResource := getResource .cd "name" "container-wait-image" }}
+    {{ $waitImgRepo := ociRefRepo $waitResource.access.imageReference }}
+    {{ $waitImgTag := ociRefVersion $waitResource.access.imageReference }}
+    {{ $waitImgRef := dict "repository" $waitImgRepo "tag" $waitImgTag }}
+    {{ $_ := set $deployerVal "waitContainer" $waitImgRef }}
+
     {{ if .imports.landscaperCluster  }}
     {{ $lsClusterKubeconfig := .imports.landscaperCluster.spec.config.kubeconfig }}
     {{ $newKubeconfig := dict "kubeconfig" $lsClusterKubeconfig }}

--- a/.landscaper/container-deployer/example/component-descriptor.yaml
+++ b/.landscaper/container-deployer/example/component-descriptor.yaml
@@ -24,6 +24,20 @@ component:
     access:
       type: ociRegistry
       imageReference: eu.gcr.io/gardener-project/landscaper/container-deployer-controller:v0.5.3
+  - type: ociImage
+    name: container-init-image
+    version: v0.5.3
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: eu.gcr.io/gardener-project/landscaper/container-init-controller:v0.5.3
+  - type: ociImage
+    name: container-wait-image
+    version: v0.5.3
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: eu.gcr.io/gardener-project/landscaper/container-wait-controller:v0.5.3
   - type: blueprint
     name: container-deployer-blueprint
     version: v0.5.3


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

The container deployer blueprint now honors the init and wait container defined in the component descriptor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The container deployer blueprint now honors the init and wait container defined in its component descriptor.
```
