### PR TITLE
Improve testsetup by using the new testenv tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install-requirements:
 	@go install -mod=vendor $(REPO_ROOT)/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 	@go install -mod=vendor $(REPO_ROOT)/vendor/github.com/ahmetb/gen-crd-api-reference-docs
 	@go install -mod=vendor $(REPO_ROOT)/vendor/github.com/golang/mock/mockgen
+	@go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 	@$(REPO_ROOT)/hack/install-requirements.sh
 	@chmod +x $(REPO_ROOT)/apis/vendor/k8s.io/code-generator/*
 
@@ -41,10 +42,13 @@ check:
 	@$(REPO_ROOT)/hack/check.sh --golangci-lint-config=./.golangci.yaml $(REPO_ROOT)/cmd/... $(REPO_ROOT)/pkg/... $(REPO_ROOT)/test/...
 	@cd $(REPO_ROOT)/apis && $(REPO_ROOT)/hack/check.sh --golangci-lint-config=../.golangci.yaml $(REPO_ROOT)/apis/config/... $(REPO_ROOT)/apis/core/... $(REPO_ROOT)/apis/deployer/...
 
+.PHONY: setup-testenv
+setup-testenv:
+	@$(REPO_ROOT)/hack/setup-testenv.sh
+
 .PHONY: test
-test:
-	@go test -mod=vendor $(REPO_ROOT)/cmd/... $(REPO_ROOT)/pkg/... $(REPO_ROOT)/test/framework/... $(REPO_ROOT)/test/utils/... $(REPO_ROOT)/test/landscaper/...
-	@cd $(REPO_ROOT)/apis && GO111MODULE=on go test ./...
+test: setup-testenv
+	@$(REPO_ROOT)/hack/test.sh
 
 .PHONY: integration-test
 integration-test:

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -12,15 +12,3 @@ PROJECT_ROOT="${CURRENT_DIR}"/..
 curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.32.2
 
 GO111MODULE=off go get golang.org/x/tools/cmd/goimports
-
-echo "> Download Kubernetes test binaries"
-TEST_BIN_DIR=${PROJECT_ROOT}/tmp/test/bin
-KUBEBUILDER_VER=2.3.1
-
-os=$(go env GOOS)
-arch=$(go env GOARCH)
-
-mkdir -p ${TEST_BIN_DIR}
-
-curl -L https://go.kubebuilder.io/dl/${KUBEBUILDER_VER}/${os}/${arch} | tar -xz -C /tmp/
-mv /tmp/kubebuilder_${KUBEBUILDER_VER}_${os}_${arch}/bin/* ${TEST_BIN_DIR}/

--- a/hack/setup-testenv.sh
+++ b/hack/setup-testenv.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+K8S_VERSION="1.19.x"
+
+echo "> Setup Test Environment for K8s Version ${K8S_VERSION}"
+
+CURRENT_DIR=$(dirname $0)
+PROJECT_ROOT="${CURRENT_DIR}"/..
+export KUBEBUILDER_ASSETS=$(setup-envtest use -p path ${K8S_VERSION})
+mkdir -p ${PROJECT_ROOT}/tmp/test
+rm -f ${PROJECT_ROOT}/tmp/test/bin
+ln -s "${KUBEBUILDER_ASSETS}" ${PROJECT_ROOT}/tmp/test/bin

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+CURRENT_DIR=$(dirname $0)
+PROJECT_ROOT="${CURRENT_DIR}"/..
+
+go test -mod=vendor ${PROJECT_ROOT}/cmd/... \
+                    ${PROJECT_ROOT}/pkg/... \
+                    ${PROJECT_ROOT}/test/framework/... \
+                    ${PROJECT_ROOT}/test/utils/... \
+                    ${PROJECT_ROOT}/test/landscaper/...
+cd ${PROJECT_ROOT}/apis && GO111MODULE=on go test ./...

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -44,15 +44,20 @@ func New(projectRoot string) (*Environment, error) {
 		return nil, err
 	}
 	testBinPath := filepath.Join(projectRoot, "tmp", "test", "bin")
-	if err := os.Setenv("TEST_ASSET_KUBE_APISERVER", filepath.Join(testBinPath, "kube-apiserver")); err != nil {
-		return nil, err
+	// if the default Landscaper test bin does not exist we default to the kubebuilder testenv default
+	// that uses the KUBEBUILDER_ASSETS env var.
+	if _, err := os.Stat(testBinPath); err == nil {
+		if err := os.Setenv("TEST_ASSET_KUBE_APISERVER", filepath.Join(testBinPath, "kube-apiserver")); err != nil {
+			return nil, err
+		}
+		if err := os.Setenv("TEST_ASSET_ETCD", filepath.Join(testBinPath, "etcd")); err != nil {
+			return nil, err
+		}
+		if err := os.Setenv("TEST_ASSET_KUBECTL", filepath.Join(testBinPath, "kubectl")); err != nil {
+			return nil, err
+		}
 	}
-	if err := os.Setenv("TEST_ASSET_ETCD", filepath.Join(testBinPath, "etcd")); err != nil {
-		return nil, err
-	}
-	if err := os.Setenv("TEST_ASSET_KUBECTL", filepath.Join(testBinPath, "kubectl")); err != nil {
-		return nil, err
-	}
+
 	return &Environment{
 		Env: &envtest.Environment{
 			CRDDirectoryPaths: []string{filepath.Join(projectRoot, ".crd")},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/priority 3

**What this PR does / why we need it**:

Replaces the curl based testenv setup with the new controller-runtime testenv tool.
This new tool should make it easier in the future to update to newer k8s versions or even test different versions.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/208

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
