### PR TITLE
add standalone blueprint rendering and unit tests for deployer bluepints

### DIFF
--- a/pkg/landscaper/blueprints/blueprint.go
+++ b/pkg/landscaper/blueprints/blueprint.go
@@ -33,6 +33,20 @@ func New(blueprint *lsv1alpha1.Blueprint, content vfs.FileSystem) *Blueprint {
 	return b
 }
 
+// NewFromFs creates a new internal Blueprint from a filesystem.
+// The blueprint is automatically read from within the filesystem
+func NewFromFs(content vfs.FileSystem) (*Blueprint, error) {
+	data, err := vfs.ReadFile(content, lsv1alpha1.BlueprintFileName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read blueprint from filesystem: %w", err)
+	}
+	blueprint := &lsv1alpha1.Blueprint{}
+	if _, _, err := api.Decoder.Decode(data, nil, blueprint); err != nil {
+		return nil, fmt.Errorf("unable to decode blueprint: %w", err)
+	}
+	return New(blueprint, content), nil
+}
+
 // GetSubinstallations gets the direct subinstallation templates for a blueprint.
 func (b *Blueprint) GetSubinstallations() ([]*lsv1alpha1.InstallationTemplate, error) {
 	var (

--- a/pkg/utils/landscaper/blueprint.go
+++ b/pkg/utils/landscaper/blueprint.go
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package landscaper
+
+import (
+	"fmt"
+	"path/filepath"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/codec"
+	"github.com/gardener/component-spec/bindings-go/ctf"
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	"github.com/mandelsoft/vfs/pkg/projectionfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/api"
+	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
+	"github.com/gardener/landscaper/pkg/landscaper/execution"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/gotemplate"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/spiff"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations"
+	"github.com/gardener/landscaper/pkg/landscaper/jsonschema"
+	"github.com/gardener/landscaper/pkg/landscaper/registry/components/cdutils"
+	"github.com/gardener/landscaper/pkg/utils"
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+)
+
+type BlueprintRenderArgs struct {
+	Fs                          vfs.FileSystem
+	BlueprintPath               string
+	ImportValuesFilepath        string
+	ComponentDescriptorFilepath string
+
+	// RootDir describes a directory that is used to default the other filepaths.
+	// The blueprint is expected to have the following structure
+	// <root Dir>
+	// - blueprint
+	//   - blueprint.yaml
+	// - examples
+	//   - imports.yaml
+	//   - component-descriptor.yaml
+	// +optional
+	RootDir string
+
+	ComponentsResolveFunc cdutils.ResolveComponentReferenceFunc
+}
+
+// Default defaults the BlueprintRender args
+func (args *BlueprintRenderArgs) Default() error {
+	if args.Fs == nil {
+		args.Fs = osfs.New()
+	}
+	if len(args.RootDir) == 0 {
+		args.RootDir = "../"
+	}
+	exampleDir := filepath.Join(args.RootDir, "example")
+	if len(args.BlueprintPath) == 0 {
+		args.BlueprintPath = filepath.Join(args.RootDir, "blueprint")
+		if _, err := args.Fs.Stat(args.BlueprintPath); err != nil {
+			args.BlueprintPath = ""
+		}
+	}
+	if len(args.ImportValuesFilepath) == 0 {
+		args.ImportValuesFilepath = filepath.Join(exampleDir, "imports.yaml")
+		if _, err := args.Fs.Stat(args.ImportValuesFilepath); err != nil {
+			args.ImportValuesFilepath = ""
+		}
+	}
+	if len(args.ComponentDescriptorFilepath) == 0 {
+		args.ComponentDescriptorFilepath = filepath.Join(exampleDir, "component-descriptor.yaml")
+		if _, err := args.Fs.Stat(args.ComponentDescriptorFilepath); err != nil {
+			args.ComponentDescriptorFilepath = ""
+		}
+	}
+	return nil
+}
+
+// BlueprintRenderOut describes the output of the blueprint render function.
+type BlueprintRenderOut struct {
+	DeployItems               []*lsv1alpha1.DeployItem
+	DeployItemTemplateState   map[string][]byte
+	Installations             []*lsv1alpha1.Installation
+	InstallationTemplateState map[string][]byte
+}
+
+type Imports struct {
+	Imports map[string]interface{} `json:"imports"`
+}
+
+// RenderBlueprint renders a blueprint
+func RenderBlueprint(args BlueprintRenderArgs) (*BlueprintRenderOut, error) {
+	if err := args.Default(); err != nil {
+		return nil, fmt.Errorf("unable to default args: %w", err)
+	}
+	imports := Imports{}
+	if err := utils.YAMLReadFromFile(osfs.New(), args.ImportValuesFilepath, &imports); err != nil {
+		return nil, fmt.Errorf("unable to read imports from %q: %w", args.ImportValuesFilepath, err)
+	}
+
+	var cd *cdv2.ComponentDescriptor
+	if len(args.ComponentDescriptorFilepath) != 0 {
+		cd = &cdv2.ComponentDescriptor{}
+		data, err := vfs.ReadFile(osfs.New(), args.ComponentDescriptorFilepath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read component descriptor from %q: %w", args.ComponentDescriptorFilepath, err)
+		}
+		if err := codec.Decode(data, cd); err != nil {
+			return nil, fmt.Errorf("unable to decode component descriptor from %q: %w", args.ComponentDescriptorFilepath, err)
+		}
+	}
+
+	bpFs, err := projectionfs.New(osfs.New(), args.BlueprintPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create blueprint fs for %q: %w", args.BlueprintPath, err)
+	}
+	blueprint, err := blueprints.NewFromFs(bpFs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read blueprint from %q: %w", args.BlueprintPath, err)
+	}
+
+	if err := ValidateImports(blueprint, &imports, cd, nil, args.ComponentsResolveFunc); err != nil {
+		return nil, err
+	}
+
+	inst := &lsv1alpha1.Installation{}
+	inst.Spec.Blueprint.Reference = &lsv1alpha1.RemoteBlueprintReference{
+		ResourceName: "example-blueprint",
+	}
+	inst.Spec.ComponentDescriptor = &lsv1alpha1.ComponentDescriptorDefinition{
+		Reference: &lsv1alpha1.ComponentDescriptorReference{
+			RepositoryContext: &cdv2.RepositoryContext{
+				Type:    cdv2.OCIRegistryType,
+				BaseURL: "example.com/components",
+			},
+			ComponentName: "my-example-component",
+			Version:       "v0.0.0",
+		},
+	}
+	if cd != nil {
+		inst.Spec.ComponentDescriptor.Reference.ComponentName = cd.GetName()
+		inst.Spec.ComponentDescriptor.Reference.Version = cd.GetVersion()
+		if len(cd.RepositoryContexts) != 0 {
+			repoCtx := cd.GetEffectiveRepositoryContext()
+			inst.Spec.ComponentDescriptor.Reference.RepositoryContext = &repoCtx
+		}
+	}
+
+	deployItems, deployItemsState, err := RenderBlueprintDeployItems(blueprint, imports, cd, inst)
+	if err != nil {
+		return nil, err
+	}
+
+	installations, installationsState, err := RenderBlueprintSubInstallations(blueprint, imports, cd, inst, args.ComponentsResolveFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BlueprintRenderOut{
+		DeployItems:               deployItems,
+		DeployItemTemplateState:   deployItemsState,
+		Installations:             installations,
+		InstallationTemplateState: installationsState,
+	}, nil
+}
+
+func RenderBlueprintDeployItems(
+	blueprint *blueprints.Blueprint,
+	imports Imports,
+	cd *cdv2.ComponentDescriptor,
+	inst *lsv1alpha1.Installation) ([]*lsv1alpha1.DeployItem, map[string][]byte, error) {
+
+	templateStateHandler := template.NewMemoryStateHandler()
+	deployItemTemplates, err := template.New(gotemplate.New(nil, templateStateHandler), spiff.New(templateStateHandler)).TemplateDeployExecutions(template.DeployExecutionOptions{
+		Imports:              imports.Imports,
+		Blueprint:            blueprint,
+		ComponentDescriptor:  cd,
+		ComponentDescriptors: &cdv2.ComponentDescriptorList{},
+		Installation:         inst,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to template deploy executions: %w", err)
+	}
+
+	deployItems := make([]*lsv1alpha1.DeployItem, len(deployItemTemplates))
+	for i, tmpl := range deployItemTemplates {
+		di := &lsv1alpha1.DeployItem{}
+		if err := kutil.InjectTypeInformation(di, api.LandscaperScheme); err != nil {
+			return nil, nil, fmt.Errorf("unable to inject deploy item type information for %q: %w", tmpl.Name, err)
+		}
+		execution.ApplyDeployItemTemplate(di, tmpl)
+		deployItems[i] = di
+	}
+	return deployItems, templateStateHandler, nil
+}
+
+func RenderBlueprintSubInstallations(
+	blueprint *blueprints.Blueprint,
+	imports Imports,
+	cd *cdv2.ComponentDescriptor,
+	inst *lsv1alpha1.Installation,
+	cdResolveFunc cdutils.ResolveComponentReferenceFunc) ([]*lsv1alpha1.Installation, map[string][]byte, error) {
+
+	installationTemplates, err := blueprint.GetSubinstallations()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to get subinstallation of blueprint: %w", err)
+	}
+
+	templateStateHandler := template.NewMemoryStateHandler()
+	subInstallationTemplates, err := template.New(gotemplate.New(nil, templateStateHandler), spiff.New(templateStateHandler)).TemplateSubinstallationExecutions(template.DeployExecutionOptions{
+		Imports:              imports.Imports,
+		Blueprint:            blueprint,
+		ComponentDescriptor:  cd,
+		ComponentDescriptors: &cdv2.ComponentDescriptorList{},
+		Installation:         inst,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to template subinstalltion executions: %w", err)
+	}
+
+	installationTemplates = append(installationTemplates, subInstallationTemplates...)
+	installations := make([]*lsv1alpha1.Installation, len(installationTemplates))
+	for i, subInstTmpl := range installationTemplates {
+		subInst := &lsv1alpha1.Installation{}
+		subInst.Spec = lsv1alpha1.InstallationSpec{
+			Imports:            subInstTmpl.Imports,
+			ImportDataMappings: subInstTmpl.ImportDataMappings,
+			Exports:            subInstTmpl.Exports,
+			ExportDataMappings: subInstTmpl.ExportDataMappings,
+		}
+		subBlueprint, _, err := subinstallations.GetBlueprintDefinitionFromInstallationTemplate(
+			inst,
+			subInstTmpl,
+			cd,
+			cdResolveFunc)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to get blueprint for subinstallation %q: %w", subInstTmpl.Name, err)
+		}
+		subInst.Spec.Blueprint = *subBlueprint
+		installations[i] = subInst
+	}
+
+	return installations, templateStateHandler, nil
+}
+
+// ValidateImports the imports for a blueprint.
+func ValidateImports(bp *blueprints.Blueprint,
+	imports *Imports,
+	cd *cdv2.ComponentDescriptor,
+	componentResolver ctf.ComponentResolver,
+	componentReferenceResolver cdutils.ResolveComponentReferenceFunc) error {
+
+	jsonschemaValidator := &jsonschema.Validator{
+		Config: &jsonschema.LoaderConfig{
+			LocalTypes:                 bp.Info.LocalTypes,
+			BlueprintFs:                bp.Fs,
+			ComponentDescriptor:        cd,
+			ComponentResolver:          componentResolver,
+			ComponentReferenceResolver: componentReferenceResolver,
+		},
+	}
+
+	var allErr field.ErrorList
+	for _, importDef := range bp.Info.Imports {
+		fldPath := field.NewPath(importDef.Name)
+		value, ok := imports.Imports[importDef.Name]
+		if !ok {
+			if *importDef.Required {
+				allErr = append(allErr, field.Required(fldPath, "Import is required"))
+			}
+			continue
+		}
+		if importDef.Schema != nil {
+			if err := jsonschemaValidator.ValidateGoStruct(importDef.Schema.RawMessage, value); err != nil {
+				allErr = append(allErr, field.Invalid(
+					fldPath,
+					value,
+					fmt.Sprintf("invalid imported value: %s", err.Error())))
+			}
+		} else {
+			// import is a target import
+			targetObj, ok := value.(map[string]interface{})
+			if !ok {
+				allErr = append(allErr, field.Invalid(fldPath, value, "a target is expected to be an object"))
+				continue
+			}
+			targetType, _, err := unstructured.NestedString(targetObj, "spec", "type")
+			if err != nil {
+				allErr = append(allErr, field.Invalid(
+					fldPath,
+					value,
+					fmt.Sprintf("unable to get type of target: %s", err.Error())))
+				continue
+			}
+			if targetType != importDef.TargetType {
+				allErr = append(allErr, field.Invalid(
+					fldPath,
+					targetType,
+					fmt.Sprintf("expected target type to be %q but got %q", importDef.TargetType, targetType)))
+				continue
+			}
+		}
+	}
+
+	return allErr.ToAggregate()
+}

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"sigs.k8s.io/yaml"
 )
 
 // MergeMaps takes two maps <a>, <b> and merges them. If <b> defines a value with a key
@@ -103,4 +104,14 @@ func CopyFS(src, dst vfs.FileSystem, srcPath, dstPath string) error {
 		}
 		return nil
 	})
