### PR TITLE
update landscaper oci media types and parsing

### DIFF
--- a/apis/core/v1alpha1/constants.go
+++ b/apis/core/v1alpha1/constants.go
@@ -54,18 +54,9 @@ const (
 
 	// Component Descriptor
 
-	// BlueprintType is the name of the blueprint type in a component descriptor.
-	BlueprintType = "landscaper.gardener.cloud/blueprint"
-
-	// OldBlueprintType is the old name of the blueprint type in a component descriptor.
-	OldBlueprintType = "blueprint"
+	// InlineComponentDescriptorLabel is the label name used for nested inline component descriptors
+	InlineComponentDescriptorLabel = "landscaper.gardener.cloud/component-descriptor"
 
 	// BlueprintFileName is the filename of a component definition on a local path
 	BlueprintFileName = "blueprint.yaml"
-
-	// BlueprintArtifactsMediaType is the reserved media type for a blueprint that is stored as its own artifact.
-	BlueprintArtifactsMediaType = "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
-
-	// InlineComponentDescriptorLabel is the label name used for nested inline component descriptors
-	InlineComponentDescriptorLabel = "landscaper.gardener.cloud/component-descriptor"
 )

--- a/apis/mediatype/constants.go
+++ b/apis/mediatype/constants.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mediatype
+
+const (
+	// BlueprintType is the name of the blueprint type in a component descriptor.
+	BlueprintType = "landscaper.gardener.cloud/blueprint"
+
+	// OldBlueprintType is the old name of the blueprint type in a component descriptor.
+	OldBlueprintType = "blueprint"
+
+	// BlueprintArtifactsMediaTypeV0 is the reserved media type for a blueprint that is stored as its own artifact.
+	// This is the legacy deprecated artifact media type that was used for the layer and the config type.
+	// Use BlueprintArtifactsConfigMediaTypeV1 or BlueprintArtifactsLayerMediaTypeV1 instead.
+	// DEPRECATED
+	BlueprintArtifactsMediaTypeV0 = "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
+
+	// BlueprintArtifactsConfigMediaTypeV1 is the config reserved media type for a blueprint that is stored as its own artifact.
+	// This describes the config media type of the blueprint artifact.
+	// The suffix can be yaml or json whereas yaml is the default.
+	BlueprintArtifactsConfigMediaTypeV1 = "application/vnd.gardener.landscaper.blueprint.config.v1"
+
+	// BlueprintArtifactsLayerMediaTypeV1 is the reserved layer media type for a blueprint that is stored as its own artifact.
+	// This describes the layer media type of the blueprint artifact as well as the media type of a localOciBlob.
+	// Optionally the compression can be added as "+gzip"
+	BlueprintArtifactsLayerMediaTypeV1 = "application/vnd.gardener.landscaper.blueprint.layer.v1.tar"
+
+	// JSONSchemaArtifactsMediaTypeV0 is the reserved media type for a jsonschema that is stored as layer in an oci artifact.
+	// This is the legacy deprecated artifact media type use JSONSchemaArtifactsMediaTypeV1 instead.
+	// DEPRECATED
+	JSONSchemaArtifactsMediaTypeV0 = "application/vnd.gardener.landscaper.jsonscheme.v1+json"
+
+	// JSONSchemaArtifactsMediaTypeV1 is the reserved media type for a jsonschema that is stored as layer in an oci artifact.
+	// This is the legacy deprecated artifact media type.
+	JSONSchemaArtifactsMediaTypeV1 = "application/vnd.gardener.landscaper.jsonschema.layer.v1.json"
+
+	// GZipCompression is the identifier for a gzip compressed file.
+	GZipCompression = "gzip"
+
+	// MediaTypeGZip defines the media type for a gzipped file
+	MediaTypeGZip = "application/gzip"
+)
+
+// DefaultMediaTypeConversions defines the default conversions for landscaper media types.
+func DefaultMediaTypeConversions(mediaType string) (convertedType string, converted bool, err error) {
+	switch mediaType {
+		case BlueprintArtifactsMediaTypeV0:
+			return NewBuilder(BlueprintArtifactsLayerMediaTypeV1).Compression(GZipCompression).String(), true, nil
+	case JSONSchemaArtifactsMediaTypeV0:
+		return JSONSchemaArtifactsMediaTypeV1, true, nil
+	}
+	return "", false, nil
+}

