### PR TITLE
improve force reconcile deadlock in the execution controller

### DIFF
--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -114,6 +114,19 @@ func HandleAnnotationsAndGeneration(ctx context.Context, log logr.Logger, c clie
 		}
 		log.V(7).Info("successfully updated metadata")
 	}
+
+	// also reset the phase when the force reconcile annotation is present.
+	// Otherwise we would never bbe able to leave a final phase
+	if lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
+		if lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) {
+			exec.Status.Phase = lsv1alpha1.ExecutionPhaseInit
+			log.V(7).Info("updating status")
+			if err := c.Status().Update(ctx, exec); err != nil {
+				return err
+			}
+			log.V(7).Info("successfully updated status")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a deadlock in the execution that can occur when the execution is in a Final state.
The force reconcile annotation now also resets the phase even if the generation stays the same.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes the `force-reconcile` handling in the execution controller that could lead to a reconcile deadlock.
```