+}
+
+// YAMLReadFromFile reads a file from a filesystem and decodes it into the given obj
+// using YAMl/JSON decoder.
+func YAMLReadFromFile(fs vfs.FileSystem, path string, obj interface{}) error {
+	data, err := vfs.ReadFile(fs, path)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, obj)
 }

--- a/test/landscaper/deployer_blueprints/deployer_blueprint_test.go
+++ b/test/landscaper/deployer_blueprints/deployer_blueprint_test.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package deployer_blueprints_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper/pkg/deployer/helm"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
+	testutils "github.com/gardener/landscaper/test/utils"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Container Deployer Test Suite")
+}
+
+const projectRoot = "../../../"
+
+var _ = Describe("Blueprint", func() {
+
+	It("ContainerDeployer", func() {
+		out, err := lsutils.RenderBlueprint(lsutils.BlueprintRenderArgs{
+			Fs:      osfs.New(),
+			RootDir: filepath.Join(projectRoot, ".landscaper/container-deployer"),
+		})
+		testutils.ExpectNoError(err)
+		Expect(out.DeployItems).To(HaveLen(1))
+		Expect(out.Installations).To(HaveLen(0))
+
+		di := out.DeployItems[0]
+		Expect(di.Spec.Type).To(Equal(helm.Type))
+		expectedConfig := `
+{
+  "apiVersion": "helm.deployer.landscaper.gardener.cloud/v1alpha1",
+  "chart": {
+    "ref": "eu.gcr.io/gardener-project/landscaper/charts/container-deployer-controller:v0.5.3"
+  },
+  "kind": "ProviderConfiguration",
+  "name": "landscaper-container-deployer",
+  "namespace": "container-deployer",
+  "updateStrategy": "update",
+  "values": {
+    "deployer": {
+      "identity": "my-id",
+      "initContainer": {
+        "repository": "eu.gcr.io/gardener-project/landscaper/container-init-controller",
+        "tag": "v0.5.3"
+      },
+      "namespace": "",
+      "oci": {
+        "allowPlainHttp": false,
+        "secrets": {}
+      },
+      "waitContainer": {
+        "repository": "eu.gcr.io/gardener-project/landscaper/container-wait-controller",
+        "tag": "v0.5.3"
+      }
+    },
+    "image": {
+      "pullPolicy": "IfNotPresent",
+      "repository": "eu.gcr.io/gardener-project/landscaper/container-deployer-controller",
+      "tag": "v0.5.3"
+    },
+    "replicaCount": 1
+  }
+}
+`
+		Expect(di.Spec.Configuration.Raw).To(MatchJSON(expectedConfig))
+	})
+
+	It("HelmDeployer", func() {
+		out, err := lsutils.RenderBlueprint(lsutils.BlueprintRenderArgs{
+			Fs:      osfs.New(),
+			RootDir: filepath.Join(projectRoot, ".landscaper/helm-deployer"),
+		})
+		testutils.ExpectNoError(err)
+		Expect(out.DeployItems).To(HaveLen(1))
+		Expect(out.Installations).To(HaveLen(0))
+
+		di := out.DeployItems[0]
+		Expect(di.Spec.Type).To(Equal(helm.Type))
+		expectedConfig := `
+{
+  "apiVersion": "helm.deployer.landscaper.gardener.cloud/v1alpha1",
+  "chart": {
+    "ref": "eu.gcr.io/gardener-project/landscaper/charts/helm-deployer-controller:v0.5.3"
+  },
+  "kind": "ProviderConfiguration",
+  "name": "landscaper-helm-deployer",
+  "namespace": "helm-deployer",
+  "updateStrategy": "update",
+  "values": {
+    "deployer": {
+      "namespace": "",
+      "oci": {
+        "allowPlainHttp": false,
+        "secrets": {}
+      }
+    },
+    "image": {
+      "pullPolicy": "IfNotPresent",
+      "repository": "eu.gcr.io/gardener-project/landscaper/helm-deployer-controller",
+      "tag": "v0.5.3"
+    },
+    "replicaCount": 1
+  }
+}
+`
+		Expect(di.Spec.Configuration.Raw).To(MatchJSON(expectedConfig))
+	})
+
+	It("ManifestDeployer", func() {
+		out, err := lsutils.RenderBlueprint(lsutils.BlueprintRenderArgs{
+			Fs:      osfs.New(),
+			RootDir: filepath.Join(projectRoot, ".landscaper/manifest-deployer"),
+		})
+		testutils.ExpectNoError(err)
+		Expect(out.DeployItems).To(HaveLen(1))
+		Expect(out.Installations).To(HaveLen(0))
+
+		di := out.DeployItems[0]
+		Expect(di.Spec.Type).To(Equal(helm.Type))
+		expectedConfig := `
+{
+  "apiVersion": "helm.deployer.landscaper.gardener.cloud/v1alpha1",
+  "chart": {
+    "ref": "eu.gcr.io/gardener-project/landscaper/charts/manifest-deployer-controller:v0.5.3"
+  },
+  "kind": "ProviderConfiguration",
+  "name": "landscaper-manifest-deployer",
+  "namespace": "manifest-deployer",
+  "updateStrategy": "update",
+  "values": {
+    "deployer": {
+      "namespace": "",
+      "oci": {
+        "allowPlainHttp": false,
+        "secrets": {}
+      }
+    },
+    "image": {
+      "pullPolicy": "IfNotPresent",
+      "repository": "eu.gcr.io/gardener-project/landscaper/manifest-deployer-controller",
+      "tag": "v0.5.3"
+    },
+    "replicaCount": 1
+  }
+}
+`
+		Expect(di.Spec.Configuration.Raw).To(MatchJSON(expectedConfig))
+	})
+
+	It("MockDeployer", func() {
+		out, err := lsutils.RenderBlueprint(lsutils.BlueprintRenderArgs{
+			Fs:      osfs.New(),
+			RootDir: filepath.Join(projectRoot, ".landscaper/mock-deployer"),
+		})
+		testutils.ExpectNoError(err)
+		Expect(out.DeployItems).To(HaveLen(1))
+		Expect(out.Installations).To(HaveLen(0))
+
+		di := out.DeployItems[0]
+		Expect(di.Spec.Type).To(Equal(helm.Type))
+		expectedConfig := `
+{
+  "apiVersion": "helm.deployer.landscaper.gardener.cloud/v1alpha1",
+  "chart": {
+    "ref": "eu.gcr.io/gardener-project/landscaper/charts/mock-deployer-controller:v0.5.3"
+  },
+  "kind": "ProviderConfiguration",
+  "name": "landscaper-mock-deployer",
+  "namespace": "mock-deployer",
+  "updateStrategy": "update",
+  "values": {
+    "deployer": {
+      "namespace": "",
+      "oci": {
+        "allowPlainHttp": false,
+        "secrets": {}
+      }
+    },
+    "image": {
+      "pullPolicy": "IfNotPresent",
+      "repository": "eu.gcr.io/gardener-project/landscaper/mock-deployer-controller",
+      "tag": "v0.5.3"
+    },
+    "replicaCount": 1
+  }
+}
+`
+		Expect(di.Spec.Configuration.Raw).To(MatchJSON(expectedConfig))
+	})
+
+})