--- a/apis/mediatype/mediatype.go
+++ b/apis/mediatype/mediatype.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mediatype
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var InvalidTypeError = errors.New("INVALID_MEDIA_TYPE")
+
+type MediaTypeFormat string
+
+const (
+	DefaultFormat MediaTypeFormat = ""
+	OCIConfigFormat MediaTypeFormat  = "ociConfig"
+	OCILayerFormat MediaTypeFormat  = "ociLayer"
+)
+
+// MediaType describes a media type (formerly known as MIME type) defined by the IANA in THE RFC 2045.
+// In addition oci specific media types as defined in
+// https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#defining-layermediatypes are parsed.
+type MediaType struct {
+	// Orig contains the complete original type
+	Orig string
+	// Format describes the specific format of the media type
+	Format MediaTypeFormat
+	// Type contain the parsed type without suffix.
+	Type string
+	// Suffix contains the suffix of a media that is given after the "+"-char
+	Suffix *string
+
+	// Only valid for oci types
+
+	// Version describes the config or layer version.
+	Version *string
+	// FileFormat contains only the file format.
+	// This is part of the Type if the mediatype is not a ConfigType.
+	// If it is a ConfigType the FileFormat is not part of the type.
+	FileFormat *string
+	// CompressionFormat contains the optional compression format.
+	CompressionFormat *string
+}
+
+// String returns the string using the parsed type file and compression.
+func (t MediaType) String() string {
+	s := t.Type
+	if t.CompressionFormat !=  nil  && t.Suffix == nil {
+		t.Suffix = t.CompressionFormat
+	}
+	if t.Suffix != nil {
+		s = s + "+" + *t.Suffix
+	}
+	return s
+}
+
+// HasSuffix checks if the media type contains the given suffix.
+// if the given format is empty this functions only validates if a format is given
+func (t MediaType) HasSuffix(suffix string) bool {
+	if t.Suffix == nil {
+		return false
+	}
+	if len(suffix) == 0 {
+		return true
+	}
+	return *t.Suffix == suffix
+}
+
+// IsCompressed checks if the media type is compressed with the given format.
+// if the given format is empty this functions only validates if a compression is given
+func (t MediaType) IsCompressed(format string) bool {
+	if t.CompressionFormat == nil {
+
+		// try to parse the compression from the suffix or tree
+		if t.Suffix == nil {
+			return  false
+		}
+
+		return *t.Suffix == format
+	}
+	if len(format) == 0 {
+		return true
+	}
+	return *t.CompressionFormat == format
+}
+
+// HasFileFormat checks if the media type contains the given file format.
+// if the given format is empty this functions only validates if a format is given
+func (t MediaType) HasFileFormat(format string) bool {
+	if t.FileFormat == nil {
+		return false
+	}
+	if len(format) == 0 {
+		return true
+	}
+	return *t.FileFormat == format
+}
+
+// ConversionFunc describes a conversion func for a media type
+type ConversionFunc func(mediaType string) (convertedType string, converted bool, err error)
+
+// Parse parses a config and layer media type according to the oci spec.
+// Config:
+// [registration-tree].[org|company|entity].[objectType].[optional-subType].config.[version]+[optional-configFormat]
+// Layers:
+// [registration-tree].[org|company|entity].[layerType].[optional-layerSubType].layer.[version].[fileFormat]+[optional-compressionFormat]
+// Layers also allow any IANA media type
+//
+// https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#defining-layermediatypes
+//
+// This method is highly landscaper specific and can also handle legacy types that are automatically converted.
+func Parse(mediaType string, conversions ...ConversionFunc) (MediaType, error) {
+	for _, conversion := range append(conversions, DefaultMediaTypeConversions) {
+		converted, ok, err := conversion(mediaType)
+		if err != nil {
+			return MediaType{}, fmt.Errorf("error during conversion: %w", err)
+		}
+		if ok {
+			mediaType = converted
+		}
+	}
+
+	splitType := strings.Split(mediaType, "/")
+	if len(splitType) != 2 {
+		return MediaType{}, InvalidTypeError
+	}
+	mt := MediaType{
+		Orig: mediaType,
+		Type: mediaType,
+	}
+	t := splitType[0]
+	tree := splitType[1]
+
+	if suffixIndex := strings.Index(mediaType, "+"); suffixIndex > -1 {
+		mt.Suffix = strPtr(mediaType[suffixIndex+1:])
+		mt.Type = mediaType[:suffixIndex]
+		tree = mediaType[len(mediaType)-len(tree) : suffixIndex]
+	}
+
+	if t != "application" {
+		mt.Type = mediaType
+		mt.FileFormat = strPtr(tree)
+		return mt, nil
+	}
+
+	// try to detect config or layer type
+	splitType = strings.Split(tree, ".")
+
+
+	if len(splitType) > 2 && splitType[len(splitType)-2] == "config" {
+		mt.Format = OCIConfigFormat
+		mt.FileFormat = mt.Suffix
+		mt.Version = strPtr(splitType[len(splitType)-1])
+	} else if len(splitType) > 3 && splitType[len(splitType)-3] == "layer" {
+		mt.Format =  OCILayerFormat
+		mt.FileFormat = strPtr(splitType[len(splitType)-1])
+		mt.Version = strPtr(splitType[len(splitType)-2])
+	}
+
+	return mt, nil
+}
+
+// Builder is a media type builder
+type Builder struct {
+	Type MediaType
+}
+
+// NewBuilder creates a new media type builder.
+func NewBuilder(t string) *Builder {
+	return &Builder{
+		MediaType{
+			Orig:              "",
+			Type:              t,
+			Format: DefaultFormat,
+			Version: nil,
+			FileFormat:        nil,
+			CompressionFormat: nil,
+		},
+	}
+}
+
+// Compression sets the compression format
+func (b *Builder) Compression(comp string) *Builder {
+	b.Type.CompressionFormat = &comp
+	b.Type.Suffix  = &comp
+	return b
+}
+
+// FileFormat sets the file format of the media type.
+// Will be automatically parsed from the type if it is not a config type.
+func (b *Builder) FileFormat(format string) *Builder {
+	b.Type.FileFormat = &format
+	b.Type.Suffix  = &format
+	return b
+}
+
+// IsConfigType configures the media type as oci config.
+func (b *Builder) IsConfigType() *Builder {
+	b.Type.Format = OCIConfigFormat
+	return b
+}
+
+// IsLayerType configures the media type as oci layer.
+func (b *Builder) IsLayerType() *Builder {
+	b.Type.Format = OCILayerFormat
+	return b
+}
+
+// Build builds the mediatype
+func (b *Builder) Build() MediaType {
+	return b.Type
+}
+
+// String returns the media type as string
+func (b *Builder) String() string {
+	return b.Build().String()
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/apis/mediatype/mediatypes_test.go
+++ b/apis/mediatype/mediatypes_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mediatype_test
+
+import (
+	"testing"
+
+	"github.com/gardener/landscaper/apis/mediatype"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega/gstruct"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "mediatype Test Suite")
+}
+
+var _ = Describe("MediaType test suite", func() {
+
+	DescribeTable("Stringer",
+		func(raw string) {
+			mt, err := mediatype.Parse(raw)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mt.String()).To(Equal(raw))
+		},
+		Entry("application/json", "application/json"),
+		Entry("application/tar+gzip", "application/tar+gzip"),
+		Entry("application/vnd.oci.null-sample.config.v1", "application/vnd.oci.null-sample.config.v1"),
+	)
+
+	It("Should be able to manually create a media type", func() {
+		c := mediatype.GZipCompression
+		mt := mediatype.MediaType{
+			Type:              "application/json",
+			CompressionFormat: &c,
+		}
+		Expect(mt.String()).To(Equal("application/json+gzip"))
+
+		mt = mediatype.NewBuilder("application/json").Compression(mediatype.GZipCompression).Build()
+		Expect(mt.String()).To(Equal("application/json+gzip"))
+		Expect(mt.IsCompressed("")).To(BeTrue())
+		Expect(mt.IsCompressed(mediatype.GZipCompression)).To(BeTrue())
+
+		mt, err := mediatype.Parse(mt.String())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(mediatype.NewBuilder(mediatype.BlueprintArtifactsLayerMediaTypeV1).Compression(mediatype.GZipCompression).String()).
+			To(Equal("application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip"))
+	})
+
+	It("should parse a simple valid media type without compression", func() {
+		mt, err := mediatype.Parse("application/json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mt.Orig).To(Equal("application/json"))
+		Expect(mt.Type).To(Equal("application/json"))
+		Expect(mt.Format).To(Equal(mediatype.DefaultFormat))
+		Expect(mt.CompressionFormat).To(BeNil())
+	})
+
+	It("should parse a simple valid media type with compression", func() {
+		mt, err := mediatype.Parse("application/tar+gzip")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mt.Orig).To(Equal("application/tar+gzip"))
+		Expect(mt.Type).To(Equal("application/tar"))
+		Expect(mt.Format).To(Equal(mediatype.DefaultFormat))
+		Expect(mt.Suffix).To(gstruct.PointTo(Equal("gzip")))
+		Expect(mt.IsCompressed(mediatype.GZipCompression)).To(BeTrue())
+	})
+
+	It("should parse a simple valid media type without compression but with a suffix", func() {
+		mt, err := mediatype.Parse("application/ld+json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mt.Orig).To(Equal("application/ld+json"))
+		Expect(mt.Type).To(Equal("application/ld"))
+		Expect(mt.Format).To(Equal(mediatype.DefaultFormat))
+		Expect(mt.Suffix).To(gstruct.PointTo(Equal("json")))
+		Expect(mt.IsCompressed("")).To(BeFalse())
+	})
+
+	It("should parse a default valid config media type", func() {
+		mt, err := mediatype.Parse("application/vnd.oci.null-sample.config.v1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mt.Orig).To(Equal("application/vnd.oci.null-sample.config.v1"))
+		Expect(mt.Type).To(Equal("application/vnd.oci.null-sample.config.v1"))
+		Expect(mt.Format).To(Equal(mediatype.OCIConfigFormat))
+		Expect(mt.Version).To(gstruct.PointTo(Equal("v1")))
+		Expect(mt.FileFormat).To(BeNil())
+		Expect(mt.CompressionFormat).To(BeNil())
+	})
+
+	It("should parse a custom valid config media type", func() {
+		mt, err := mediatype.Parse("application/vnd.cncf.helm.chart.config.v1+json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mt.Orig).To(Equal("application/vnd.cncf.helm.chart.config.v1+json"))
+		Expect(mt.Type).To(Equal("application/vnd.cncf.helm.chart.config.v1"))
+		Expect(mt.FileFormat).To(gstruct.PointTo(Equal("json")))
+		Expect(mt.CompressionFormat).To(BeNil())
+	})
+
+	Context("Landscaper specifics", func() {
+		It("should parse a legacy blueprint layer type", func() {
+			mt, err := mediatype.Parse(mediatype.BlueprintArtifactsMediaTypeV0)
+			layerMT, err := mediatype.Parse(mediatype.BlueprintArtifactsLayerMediaTypeV1 + "+gzip")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mt).To(Equal(layerMT))
+		})
+
+		It("should parse a legacy jsonschema layer type", func() {
+			mt, err := mediatype.Parse(mediatype.JSONSchemaArtifactsMediaTypeV0)
+			newMT, err := mediatype.Parse(mediatype.JSONSchemaArtifactsMediaTypeV1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mt).To(Equal(newMT))
+		})
+	})
+})

--- a/apis/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/apis/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,110 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+
+A description function can be passed to Entry in place of the description. The function is then fed with the entry parameters to generate the description of the It corresponding to that particular Entry.
+
+For example:
+
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeNone)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeFocused)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, flag types.FlagType) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	global.Suite.PushContainerNode(
+		description,
+		func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		},
+		flag,
+		codelocation.New(2),
+	)
+}

