### PR TITLE
improve deploy item abort timeout handling

### DIFF
--- a/apis/core/v1alpha1/helper/helpers.go
+++ b/apis/core/v1alpha1/helper/helpers.go
@@ -51,9 +51,21 @@ func SetTimestampAnnotationNow(obj *metav1.ObjectMeta, ta TimestampAnnotation) {
 	metav1.SetMetaDataAnnotation(obj, string(ta), time.Now().Format(time.RFC3339))
 }
 
+// SetAbortOperationAndTimestamp sets the annotations for a deploy item abort.
 func SetAbortOperationAndTimestamp(obj *metav1.ObjectMeta) {
 	SetOperation(obj, v1alpha1.AbortOperation)
 	SetTimestampAnnotationNow(obj, AbortTimestamp)
+}
+
+// RemoveAbortOperationAndTimestamp removes all abort related annotations
+func RemoveAbortOperationAndTimestamp(obj *metav1.ObjectMeta) {
+	if len(obj.Annotations) == 0 {
+		return
+	}
+	if val, ok := obj.Annotations[v1alpha1.OperationAnnotation]; ok && val == string(v1alpha1.AbortOperation) {
+		delete(obj.Annotations, v1alpha1.OperationAnnotation)
+	}
+	delete(obj.Annotations, string(AbortTimestamp))
 }
 
 // InitCondition initializes a new Condition with an Unknown status.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -51,9 +51,21 @@ func SetTimestampAnnotationNow(obj *metav1.ObjectMeta, ta TimestampAnnotation) {
 	metav1.SetMetaDataAnnotation(obj, string(ta), time.Now().Format(time.RFC3339))
 }
 
+// SetAbortOperationAndTimestamp sets the annotations for a deploy item abort.
 func SetAbortOperationAndTimestamp(obj *metav1.ObjectMeta) {
 	SetOperation(obj, v1alpha1.AbortOperation)
 	SetTimestampAnnotationNow(obj, AbortTimestamp)
+}
+
+// RemoveAbortOperationAndTimestamp removes all abort related annotations
+func RemoveAbortOperationAndTimestamp(obj *metav1.ObjectMeta) {
+	if len(obj.Annotations) == 0 {
+		return
+	}
+	if val, ok := obj.Annotations[v1alpha1.OperationAnnotation]; ok && val == string(v1alpha1.AbortOperation) {
+		delete(obj.Annotations, v1alpha1.OperationAnnotation)
+	}
+	delete(obj.Annotations, string(AbortTimestamp))
 }
 
 // InitCondition initializes a new Condition with an Unknown status.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind robustness
/priority 3

**What this PR does / why we need it**:

Improves the abort timeout handling that can cause a infinite reconcile loop between the deployer and the landscaper deployitem controller if a aborted deployitem is reconciled.
The issue is that the deployitem controller does not remove the abort timeout annotation which causes the deploy item controller to read the abort failed state whereas the deployer in parallel tries to reconcile the item.

This PR removes that behavior so that the abort annotations are removed as soon as the deploy item controller sets the deploy item into a failed state.

@Diaphteiros do we have other annotation that are also not cleaned up correctly? Or should the deployers also clean up these other annotations.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Improved the abort handling of the deploy item controller to not cause an infinite reconcile while competing with a deployer
```
