### PR TITLE
Fix helm chart

### DIFF
--- a/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/templates/_helpers.tpl
@@ -113,8 +113,9 @@ crdManagement:
     {{- end }}
 {{- end }}
 
-{{- if .Values.landscaper.deployerManagement -}}
-{{ toYaml .Values.landscaper.deployerManagement }}
+{{- if .Values.landscaper.deployerManagement }}
+deployerManagement:
+{{ toYaml .Values.landscaper.deployerManagement | indent 2 }}
 {{- end -}}
 
 {{- if .Values.landscaper.deployItemTimeouts }}

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -207,7 +207,7 @@ Componenten reference has been overwritten:
 		cond = lsv1alpha1helper.UpdatedCondition(cond,
 			lsv1alpha1.ConditionFalse,
 			"No overwrite defined",
-			"component refernece has not been overwritten")
+			"component reference has not been overwritten")
 	}
 	inst.Status.Conditions = lsv1alpha1helper.MergeConditions(inst.Status.Conditions, cond)
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 2

**What this PR does / why we need it**:
Fixes a templating error in the helm chart and a small typo in an error message.
The templating error causes the rendered landscaper-config secret to contain an invalid configuration if the `landscaper.deployerManagement` field is specified in the values file, which prevents the landscaper from starting.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