--- a/apis/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/apis/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,129 @@
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description  interface{}
+	Parameters   []interface{}
+	Pending      bool
+	Focused      bool
+	codeLocation types.CodeLocation
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	var description string
+	descriptionValue := reflect.ValueOf(t.Description)
+	switch descriptionValue.Kind() {
+	case reflect.String:
+		description = descriptionValue.String()
+	case reflect.Func:
+		values := castParameters(descriptionValue, t.Parameters)
+		res := descriptionValue.Call(values)
+		if len(res) != 1 {
+			panic(fmt.Sprintf("The describe function should return only a value, returned %d", len(res)))
+		}
+		if res[0].Kind() != reflect.String {
+			panic(fmt.Sprintf("The describe function should return a string, returned %#v", res[0]))
+		}
+		description = res[0].String()
+	default:
+		panic(fmt.Sprintf("Description can either be a string or a function, got %#v", descriptionValue))
+	}
+
+	if t.Pending {
+		global.Suite.PushItNode(description, func() {}, types.FlagTypePending, t.codeLocation, 0)
+		return
+	}
+
+	values := castParameters(itBody, t.Parameters)
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		global.Suite.PushItNode(description, body, types.FlagTypeFocused, t.codeLocation, global.DefaultTimeout)
+	} else {
+		global.Suite.PushItNode(description, body, types.FlagTypeNone, t.codeLocation, global.DefaultTimeout)
+	}
+}
+
+func castParameters(function reflect.Value, parameters []interface{}) []reflect.Value {
+	res := make([]reflect.Value, len(parameters))
+	funcType := function.Type()
+	for i, param := range parameters {
+		if param == nil {
+			inType := funcType.In(i)
+			res[i] = reflect.Zero(inType)
+		} else {
+			res[i] = reflect.ValueOf(param)
+		}
+	}
+	return res
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      true,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}