--- a/test/utils/resources.go
+++ b/test/utils/resources.go
@@ -19,13 +19,13 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/gardener/landscaper/apis/core/install"
+	"github.com/gardener/landscaper/pkg/api"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 	"github.com/gardener/landscaper/pkg/deployer/container"
@@ -124,11 +124,7 @@ func ReadResourceFromFile(obj runtime.Object, testfile string) error {
 	if err != nil {
 		return err
 	}
-
-	landscaperScheme := runtime.NewScheme()
-	install.Install(landscaperScheme)
-	decoder := serializer.NewCodecFactory(landscaperScheme).UniversalDecoder()
-	if _, _, err := decoder.Decode(data, nil, obj); err != nil {
+	if _, _, err := api.Decoder.Decode(data, nil, obj); err != nil {
 		return err
 	}
 	return nil
@@ -140,16 +136,11 @@ func ReadBlueprintFromFile(testfile string) (*lsv1alpha1.Blueprint, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	landscaperScheme := runtime.NewScheme()
-	install.Install(landscaperScheme)
-	decoder := serializer.NewCodecFactory(landscaperScheme).UniversalDecoder()
-
-	component := &lsv1alpha1.Blueprint{}
-	if _, _, err := decoder.Decode(data, nil, component); err != nil {
+	blueprint := &lsv1alpha1.Blueprint{}
+	if _, _, err := api.Decoder.Decode(data, nil, blueprint); err != nil {
 		return nil, err
 	}
-	return component, nil
+	return blueprint, nil
 }
 
 // CreateBlueprintFromFile reads a blueprint from the given file and creates a internal blueprint object.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind test
/priority 3

**What this PR does / why we need it**:

Added a standalone render function for subinstallations and deploy items defined by blueprints.
That function is used to unit test the deployer blueprints

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Unit tests for the deployer blueprints have been added
```
