### PR TITLE
Fix missing defaulting for Landscaper Controller config

### DIFF
--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -55,7 +55,7 @@ func NewLandscaperControllerCommand(ctx context.Context) *cobra.Command {
 		Short: "Landscaper controller manages the orchestration of components",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.Complete(); err != nil {
+			if err := options.Complete(ctx); err != nil {
 				fmt.Print(err)
 				os.Exit(1)
 			}

--- a/cmd/landscaper-controller/app/app_test.go
+++ b/cmd/landscaper-controller/app/app_test.go
@@ -51,10 +51,12 @@ var _ = Describe("Landscaper Controller", func() {
 
 	Context("Options", func() {
 
+		var ctx = context.Background()
+
 		It("should parse enabled deployers", func() {
 			opts := NewOptions()
 			opts.deployer.deployers = "deployer1,deployer2"
-			Expect(opts.Complete()).To(Succeed())
+			Expect(opts.Complete(ctx)).To(Succeed())
 
 			Expect(opts.deployer.EnabledDeployers).To(ConsistOf("deployer1", "deployer2"))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

The configuration object was not properly initialized with default values which caused the landscaper controller to crash if it was started without a configuration file (due to uninitialized NIL pointers). This PR makes sure the configuration object gets initialized with default values if not configuration file is supplied. Builds upon PR #201.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Proper initialization of configuration with default values, fixes crash if landscaper-controller is started without configuration file.
```