--- a/apis/vendor/modules.txt
+++ b/apis/vendor/modules.txt
@@ -51,6 +51,7 @@ github.com/nxadm/tail/winfile
 ## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/internal/codelocation
 github.com/onsi/ginkgo/internal/containernode
 github.com/onsi/ginkgo/internal/failer

--- a/docs/technical/types.md
+++ b/docs/technical/types.md
@@ -21,8 +21,20 @@ Resource type refer to the type defined in a component descriptor.
     <tr>
         <td>Access</td>
         <td> 
-            localFilesystemBlob: <code>application/vnd.gardener.landscaper.blueprint.v1+tar+gzip</code> <br>
-            Standalone Artifact (ociRegistry): oci artifact with one layer of type <code>application/vnd.gardener.landscaper.blueprint.v1+tar+gzip</code>
+            localFilesystemBlob: 
+              <ul>
+                <li>DEPRECATED:<code>application/vnd.gardener.landscaper.blueprint.v1+tar+gzip</code></li>
+                <li><code>application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip</code></li>
+              </ul>
+ <br>
+            Standalone Artifact (ociRegistry): <br>
+            <i>Config</i><br>
+              <code>application/vnd.gardener.landscaper.blueprint.config.v1+yaml</code><br>
+            <i>One Layer</i> (the compression is optional)
+              <ul>
+                <li>DEPRECATED:<code>application/vnd.gardener.landscaper.blueprint.v1+tar+gzip</code></li>
+                <li><code>application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip</code></li>
+              </ul>
         </td>
     </tr>
 </table>
@@ -39,7 +51,7 @@ resources:
   access:
     type: localFilesystemBlob
     filename: my-bloc
-    mediaType: application/vnd.gardener.landscaper.blueprint.v1+tar+gzip
+    mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
 ```
 
 A blueprint blob is expected to be a gzipped tar that MUST contains the `blueprint.yaml` at the root.
@@ -47,21 +59,19 @@ A blueprint blob is expected to be a gzipped tar that MUST contains the `bluepri
 **Standalone Artifact**:
 
 The OCI manifest of the Blueprint in this case would look like this:
-Whereas the config is ignored and can be anything.
-It is recommended to use empty json to comply with most oci registry implementations.
-
+Whereas the config is contains the `blueprint.yaml`.
 ```json
 {
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "schemaVersion": 2, 
  "config": { 
    "digest": "sha256:efg",
-   "mediaType": "application/json"
+   "mediaType": "application/vnd.gardener.landscaper.blueprint.config.v1+yaml"
  },
  "layers": [
    {
      "digest": "sha256:efg",
-     "mediaType": "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
+     "mediaType": "application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip"
    }
  ]
 }
@@ -86,7 +96,11 @@ resources:
     <tr>
         <td>Access</td>
         <td> 
-            localFilesystemBlob: <code>application/vnd.gardener.landscaper.jsonscheme.v1+json</code> <br>
+            localFilesystemBlob:
+              <ul>
+                <li>DEPRECATED: <code>application/vnd.gardener.landscaper.jsonscheme.v1+json</code></li>
+                <li><code>application/vnd.gardener.landscaper.jsonschema.layer.v1.json</code></li>
+              </ul>
             Standalone Artifact (ociRegistry): not yet implemented
         </td>
     </tr>
@@ -104,7 +118,7 @@ resources:
   access:
     type: localFilesystemBlob
     filename: my-bloc
-    mediaType: application/vnd.gardener.landscaper.jsonscheme.v1+json
+    mediaType: application/vnd.gardener.landscaper.jsonschema.layer.v1.json
 ```
 
 

--- a/examples/01-simple/definitions/component-descriptor.yaml
+++ b/examples/01-simple/definitions/component-descriptor.yaml
@@ -25,4 +25,5 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	helm.sh/helm/v3 v3.2.4
 	k8s.io/api v0.20.2

--- a/pkg/landscaper/blueprints/blueprint.go
+++ b/pkg/landscaper/blueprints/blueprint.go
@@ -76,7 +76,10 @@ func (b *Blueprint) GetSubinstallations() ([]*lsv1alpha1.InstallationTemplate, e
 
 		coreInstTmpl := &core.InstallationTemplate{}
 		if _, _, err := api.Decoder.Decode(data, nil, coreInstTmpl); err != nil {
-			allErrs = append(allErrs, field.Invalid(instPath.Child("file"), subInstTmpl.File, fmt.Sprintf("unable to decode installation template: %s", err.Error())))
+			allErrs = append(allErrs, field.Invalid(
+				instPath.Child("file"),
+				subInstTmpl.File,
+				fmt.Sprintf("unable to decode installation template: %s", err.Error())))
 			continue
 		}
 		if valErrs := validation.ValidateInstallationTemplate(instPath, coreInstTmpl); len(valErrs) != 0 {

--- a/pkg/landscaper/blueprints/bputils/utils.go
+++ b/pkg/landscaper/blueprints/bputils/utils.go
@@ -16,6 +16,8 @@ import (
 	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
+	"github.com/gardener/landscaper/apis/mediatype"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/utils"
@@ -23,10 +25,10 @@ import (
 	"github.com/gardener/component-cli/ociclient/cache"
 )
 
-// BuildNewDefinition creates a ocispec Manifest from a component definition.
-func BuildNewDefinition(cache cache.Cache, fs vfs.FileSystem, path string) (*ocispecv1.Manifest, error) {
+// BuildNewBlueprint creates a ocispec Manifest from a component definition.
+func BuildNewBlueprint(cache cache.Cache, fs vfs.FileSystem, path string) (*ocispecv1.Manifest, error) {
 
-	config, err := BuildNewDefinitionConfig(cache, fs, path)
+	config, err := BuildNewBlueprintConfig(cache, fs, path)
 	if err != nil {
 		return nil, err
 	}
@@ -35,6 +37,7 @@ func BuildNewDefinition(cache cache.Cache, fs vfs.FileSystem, path string) (*oci
 	if err != nil {
 		return nil, err
 	}
+	defLayer.MediaType = mediatype.BlueprintArtifactsLayerMediaTypeV1
 
 	manifest := &ocispecv1.Manifest{
 		Versioned: specs.Versioned{SchemaVersion: 2},
@@ -47,8 +50,8 @@ func BuildNewDefinition(cache cache.Cache, fs vfs.FileSystem, path string) (*oci
 	return manifest, nil
 }
 
-// BuildNewDefinitionConfig creates a ocispec Manifest from a component definition.
-func BuildNewDefinitionConfig(cache cache.Cache, fs vfs.FileSystem, path string) (ocispecv1.Descriptor, error) {
+// BuildNewBlueprintConfig creates a ocispec Manifest from a component definition.
+func BuildNewBlueprintConfig(cache cache.Cache, fs vfs.FileSystem, path string) (ocispecv1.Descriptor, error) {
 	data, err := vfs.ReadFile(fs, filepath.Join(path, lsv1alpha1.BlueprintFileName))
 	if err != nil {
 		return ocispecv1.Descriptor{}, err
@@ -65,7 +68,7 @@ func BuildNewDefinitionConfig(cache cache.Cache, fs vfs.FileSystem, path string)
 	}
 
 	desc := ocispecv1.Descriptor{
-		MediaType: lsv1alpha1.BlueprintArtifactsMediaType,
+		MediaType: mediatype.BlueprintArtifactsConfigMediaTypeV1,
 		Digest:    digest.FromBytes(data),
 		Size:      int64(len(data)),
 	}

--- a/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
@@ -25,6 +25,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root
   - name: res-a
     type: blueprint
@@ -32,6 +33,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: a
   - name: res-b
     type: blueprint
@@ -39,6 +41,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: b
   - name: res-c
     type: blueprint
@@ -46,6 +49,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: c
   - name: res-d
     type: blueprint
@@ -53,4 +57,5 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: d

--- a/pkg/landscaper/installations/testdata/registry/component-descriptor.yaml
+++ b/pkg/landscaper/installations/testdata/registry/component-descriptor.yaml
@@ -25,6 +25,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root
   - name: root-2
     type: blueprint
@@ -32,6 +33,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root-2
   - name: root-3
     type: blueprint
@@ -39,6 +41,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root-3
   - name: res-a
     type: blueprint
@@ -46,6 +49,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: a
   - name: res-b
     type: blueprint
@@ -53,6 +57,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: b
   - name: res-c
     type: blueprint
@@ -60,6 +65,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: c
   - name: res-d
     type: blueprint
@@ -67,6 +73,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: d
   - name: res-e
     type: blueprint
@@ -74,6 +81,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: e
   - name: res-f
     type: blueprint
@@ -81,6 +89,7 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: f
   - name: root-cond
     type: blueprint
@@ -88,4 +97,5 @@ component:
     relation: local
     access:
       type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root-cond

--- a/pkg/landscaper/registry/components/blueprint.go
+++ b/pkg/landscaper/registry/components/blueprint.go
@@ -12,9 +12,9 @@ import (
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/ctf"
 
-	"github.com/gardener/component-cli/ociclient"
+	"github.com/gardener/landscaper/apis/mediatype"
 
-	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/component-cli/ociclient"
 )
 
 // BlueprintResolver is a blob resolver that can resolve
@@ -26,7 +26,7 @@ type BlueprintResolver struct {
 var _ ctf.TypedBlobResolver = &BlueprintResolver{}
 
 func (b BlueprintResolver) CanResolve(res cdv2.Resource) bool {
-	if res.GetType() != lsv1alpha1.BlueprintType && res.GetType() != lsv1alpha1.OldBlueprintType {
+	if res.GetType() != mediatype.BlueprintType && res.GetType() != mediatype.OldBlueprintType {
 		return false
 	}
 	return res.Access != nil && res.Access.GetType() == cdv2.OCIRegistryType

--- a/pkg/landscaper/registry/components/local.go
+++ b/pkg/landscaper/registry/components/local.go
@@ -89,7 +89,7 @@ func (c *localClient) Type() string {
 	return LocalRepositoryType
 }
 
-// Get resolves a reference and returns the component descriptor.
+// Resolve resolves a reference and returns the component descriptor.
 func (c *localClient) Resolve(_ context.Context, repoCtx cdv2.RepositoryContext, name, version string) (*cdv2.ComponentDescriptor, ctf.BlobResolver, error) {
 	if repoCtx.Type != LocalRepositoryType {
 		return nil, nil, fmt.Errorf("unsupported type %s expected %s", repoCtx.Type, LocalRepositoryType)
@@ -269,6 +269,9 @@ func (ca *LocalFilesystemBlobResolver) resolve(res cdv2.Resource) (*ctf.BlobInfo
 		return nil, nil, err
 	}
 	info.MediaType = res.Type
+	if len(localFSAccess.MediaType) != 0 {
+		info.MediaType = localFSAccess.MediaType
+	}
 	return info, file, nil
 }
 
@@ -277,7 +280,7 @@ type BaseFilesystemBlobResolver struct {
 	fs vfs.FileSystem
 }
 
-// ResolveFromFs
+// ResolveFromFs resolves a blob from a given path.
 func (res *BaseFilesystemBlobResolver) ResolveFromFs(blobpath string) (*ctf.BlobInfo, io.ReadCloser, error) {
 	info, err := res.fs.Stat(blobpath)
 	if err != nil {

--- a/pkg/utils/tar.go
+++ b/pkg/utils/tar.go
@@ -83,14 +83,9 @@ func BuildTar(fs vfs.FileSystem, root string, buf io.Writer) error {
 	return nil
 }
 
-// ExtractTarGzip extracts the content of a tar to the given filesystem with the given root base path
-func ExtractTarGzip(gzipStream io.Reader, fs vfs.FileSystem, root string) error {
-	uncompStream, err := gzip.NewReader(gzipStream)
-	if err != nil {
-		return err
-	}
-
-	tarReader := tar.NewReader(uncompStream)
+// ExtractTar extracts the content of a tar to the given filesystem with the given root base path
+func ExtractTar(tarStream io.Reader, fs vfs.FileSystem, root string) error {
+	tarReader := tar.NewReader(tarStream)
 	for {
 		header, err := tarReader.Next()
 		if err != nil {
@@ -123,6 +118,15 @@ func ExtractTarGzip(gzipStream io.Reader, fs vfs.FileSystem, root string) error 
 			}
 		}
 	}
+}
+
+// ExtractTarGzip extracts the content of a tar to the given filesystem with the given root base path
+func ExtractTarGzip(gzipStream io.Reader, fs vfs.FileSystem, root string) error {
+	uncompStream, err := gzip.NewReader(gzipStream)
+	if err != nil {
+		return err
+	}
+	return ExtractTar(uncompStream, fs, root)
 }
 
 // BuildTarGzipLayer tar and gzips the given path and adds the layer to the cache.

--- a/test/integration/core/registry.go
+++ b/test/integration/core/registry.go
@@ -25,6 +25,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/pointer"
 
+	"github.com/gardener/landscaper/apis/mediatype"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
@@ -166,7 +168,7 @@ func buildAndUploadComponentDescriptorWithArtifacts(ctx context.Context, f *fram
 	blueprintInput := input.BlobInput{
 		Type:             input.DirInputType,
 		Path:             blueprintDir,
-		MediaType:        lsv1alpha1.BlueprintArtifactsMediaType,
+		MediaType:        mediatype.NewBuilder(mediatype.BlueprintArtifactsLayerMediaTypeV1).Compression(mediatype.GZipCompression).String(),
 		CompressWithGzip: pointer.BoolPtr(true),
 	}
 	blob, err = blueprintInput.Read(osfs.New(), "")
@@ -179,7 +181,7 @@ func buildAndUploadComponentDescriptorWithArtifacts(ctx context.Context, f *fram
 	utils.ExpectNoError(file.Close())
 	utils.ExpectNoError(blob.Reader.Close())
 
-	cd.Resources = append(cd.Resources, buildLocalFilesystemResource("my-blueprint", lsv1alpha1.BlueprintType, input.MediaTypeGZip, "bp"))
+	cd.Resources = append(cd.Resources, buildLocalFilesystemResource("my-blueprint", mediatype.BlueprintType, blueprintInput.MediaType, "bp"))
 
 	utils.ExpectNoError(cdv2.DefaultComponent(cd))
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -17,7 +17,7 @@ const (
 	// LandscaperDMFinalizer is the finalizer of the landscaper deployer management.
 	LandscaperDMFinalizer = "finalizer.deployermanagement.landscaper.gardener.cloud"
 
-	// LandscaperAgentFinalizer is the finalizer of the landscaper agennt.
+	// LandscaperAgentFinalizer is the finalizer of the landscaper agent.
 	LandscaperAgentFinalizer = "finalizer.agent.landscaper.gardener.cloud"
 
 	// Annotations
@@ -54,18 +54,9 @@ const (
 
 	// Component Descriptor
 
-	// BlueprintType is the name of the blueprint type in a component descriptor.
-	BlueprintType = "landscaper.gardener.cloud/blueprint"
-
-	// OldBlueprintType is the old name of the blueprint type in a component descriptor.
-	OldBlueprintType = "blueprint"
+	// InlineComponentDescriptorLabel is the label name used for nested inline component descriptors
+	InlineComponentDescriptorLabel = "landscaper.gardener.cloud/component-descriptor"
 
 	// BlueprintFileName is the filename of a component definition on a local path
 	BlueprintFileName = "blueprint.yaml"
-
-	// BlueprintArtifactsMediaType is the reserved media type for a blueprint that is stored as its own artifact.
-	BlueprintArtifactsMediaType = "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
-
-	// InlineComponentDescriptorLabel is the label name used for nested inline component descriptors
-	InlineComponentDescriptorLabel = "landscaper.gardener.cloud/component-descriptor"
 )

--- a/vendor/github.com/gardener/landscaper/apis/mediatype/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/mediatype/constants.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mediatype
+
+const (
+	// BlueprintType is the name of the blueprint type in a component descriptor.
+	BlueprintType = "landscaper.gardener.cloud/blueprint"
+
+	// OldBlueprintType is the old name of the blueprint type in a component descriptor.
+	OldBlueprintType = "blueprint"
+
+	// BlueprintArtifactsMediaTypeV0 is the reserved media type for a blueprint that is stored as its own artifact.
+	// This is the legacy deprecated artifact media type that was used for the layer and the config type.
+	// Use BlueprintArtifactsConfigMediaTypeV1 or BlueprintArtifactsLayerMediaTypeV1 instead.
+	// DEPRECATED
+	BlueprintArtifactsMediaTypeV0 = "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
+
+	// BlueprintArtifactsConfigMediaTypeV1 is the config reserved media type for a blueprint that is stored as its own artifact.
+	// This describes the config media type of the blueprint artifact.
+	// The suffix can be yaml or json whereas yaml is the default.
+	BlueprintArtifactsConfigMediaTypeV1 = "application/vnd.gardener.landscaper.blueprint.config.v1"
+
+	// BlueprintArtifactsLayerMediaTypeV1 is the reserved layer media type for a blueprint that is stored as its own artifact.
+	// This describes the layer media type of the blueprint artifact as well as the media type of a localOciBlob.
+	// Optionally the compression can be added as "+gzip"
+	BlueprintArtifactsLayerMediaTypeV1 = "application/vnd.gardener.landscaper.blueprint.layer.v1.tar"
+
+	// JSONSchemaArtifactsMediaTypeV0 is the reserved media type for a jsonschema that is stored as layer in an oci artifact.
+	// This is the legacy deprecated artifact media type use JSONSchemaArtifactsMediaTypeV1 instead.
+	// DEPRECATED
+	JSONSchemaArtifactsMediaTypeV0 = "application/vnd.gardener.landscaper.jsonscheme.v1+json"
+
+	// JSONSchemaArtifactsMediaTypeV1 is the reserved media type for a jsonschema that is stored as layer in an oci artifact.
+	// This is the legacy deprecated artifact media type.
+	JSONSchemaArtifactsMediaTypeV1 = "application/vnd.gardener.landscaper.jsonschema.layer.v1.json"
+
+	// GZipCompression is the identifier for a gzip compressed file.
+	GZipCompression = "gzip"
+
+	// MediaTypeGZip defines the media type for a gzipped file
+	MediaTypeGZip = "application/gzip"
+)
+
+// DefaultMediaTypeConversions defines the default conversions for landscaper media types.
+func DefaultMediaTypeConversions(mediaType string) (convertedType string, converted bool, err error) {
+	switch mediaType {
+		case BlueprintArtifactsMediaTypeV0:
+			return NewBuilder(BlueprintArtifactsLayerMediaTypeV1).Compression(GZipCompression).String(), true, nil
+	case JSONSchemaArtifactsMediaTypeV0:
+		return JSONSchemaArtifactsMediaTypeV1, true, nil
+	}
+	return "", false, nil
+}

--- a/vendor/github.com/gardener/landscaper/apis/mediatype/mediatype.go
+++ b/vendor/github.com/gardener/landscaper/apis/mediatype/mediatype.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mediatype
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var InvalidTypeError = errors.New("INVALID_MEDIA_TYPE")
+
+type MediaTypeFormat string
+
+const (
+	DefaultFormat MediaTypeFormat = ""
+	OCIConfigFormat MediaTypeFormat  = "ociConfig"
+	OCILayerFormat MediaTypeFormat  = "ociLayer"
+)
+
+// MediaType describes a media type (formerly known as MIME type) defined by the IANA in THE RFC 2045.
+// In addition oci specific media types as defined in
+// https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#defining-layermediatypes are parsed.
+type MediaType struct {
+	// Orig contains the complete original type
+	Orig string
+	// Format describes the specific format of the media type
+	Format MediaTypeFormat
+	// Type contain the parsed type without suffix.
+	Type string
+	// Suffix contains the suffix of a media that is given after the "+"-char
+	Suffix *string
+
+	// Only valid for oci types
+
+	// Version describes the config or layer version.
+	Version *string
+	// FileFormat contains only the file format.
+	// This is part of the Type if the mediatype is not a ConfigType.
+	// If it is a ConfigType the FileFormat is not part of the type.
+	FileFormat *string
+	// CompressionFormat contains the optional compression format.
+	CompressionFormat *string
+}
+
+// String returns the string using the parsed type file and compression.
+func (t MediaType) String() string {
+	s := t.Type
+	if t.CompressionFormat !=  nil  && t.Suffix == nil {
+		t.Suffix = t.CompressionFormat
+	}
+	if t.Suffix != nil {
+		s = s + "+" + *t.Suffix
+	}
+	return s
+}
+
+// HasSuffix checks if the media type contains the given suffix.
+// if the given format is empty this functions only validates if a format is given
+func (t MediaType) HasSuffix(suffix string) bool {
+	if t.Suffix == nil {
+		return false
+	}
+	if len(suffix) == 0 {
+		return true
+	}
+	return *t.Suffix == suffix
+}
+
+// IsCompressed checks if the media type is compressed with the given format.
+// if the given format is empty this functions only validates if a compression is given
+func (t MediaType) IsCompressed(format string) bool {
+	if t.CompressionFormat == nil {
+
+		// try to parse the compression from the suffix or tree
+		if t.Suffix == nil {
+			return  false
+		}
+
+		return *t.Suffix == format
+	}
+	if len(format) == 0 {
+		return true
+	}
+	return *t.CompressionFormat == format
+}
+
+// HasFileFormat checks if the media type contains the given file format.
+// if the given format is empty this functions only validates if a format is given
+func (t MediaType) HasFileFormat(format string) bool {
+	if t.FileFormat == nil {
+		return false
+	}
+	if len(format) == 0 {
+		return true
+	}
+	return *t.FileFormat == format
+}
+
+// ConversionFunc describes a conversion func for a media type
+type ConversionFunc func(mediaType string) (convertedType string, converted bool, err error)
+
+// Parse parses a config and layer media type according to the oci spec.
+// Config:
+// [registration-tree].[org|company|entity].[objectType].[optional-subType].config.[version]+[optional-configFormat]
+// Layers:
+// [registration-tree].[org|company|entity].[layerType].[optional-layerSubType].layer.[version].[fileFormat]+[optional-compressionFormat]
+// Layers also allow any IANA media type
+//
+// https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#defining-layermediatypes
+//
+// This method is highly landscaper specific and can also handle legacy types that are automatically converted.
+func Parse(mediaType string, conversions ...ConversionFunc) (MediaType, error) {
+	for _, conversion := range append(conversions, DefaultMediaTypeConversions) {
+		converted, ok, err := conversion(mediaType)
+		if err != nil {
+			return MediaType{}, fmt.Errorf("error during conversion: %w", err)
+		}
+		if ok {
+			mediaType = converted
+		}
+	}
+
+	splitType := strings.Split(mediaType, "/")
+	if len(splitType) != 2 {
+		return MediaType{}, InvalidTypeError
+	}
+	mt := MediaType{
+		Orig: mediaType,
+		Type: mediaType,
+	}
+	t := splitType[0]
+	tree := splitType[1]
+
+	if suffixIndex := strings.Index(mediaType, "+"); suffixIndex > -1 {
+		mt.Suffix = strPtr(mediaType[suffixIndex+1:])
+		mt.Type = mediaType[:suffixIndex]
+		tree = mediaType[len(mediaType)-len(tree) : suffixIndex]
+	}
+
+	if t != "application" {
+		mt.Type = mediaType
+		mt.FileFormat = strPtr(tree)
+		return mt, nil
+	}
+
+	// try to detect config or layer type
+	splitType = strings.Split(tree, ".")
+
+
+	if len(splitType) > 2 && splitType[len(splitType)-2] == "config" {
+		mt.Format = OCIConfigFormat
+		mt.FileFormat = mt.Suffix
+		mt.Version = strPtr(splitType[len(splitType)-1])
+	} else if len(splitType) > 3 && splitType[len(splitType)-3] == "layer" {
+		mt.Format =  OCILayerFormat
+		mt.FileFormat = strPtr(splitType[len(splitType)-1])
+		mt.Version = strPtr(splitType[len(splitType)-2])
+	}
+
+	return mt, nil
+}
+
+// Builder is a media type builder
+type Builder struct {
+	Type MediaType
+}
+
+// NewBuilder creates a new media type builder.
+func NewBuilder(t string) *Builder {
+	return &Builder{
+		MediaType{
+			Orig:              "",
+			Type:              t,
+			Format: DefaultFormat,
+			Version: nil,
+			FileFormat:        nil,
+			CompressionFormat: nil,
+		},
+	}
+}
+
+// Compression sets the compression format
+func (b *Builder) Compression(comp string) *Builder {
+	b.Type.CompressionFormat = &comp
+	b.Type.Suffix  = &comp
+	return b
+}
+
+// FileFormat sets the file format of the media type.
+// Will be automatically parsed from the type if it is not a config type.
+func (b *Builder) FileFormat(format string) *Builder {
+	b.Type.FileFormat = &format
+	b.Type.Suffix  = &format
+	return b
+}
+
+// IsConfigType configures the media type as oci config.
+func (b *Builder) IsConfigType() *Builder {
+	b.Type.Format = OCIConfigFormat
+	return b
+}
+
+// IsLayerType configures the media type as oci layer.
+func (b *Builder) IsLayerType() *Builder {
+	b.Type.Format = OCILayerFormat
+	return b
+}
+
+// Build builds the mediatype
+func (b *Builder) Build() MediaType {
+	return b.Type
+}
+
+// String returns the media type as string
+func (b *Builder) String() string {
+	return b.Build().String()
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,6 +108,7 @@ github.com/gardener/landscaper/apis/deployer/manifest/validation
 github.com/gardener/landscaper/apis/deployer/mock
 github.com/gardener/landscaper/apis/deployer/mock/install
 github.com/gardener/landscaper/apis/deployer/mock/v1alpha1
+github.com/gardener/landscaper/apis/mediatype
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/go-logr/logr v0.3.0
@@ -370,6 +371,7 @@ golang.org/x/net/idna
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20201112073958-5cba982894dd


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area oci
/kind technical-debt
/priority 3

**What this PR does / why we need it**:

This PR updates the blueprint media types to conform with the oci spec.

It is now also possible to create non-compressed blueprints by omitting the `+gzip` suffix.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/217

**Special notes for your reviewer**:

cc @enrico-kaack-comp @jschicktanz if something needs to be adjusted in the transport tool and the landscaper-cli

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The Landscaper used media types in oci artifacts are updated to conform with the OCI specification.

The old types are still supported but make sure to update your types as soon as possible.
- `application/vnd.gardener.landscaper.blueprint.v1+tar+gzip` -> `application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip`
- `application/vnd.gardener.landscaper.jsonscheme.v1+json` -> `application/vnd.gardener.landscaper.jsonschema.layer.v1.json`
```
