### PR TITLE
Typed import/export definitions

### DIFF
--- a/.landscaper/container-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/container-deployer/blueprint/blueprint.yaml
@@ -3,25 +3,32 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: landscaperCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
   required: false
 - name: releaseName
+  type: data
   schema:
     type: string
 - name: releaseNamespace
+  type: data
   schema:
     type: string
 - name: identity
+  type: data
   required: false
   schema:
     type: string
 - name: values
+  type: data
   schema:
     description: "values for the container-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/container-deployer/values.yaml`"
     type: object
 - name: targetSelectors
+  type: data
   required: false
   schema:
     type: array

--- a/.landscaper/helm-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/helm-deployer/blueprint/blueprint.yaml
@@ -3,25 +3,32 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: landscaperCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
   required: false
 - name: releaseName
+  type: data
   schema:
     type: string
 - name: releaseNamespace
+  type: data
   schema:
     type: string
 - name: identity
+  type: data
   required: false
   schema:
     type: string
 - name: values
+  type: data
   schema:
     description: "values for the helm-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/helm-deployer/values.yaml`"
     type: object
 - name: targetSelectors
+  type: data
   required: false
   schema:
     type: array

--- a/.landscaper/manifest-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/manifest-deployer/blueprint/blueprint.yaml
@@ -3,25 +3,32 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: landscaperCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
   required: false
 - name: releaseName
+  type: data
   schema:
     type: string
 - name: releaseNamespace
+  type: data
   schema:
     type: string
 - name: identity
+  type: data
   required: false
   schema:
     type: string
 - name: values
+  type: data
   schema:
     description: "values for the manifest-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/manifest-deployer/values.yaml`"
     type: object
 - name: targetSelectors
+  type: data
   required: false
   schema:
     type: array

--- a/.landscaper/mock-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/mock-deployer/blueprint/blueprint.yaml
@@ -3,25 +3,32 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: landscaperCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
   required: false
 - name: releaseName
+  type: data
   schema:
     type: string
 - name: releaseNamespace
+  type: data
   schema:
     type: string
 - name: identity
+  type: data
   required: false
   schema:
     type: string
 - name: values
+  type: data
   schema:
     description: "values for the mock-deployer Helm Chart. See `https://github.com/gardener/landscaper/blob/master/charts/mock-deployer/values.yaml`"
     type: object
 - name: targetSelectors
+  type: data
   required: false
   schema:
     type: array

--- a/apis/.schemes/core-v1alpha1-Blueprint.json
+++ b/apis/.schemes/core-v1alpha1-Blueprint.json
@@ -118,6 +118,10 @@
         "targetType": {
           "description": "TargetType defines the type of the imported target.",
           "type": "string"
+        },
+        "type": {
+          "description": "Type specifies which kind of object is being exported. This field should be set and will likely be mandatory in future.",
+          "type": "string"
         }
       }
     },
@@ -156,6 +160,10 @@
         },
         "targetType": {
           "description": "TargetType defines the type of the imported target.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type specifies which kind of object is being imported. This field should be set and will likely be mandatory in future.",
           "type": "string"
         }
       }

--- a/apis/core/types_blueprint.go
+++ b/apis/core/types_blueprint.go
@@ -11,6 +11,14 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+type ImportType string
+type ExportType string
+
+const ImportTypeData = ImportType("data")
+const ImportTypeTarget = ImportType("target")
+const ExportTypeData = ExportType(ImportTypeData)
+const ExportTypeTarget = ExportType(ImportTypeTarget)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -67,6 +75,11 @@ type ImportDefinitionList []ImportDefinition
 type ImportDefinition struct {
 	FieldValueDefinition `json:",inline"`
 
+	// Type specifies which kind of object is being imported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ImportType `json:"type,omitempty"`
+
 	// Required specifies whether the import is required for the component to run.
 	// Defaults to true.
 	// +optional
@@ -89,6 +102,11 @@ type ExportDefinitionList []ExportDefinition
 // ExportDefinition defines a exported value
 type ExportDefinition struct {
 	FieldValueDefinition `json:",inline"`
+
+	// Type specifies which kind of object is being exported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ExportType `json:"type,omitempty"`
 }
 
 // FieldValueDefinition defines a im- or exported field.

--- a/apis/core/types_blueprint.go
+++ b/apis/core/types_blueprint.go
@@ -11,12 +11,22 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+// ImportType is a string alias
 type ImportType string
+
+// ExportType is a string alias
 type ExportType string
 
+// ImportTypeData is the import type for data imports
 const ImportTypeData = ImportType("data")
+
+// ImportTypeTarget is the import type for target imports
 const ImportTypeTarget = ImportType("target")
+
+// ExportTypeData is the export type for data exports
 const ExportTypeData = ExportType(ImportTypeData)
+
+// ExportTypeTarget is the export type for target exports
 const ExportTypeTarget = ExportType(ImportTypeTarget)
 
 // +genclient

--- a/apis/core/v1alpha1/defaults.go
+++ b/apis/core/v1alpha1/defaults.go
@@ -38,6 +38,10 @@ func SetDefaults_DefinitionImport(imports *ImportDefinitionList) {
 			// type is already set
 			continue
 		}
+		if imp.Schema != nil && len(imp.TargetType) != 0 {
+			// definition is invalid
+			continue
+		}
 		if imp.Schema != nil {
 			imp.Type = ImportTypeData
 		} else if len(imp.TargetType) != 0 {
@@ -55,6 +59,10 @@ func SetDefaults_DefinitionExport(exports *ExportDefinitionList) {
 		exp := &(*exports)[i]
 		if len(exp.Type) != 0 {
 			// type is already set
+			continue
+		}
+		if exp.Schema != nil && len(exp.TargetType) != 0 {
+			// definition is invalid
 			continue
 		}
 		if exp.Schema != nil {

--- a/apis/core/v1alpha1/defaults.go
+++ b/apis/core/v1alpha1/defaults.go
@@ -19,15 +19,49 @@ func SetDefaults_Blueprint(obj *Blueprint) {
 		obj.JSONSchemaVersion = "https://json-schema.org/draft/2019-09/schema"
 	}
 
-	for i := range obj.Imports {
-		SetDefaults_DefinitionImport(&(obj.Imports[i]))
-	}
+	SetDefaults_DefinitionImport(&obj.Imports)
+	SetDefaults_DefinitionExport(&obj.Exports)
 }
 
 // SetDefaults_DefinitionImport sets default values for the ImportDefinition objects
-func SetDefaults_DefinitionImport(obj *ImportDefinition) {
-	if obj.Required == nil {
-		obj.Required = pointer.BoolPtr(true)
+func SetDefaults_DefinitionImport(imports *ImportDefinitionList) {
+	if imports == nil {
+		return
+	}
+	for i := 0; i < len(*imports); i++ {
+		imp := &(*imports)[i]
+		if imp.Required == nil {
+			imp.Required = pointer.BoolPtr(true)
+		}
+		SetDefaults_DefinitionImport(&imp.ConditionalImports)
+		if len(imp.Type) != 0 {
+			// type is already set
+			continue
+		}
+		if imp.Schema != nil {
+			imp.Type = ImportTypeData
+		} else if len(imp.TargetType) != 0 {
+			imp.Type = ImportTypeTarget
+		}
+	}
+}
+
+// SetDefaults_DefinitionExport sets default values for the ImportDefinition objects
+func SetDefaults_DefinitionExport(exports *ExportDefinitionList) {
+	if exports == nil {
+		return
+	}
+	for i := 0; i < len(*exports); i++ {
+		exp := &(*exports)[i]
+		if len(exp.Type) != 0 {
+			// type is already set
+			continue
+		}
+		if exp.Schema != nil {
+			exp.Type = ExportTypeData
+		} else if len(exp.TargetType) != 0 {
+			exp.Type = ExportTypeTarget
+		}
 	}
 }
 

--- a/apis/core/v1alpha1/types_blueprint.go
+++ b/apis/core/v1alpha1/types_blueprint.go
@@ -11,6 +11,14 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+type ImportType string
+type ExportType string
+
+const ImportTypeData = ImportType("data")
+const ImportTypeTarget = ImportType("target")
+const ExportTypeData = ExportType(ImportTypeData)
+const ExportTypeTarget = ExportType(ImportTypeTarget)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -68,6 +76,11 @@ type ImportDefinitionList []ImportDefinition
 type ImportDefinition struct {
 	FieldValueDefinition `json:",inline"`
 
+	// Type specifies which kind of object is being imported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ImportType `json:"type,omitempty"`
+
 	// Required specifies whether the import is required for the component to run.
 	// Defaults to true.
 	// +optional
@@ -88,6 +101,11 @@ type ExportDefinitionList []ExportDefinition
 // ExportDefinition defines a exported value
 type ExportDefinition struct {
 	FieldValueDefinition `json:",inline"`
+
+	// Type specifies which kind of object is being exported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ExportType `json:"type,omitempty"`
 }
 
 // FieldValueDefinition defines a im- or exported field.

--- a/apis/core/v1alpha1/types_blueprint.go
+++ b/apis/core/v1alpha1/types_blueprint.go
@@ -11,12 +11,22 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+// ImportType is a string alias
 type ImportType string
+
+// ExportType is a string alias
 type ExportType string
 
+// ImportTypeData is the import type for data imports
 const ImportTypeData = ImportType("data")
+
+// ImportTypeTarget is the import type for target imports
 const ImportTypeTarget = ImportType("target")
+
+// ExportTypeData is the export type for data exports
 const ExportTypeData = ExportType(ImportTypeData)
+
+// ExportTypeTarget is the export type for target exports
 const ExportTypeTarget = ExportType(ImportTypeTarget)
 
 // +genclient

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1794,6 +1794,7 @@ func autoConvert_v1alpha1_ExportDefinition_To_core_ExportDefinition(in *ExportDe
 	if err := Convert_v1alpha1_FieldValueDefinition_To_core_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = core.ExportType(in.Type)
 	return nil
 }
 
@@ -1806,6 +1807,7 @@ func autoConvert_core_ExportDefinition_To_v1alpha1_ExportDefinition(in *core.Exp
 	if err := Convert_core_FieldValueDefinition_To_v1alpha1_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = ExportType(in.Type)
 	return nil
 }
 
@@ -1842,6 +1844,7 @@ func autoConvert_v1alpha1_ImportDefinition_To_core_ImportDefinition(in *ImportDe
 	if err := Convert_v1alpha1_FieldValueDefinition_To_core_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = core.ImportType(in.Type)
 	out.Required = (*bool)(unsafe.Pointer(in.Required))
 	if err := Convert_v1alpha1_Default_To_core_Default(&in.Default, &out.Default, s); err != nil {
 		return err
@@ -1859,6 +1862,7 @@ func autoConvert_core_ImportDefinition_To_v1alpha1_ImportDefinition(in *core.Imp
 	if err := Convert_core_FieldValueDefinition_To_v1alpha1_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = ImportType(in.Type)
 	out.Required = (*bool)(unsafe.Pointer(in.Required))
 	if err := Convert_core_Default_To_v1alpha1_Default(&in.Default, &out.Default, s); err != nil {
 		return err

--- a/apis/core/validation/blueprint.go
+++ b/apis/core/validation/blueprint.go
@@ -24,6 +24,7 @@ var landscaperScheme = runtime.NewScheme()
 
 func init() {
 	coreinstall.Install(landscaperScheme)
+	relevantConfigFields = computeRelevantConfigFields()
 }
 
 // ValidateBlueprint validates a Blueprint
@@ -153,8 +154,7 @@ func ValidateBlueprintExportDefinitions(fldPath *field.Path, exports []core.Expo
 func validateMutuallyExclusiveConfig(fldPath *field.Path, def interface{}, expectedConfigs []string, defType string) field.ErrorList {
 	allErrs := field.ErrorList{}
 	val := reflect.ValueOf(def)
-	rcf := relevantConfigFields()
-	for key := range rcf {
+	for key := range relevantConfigFields {
 		var f reflect.Value
 		if _, ok := isFieldValueDefinition[key]; ok {
 			f = val.FieldByName("FieldValueDefinition")

--- a/apis/core/validation/blueprint.go
+++ b/apis/core/validation/blueprint.go
@@ -22,47 +22,6 @@ import (
 
 var landscaperScheme = runtime.NewScheme()
 
-var importTypesWithExpectedConfig = map[string][]string{
-	string(core.ImportTypeData):   {"Schema"},
-	string(core.ImportTypeTarget): {"TargetType"},
-}
-var exportTypesWithExpectedConfig = map[string][]string{
-	string(core.ExportTypeData):   {"Schema"},
-	string(core.ExportTypeTarget): {"TargetType"},
-}
-
-// isFieldValueDefinition lists the fields which are not directly part of an Import/ExportDefinition, but of the FieldValueDefinition
-// (usually the fields which are present in both import and export definitions)
-// This is required for the reflection used below
-// a map is used for easier 'contains' queries, the values are ignored
-var isFieldValueDefinition = map[string]bool{
-	"Schema":     true,
-	"TargetType": true,
-}
-
-func keys(m map[string][]string) []string {
-	res := make([]string, len(m))
-	for k := range m {
-		res = append(res, string(k))
-	}
-	return res
-}
-
-func relevantConfigFields() map[string]bool {
-	res := map[string]bool{}
-	for _, v := range importTypesWithExpectedConfig {
-		for _, e := range v {
-			res[e] = true
-		}
-	}
-	for _, v := range exportTypesWithExpectedConfig {
-		for _, e := range v {
-			res[e] = true
-		}
-	}
-	return res
-}
-
 func init() {
 	coreinstall.Install(landscaperScheme)
 }

--- a/apis/core/validation/helper.go
+++ b/apis/core/validation/helper.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import "github.com/gardener/landscaper/apis/core"
+
+var importTypesWithExpectedConfig = map[string][]string{
+	string(core.ImportTypeData):   {"Schema"},
+	string(core.ImportTypeTarget): {"TargetType"},
+}
+var exportTypesWithExpectedConfig = map[string][]string{
+	string(core.ExportTypeData):   {"Schema"},
+	string(core.ExportTypeTarget): {"TargetType"},
+}
+
+// isFieldValueDefinition lists the fields which are not directly part of an Import/ExportDefinition, but of the FieldValueDefinition
+// (usually the fields which are present in both import and export definitions)
+// This is required for the reflection used below
+// a map is used for easier 'contains' queries, the values are ignored
+var isFieldValueDefinition = map[string]bool{
+	"Schema":     true,
+	"TargetType": true,
+}
+
+// keys returns all keys of a map as a slice
+func keys(m map[string][]string) []string {
+	res := make([]string, len(m))
+	for k := range m {
+		res = append(res, string(k))
+	}
+	return res
+}
+
+// relevantConfigFields returns the union of the values of importTypesWithExpectedConfig and exportTypesWithExpectedConfig
+// This is used to detect if a config field is set which should not be set for the specified type.
+func relevantConfigFields() map[string]bool {
+	res := map[string]bool{}
+	for _, v := range importTypesWithExpectedConfig {
+		for _, e := range v {
+			res[e] = true
+		}
+	}
+	for _, v := range exportTypesWithExpectedConfig {
+		for _, e := range v {
+			res[e] = true
+		}
+	}
+	return res
+}

--- a/apis/core/validation/helper.go
+++ b/apis/core/validation/helper.go
@@ -15,6 +15,8 @@ var exportTypesWithExpectedConfig = map[string][]string{
 	string(core.ExportTypeTarget): {"TargetType"},
 }
 
+var relevantConfigFields map[string]bool
+
 // isFieldValueDefinition lists the fields which are not directly part of an Import/ExportDefinition, but of the FieldValueDefinition
 // (usually the fields which are present in both import and export definitions)
 // This is required for the reflection used below
@@ -33,9 +35,10 @@ func keys(m map[string][]string) []string {
 	return res
 }
 
-// relevantConfigFields returns the union of the values of importTypesWithExpectedConfig and exportTypesWithExpectedConfig
+// computeRelevantConfigFields returns the union of the values of importTypesWithExpectedConfig and exportTypesWithExpectedConfig
+// as a map[string]bool for easier 'contains' queries. The value will always be set to 'true'.
 // This is used to detect if a config field is set which should not be set for the specified type.
-func relevantConfigFields() map[string]bool {
+func computeRelevantConfigFields() map[string]bool {
 	res := map[string]bool{}
 	for _, v := range importTypesWithExpectedConfig {
 		for _, e := range v {

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -3753,6 +3753,13 @@ func schema_landscaper_apis_core_v1alpha1_ExportDefinition(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type specifies which kind of object is being exported. This field should be set and will likely be mandatory in future.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -3823,6 +3830,13 @@ func schema_landscaper_apis_core_v1alpha1_ImportDefinition(ref common.ReferenceC
 					"targetType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TargetType defines the type of the imported target.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type specifies which kind of object is being imported. This field should be set and will likely be mandatory in future.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2834,8 +2834,31 @@ FieldValueDefinition
 </p>
 </td>
 </tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ExportType">
+ExportType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type specifies which kind of object is being exported.
+This field should be set and will likely be mandatory in future.</p>
+</td>
+</tr>
 </tbody>
 </table>
+<h3 id="landscaper.gardener.cloud/v1alpha1.ExportType">ExportType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ExportDefinition">ExportDefinition</a>)
+</p>
+<p>
+</p>
 <h3 id="landscaper.gardener.cloud/v1alpha1.FieldValueDefinition">FieldValueDefinition
 </h3>
 <p>
@@ -2921,6 +2944,21 @@ FieldValueDefinition
 <p>
 (Members of <code>FieldValueDefinition</code> are embedded into this type.)
 </p>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ImportType">
+ImportType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Type specifies which kind of object is being imported.
+This field should be set and will likely be mandatory in future.</p>
 </td>
 </tr>
 <tr>
@@ -3091,6 +3129,14 @@ string
 </p>
 <p>
 <p>ImportStatusType defines the type of a import status.</p>
+</p>
+<h3 id="landscaper.gardener.cloud/v1alpha1.ImportType">ImportType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ImportDefinition">ImportDefinition</a>)
+</p>
+<p>
 </p>
 <h3 id="landscaper.gardener.cloud/v1alpha1.InlineBlueprint">InlineBlueprint
 </h3>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2858,6 +2858,7 @@ This field should be set and will likely be mandatory in future.</p>
 <a href="#landscaper.gardener.cloud/v1alpha1.ExportDefinition">ExportDefinition</a>)
 </p>
 <p>
+<p>ExportType is a string alias</p>
 </p>
 <h3 id="landscaper.gardener.cloud/v1alpha1.FieldValueDefinition">FieldValueDefinition
 </h3>
@@ -3137,6 +3138,7 @@ string
 <a href="#landscaper.gardener.cloud/v1alpha1.ImportDefinition">ImportDefinition</a>)
 </p>
 <p>
+<p>ImportType is a string alias</p>
 </p>
 <h3 id="landscaper.gardener.cloud/v1alpha1.InlineBlueprint">InlineBlueprint
 </h3>

--- a/docs/level_0/first_example_component.md
+++ b/docs/level_0/first_example_component.md
@@ -68,6 +68,7 @@ kind: Blueprint
 
 imports:                                                   # (1)
 - name: target-cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster 
 
 deployExecutions:                                          # (2)

--- a/docs/level_0/resources/blueprint/blueprint.yaml
+++ b/docs/level_0/resources/blueprint/blueprint.yaml
@@ -3,6 +3,7 @@ kind: Blueprint
 
 imports:
 - name: target-cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 deployExecutions:

--- a/docs/proposals/Inputs.md
+++ b/docs/proposals/Inputs.md
@@ -55,25 +55,30 @@ localTypes:
 
 imports:
 - name: A
+  type: data
   schema:
     "$schema": "https://json-schema.org/draft/2019-09/schema" # optional, defaulted to .jsonSchema
     type: string
   optional: false
 - name: B
+  type: data
   schema:
     $ref: "blueprint://types/gcp-credentials" # read file from blueprint content
   optional: false
 - name: C 
+  type: data
   schema:
     $ref: "local://aws-credentials"
   optional: false
 - name: D
+  type: data
   schema:
     $ref: "cd:///componentReferences/etcd/resources/my-type" # path in component descriptor
   optional: false
 
 exports:
 - name: key1
+  type: data
   version: v1 # optional; defaults to "v1"
   schema:
     "$schema": "https://json-schema.org/draft/2019-09/schema" # optional, defaulted to .jsonSchema

--- a/docs/proposals/input-blueprint.yaml
+++ b/docs/proposals/input-blueprint.yaml
@@ -13,25 +13,30 @@ localTypes:
 
 imports:
 - name: A
+  type: data
   schema:
     "$schema": "https://json-schema.org/draft/2019-09/schema" # optional, defaulted to .jsonSchema
     type: string[]
   optional: false
 - name: B
+  type: data
   schema:
     $ref: "blueprint://types/gcp-credentials" # read file from blueprint content
   optional: false
 - name: C
+  type: data
   schema:
     $ref: "local://aws-credentials"
   optional: false
 - name: D
+  type: data
   schema:
     $ref: "cd:///componentReferences/etcd/resources/my-type" # path in component descriptor
   optional: false
 
 exports:
 - name: key1
+  type: data
   version: v1 # optional; defaults to "v1"
   schema:
     "$schema": "https://json-schema.org/draft/2019-09/schema" # optional, defaulted to .jsonSchema

--- a/docs/technical/deployer_contract.md
+++ b/docs/technical/deployer_contract.md
@@ -166,20 +166,26 @@ kind: Blueprint
 
 imports:
 - name: cluster # target to the host cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: landscaperCluster # target to the cluster running the landscaper resources.
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
   required: false
 - name: releaseName
+  type: data
   schema:
     type: string
 - name: releaseNamespace
+  type: data
   schema: 
     type: string
 - name: identity
+  type: data
   schema:
     type: string
 - name: targetSelectors # defaulted to the "landscaper.gardener.cloud/environment" annotation
+  type: data
   schema:
     type: array
     items:

--- a/docs/tutorials/01-create-simple-blueprint.md
+++ b/docs/tutorials/01-create-simple-blueprint.md
@@ -209,6 +209,7 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 deployExecutions:
@@ -247,6 +248,7 @@ exportExecutions:
 
 exports:
 - name: ingressClass
+  type: data
   schema: # here comes a valid jsonschema
     type: string
 ```

--- a/docs/tutorials/03-simple-import.md
+++ b/docs/tutorials/03-simple-import.md
@@ -45,11 +45,14 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: namespace
+  type: data
   schema:
     type: string
 - name: ingressClass
+  type: data
   schema:
     type: string
 

--- a/docs/tutorials/04-aggregated-blueprint.md
+++ b/docs/tutorials/04-aggregated-blueprint.md
@@ -39,13 +39,16 @@ kind: Blueprint
 
 imports:
 - name: aggCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: aggNamespace
+  type: data
   schema:
     type: string
 
 exports:
 - name: aggIngressClass
+  type: data
   schema:
     type: string
 ```
@@ -161,13 +164,16 @@ kind: Blueprint
 
 imports:
 - name: aggCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: aggNamespace
+  type: data
   schema:
     type: string
 
 exports:
 - name: aggIngressClass
+  type: data
   schema:
     type: string
 

--- a/docs/tutorials/05-external-jsonschema.md
+++ b/docs/tutorials/05-external-jsonschema.md
@@ -186,11 +186,14 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: ingressClass
+  type: data
   schema:
     type: string
 - name: resources
+  type: data
   schema:
     $ref: "cd://componentReferences/definitions/resources/resources-definition"
 

--- a/docs/tutorials/resources/aggregated/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/aggregated/blueprint/blueprint.yaml
@@ -11,13 +11,16 @@ kind: Blueprint
 
 imports:
 - name: aggCluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: aggNamespace
+  type: data
   schema:
     type: string
 
 exports:
 - name: aggIngressClass
+  type: data
   schema:
     type: string
 

--- a/docs/tutorials/resources/echo-server/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/echo-server/blueprint/blueprint.yaml
@@ -11,11 +11,14 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: namespace
+  type: data
   schema:
     type: string
 - name: ingressClass
+  type: data
   schema:
     type: string
 

--- a/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/external-jsonschema/echo-server/blueprint/blueprint.yaml
@@ -11,11 +11,14 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 - name: ingressClass
+  type: data
   schema:
     type: string
 - name: resources
+  type: data
   schema:
     $ref: "cd://componentReferences/definitions/resources/resources-definition"
 

--- a/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
@@ -11,9 +11,11 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 - name: namespace
+  type: data
   schema:
     type: string
 
@@ -53,5 +55,6 @@ exportExecutions:
 
 exports:
 - name: ingressClass
+  type: data
   schema:
     type: string

--- a/docs/tutorials/resources/local-ingress-nginx/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/blueprint/blueprint.yaml
@@ -7,9 +7,11 @@ kind: Blueprint
 
 imports:
 - name: cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 - name: namespace
+  type: data
   schema:
     type: string
 
@@ -50,5 +52,6 @@ exportExecutions:
 
 exports:
 - name: ingressClass
+  type: data
   schema:
     type: string

--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -59,11 +59,13 @@ imports:
 # as jsonschema.
 - name: my-import-key
   required: true # required, defaults to true
+  type: data # this is a data import
   schema: # expects a jsonschema
     type: string
 # Import a target by specifying the targetType
 - name: my-target-import-key
   required: true # required, defaults to true
+  type: target # this is a target import
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 # exports defines all values that are produced by the blueprint
@@ -74,10 +76,12 @@ exports:
 # Export a data object by specifying the expected structure of data
 # as jsonschema.
 - name: my-export-key
+  type: data # this is a data export
   schema: # expects a jsonschema
     type: string
 # Export a target by specifying the targetType
 - name: my-target-export-key
+  type: target # this is a target export
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 # deployExecutions are a templating mechanism to 
@@ -137,12 +141,15 @@ The interface of a blueprint can be described using imports and exports.<br>
 The import definitions describe the data that needed by the blueprint.<br>
 The export definitions describe the data that is produced by the blueprint.<br>
 
-Imports and Exports always consists of a name (_MUST_ be unique for the blueprint) and can be generally described as _Target_-Im/Exports or _Data_-Im/Exports.
+Imports and Exports always consists of a name (_MUST_ be unique for the blueprint) and can be generally described as _Target_-Im/Exports or _Data_-Im/Exports. The `type` field specifies which one it is.
+
+> The `type` field is currently optional to ensure backward compatibility. This is likely to change in the future and it is strongly recommended to specify a type for each im-/export.
 
 ```yaml
 imports:
 - name: <string> # some unique name
   required: <boolean> # defaults to true
+  type: <data|target> # type of the imported object
 ```
 
 :warning: in the following data import and target import is used as synonym for import and export. The specification applies to both.
@@ -159,11 +166,14 @@ It is recommended to provide a description and an example for the structure, so 
 ```yaml
 imports:
 - name: my-import
+  type: data
   schema:
     <jsonschema>
 ```
 
 For detailed information about the jsonschema and landscaper specifics see [JSONSchema Docs](./JSONSchema.md)
+
+Data im-/exports have the type `data`.
 
 #### Targets
 
@@ -176,8 +186,11 @@ The configuration structure of targets is defined by their type (currently the t
 ```yaml
 imports:
 - name: my-import
+  type: target
   targetType: <string> # name of the target type
 ```
+
+Target im-/exports have the type `target`.
 
 ### DeployExecutions
 

--- a/docs/usage/Installations.md
+++ b/docs/usage/Installations.md
@@ -357,14 +357,17 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 imports:
 - name: providers
+  type: data
   schema:
     type: array
     items:
       type: string
 - name: identifier
+  type: data
   schema:
     type: string
 - name: aws-credentials
+  type: data
   schema:
     type: object
     properties:
@@ -496,9 +499,11 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 exports:
 - name: identifier
+  type: data
   schema:
     type: string
 - name: aws-credentials
+  type: data
   schema:
     type: object
     properties:
@@ -507,6 +512,7 @@ exports:
       accessKeySecret:
         type: string
 - name: gcp-credentials
+  type: data
   schema:
     type: object
     properties:

--- a/docs/usage/JSONSchema.md
+++ b/docs/usage/JSONSchema.md
@@ -32,9 +32,11 @@ localTypes:
     
 imports:
 - name: my-import
+  type: data
   schema:
     $ref: "local://myType"
 - name: my-other-import
+  type: data
   schema:
     type: object
     properties:
@@ -77,6 +79,7 @@ kind: Blueprint
     
 imports:
 - name: my-import
+  type: data
   schema:
     $ref: "blueprint://definitions/my-type.json"
 ```

--- a/docs/usage/LandscaperCli.md
+++ b/docs/usage/LandscaperCli.md
@@ -70,9 +70,11 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 imports:
 - name: myFirstImport
+  type: data
   schema:
     type: string
 - name: mySecondImport
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 ```
 ```

--- a/examples/01-simple/definitions/blobs/root/blueprint.yaml
+++ b/examples/01-simple/definitions/blobs/root/blueprint.yaml
@@ -11,11 +11,13 @@ annotations:
 
 imports:
 - name: imp-a
+  type: data
   schema:
     type: string
 
 exports:
 - name: exp-a
+  type: data
   schema:
     type: string
 

--- a/examples/02-inline-cd/cluster/01-root-1.yaml
+++ b/examples/02-inline-cd/cluster/01-root-1.yaml
@@ -44,10 +44,12 @@ spec:
           kind: Blueprint
           imports:
           - name: imp-a
+            type: data
             schema:
               type: string
           exports:
           - name: exp-a
+            type: data
             schema:
               type: string
           deployExecutions:

--- a/examples/10-Example-Blueprint.yaml
+++ b/examples/10-Example-Blueprint.yaml
@@ -9,23 +9,27 @@ jsonSchemaVersion: ""
 
 imports:
 - name: dnsControllerClass | common.dnsControllerClass
+  type: data
   schema:
     type: string
   default:
     value: ""
 #      ref: common.dnsControllerClass # tbd
 - name: abc
+  type: data
   schema:
     type: number
 
 exports:
 - name: a.b
+  type: data
   schema:
     type: object
     properties:
       mykey:
         type: string
-- key: ijk
+- name: ijk
+  type: data
   schema:
     type: number
 

--- a/examples/components/00-installations/configuration.yaml
+++ b/examples/components/00-installations/configuration.yaml
@@ -17,6 +17,7 @@ spec:
 
           exports:
           - name: providers
+            type: data
             schema:
               type: array
               $ref: ref to provider credentials

--- a/examples/components/aggregated/blueprint/blueprint.yaml
+++ b/examples/components/aggregated/blueprint/blueprint.yaml
@@ -9,29 +9,35 @@ jsonSchema: "https://json-schema.org/draft/2019-09/schema" # required
 
 imports:
 - name: aws-dev-account-credentials
+  type: data
   schema:
     $ref: cd://componentReferences/schemas/resources/schemas#definitions/provider # maybe cd://componentReferences/dns/componentReferences/schemas/resources/schemas#definitions/provider
 
 - name: gcp-dev-account-credentials
+  type: data
   schema:
     $ref: cd://componentReferences/schemas/resources/schemas#definitions/provider # maybe cd://componentReferences/dns/componentReferences/schemas/resources/schemas#definitions/provider
 
 - name: dnsClass
+  type: data
   required: false
   schema:
     type: string
 
 - name: namespace
+  type: data
   default:
     value: kube-system
   schema:
     type: string
 
 - name: dev-cluster
+  type: target
   targetType: kubernetes-cluster
 
 exports:
 - name: exported-cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 

--- a/examples/components/external-dns-management/blueprint/blueprint.yaml
+++ b/examples/components/external-dns-management/blueprint/blueprint.yaml
@@ -9,6 +9,7 @@ jsonSchema: "https://json-schema.org/draft/2019-09/schema" # required
 
 imports:
 - name: providers
+  type: data
   required: false
   schema:
     type: array
@@ -16,23 +17,27 @@ imports:
       $ref: cd://componentReferences/schemas/resources/schemas#definitions/provider # cd://componentReferences/github.com/gardener/external-dns-management-schemas/resources/schemas#definitions/provider
 
 - name: dnsClass
+  type: data
   required: false
   schema:
     type: string
 
 - name: identifier
+  type: data
   required: false
   example: ... # optional
   schema:
     description: ""
     type: string
 - name: namespace
+  type: data
   default:
     value: kube-system
   schema:
     type: string
 
 - name: cluster
+  type: target
   targetType: landscaper.cloud/kubernetes-cluster # schema definition
   subTypes:
     - gardener
@@ -40,10 +45,12 @@ imports:
 
 exports:
 - name: dnsClass
+  type: data
   schema:
     type: string
 
 - name: myTarget
+  type: target
   targetType: landscaper.cloud/kubernetes-cluster
 
 # List of deploy item generators

--- a/examples/components/nginx-ingress/blueprint/blueprint.yaml
+++ b/examples/components/nginx-ingress/blueprint/blueprint.yaml
@@ -18,20 +18,24 @@ localTypes:
 
 imports:
 - name: dnsClass
+  type: data
   required: false
   schema:
     type: string
 
 - name: namespace
+  type: data
   default:
     value: kube-system
   schema:
     type: string
 
 - name: cluster
+  type: target
   targetType: kubernetes-cluster
 
 - name: resources
+  type: data
   required: false
   schema:
     type: object
@@ -43,10 +47,12 @@ imports:
 
 exports:
 - name: ingressClass
+  type: data
   schema:
     type: string
 
 - name: exported-cluster
+  type: target
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 # List of deploy item generators

--- a/pkg/deployer/container/init/testdata/02-di-inline-blueprint.yaml
+++ b/pkg/deployer/container/init/testdata/02-di-inline-blueprint.yaml
@@ -9,10 +9,12 @@ blueprint:
         kind: Blueprint
         imports:
         - name: imp-a
+          type: data
           schema:
             type: string
         exports:
         - name: exp-a
+          type: data
           schema:
             type: string
         exportExecutions:

--- a/pkg/deployer/container/init/testdata/04-di-inline-bp-no-cd.yaml
+++ b/pkg/deployer/container/init/testdata/04-di-inline-bp-no-cd.yaml
@@ -9,10 +9,12 @@ blueprint:
         kind: Blueprint
         imports:
         - name: imp-a
+          type: data
           schema:
             type: string
         exports:
         - name: exp-a
+          type: data
           schema:
             type: string
         exportExecutions:

--- a/pkg/deployer/container/init/testdata/05-di-inline-bp-inline-cd.yaml
+++ b/pkg/deployer/container/init/testdata/05-di-inline-bp-inline-cd.yaml
@@ -9,10 +9,12 @@ blueprint:
         kind: Blueprint
         imports:
         - name: imp-a
+          type: data
           schema:
             type: string
         exports:
         - name: exp-a
+          type: data
           schema:
             type: string
         exportExecutions:

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/a/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/a/blueprint.yaml
@@ -11,10 +11,12 @@ annotations:
 
 imports:
 - name: a.b
+  type: data
   schema:
     type: string
 
 exports:
 - name: a.z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/b/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/b/blueprint.yaml
@@ -11,10 +11,12 @@ annotations:
 
 imports:
 - name: b.a
+  type: data
   schema:
     type: string
 
 exports:
 - name: b.z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/c/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/c/blueprint.yaml
@@ -11,12 +11,16 @@ annotations:
 
 imports:
 - name: c.a
+  type: data
   schema:
     type: string
 - name: c.b
+  type: data
   schema:
     type: string
 
 exports:
-- key: c.z
-  type: string
+- name: c.z
+  type: data
+  schema:
+    type: string

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/d/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/d/blueprint.yaml
@@ -11,13 +11,16 @@ annotations:
 
 imports:
 - name: d.a
+  type: data
   schema:
     type: string
 - name: d.b
+  type: data
   schema:
     type: string
 
 exports:
 - name: d.z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/root/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/root/blueprint.yaml
@@ -11,14 +11,17 @@ annotations:
 
 imports:
 - name: root.a
+  type: data
   schema:
     type: string
 
 exports:
 - name: root.y
+  type: data
   schema:
     type: string
 - name: root.z
+  type: data
   schema:
     type: string
 

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -474,16 +474,19 @@ func (o *Operation) createOrUpdateImports(ctx context.Context, importDefs lsv1al
 			}
 		}
 
-		if len(importDef.TargetType) != 0 {
+		switch importDef.Type {
+		case lsv1alpha1.ImportTypeData:
+			if err := o.createOrUpdateDataImport(ctx, src, importDef, importData); err != nil {
+				return fmt.Errorf("unable to create or update data import '%s': %w", importDef.Name, err)
+			}
+		case lsv1alpha1.ImportTypeTarget:
 			if err := o.createOrUpdateTargetImport(ctx, src, importDef, importData); err != nil {
 				return fmt.Errorf("unable to create or update target import '%s': %w", importDef.Name, err)
 			}
-			continue
+		default:
+			return fmt.Errorf("unknown import type '%s' for import %s", string(importDef.Type), importDef.Name)
 		}
 
-		if err := o.createOrUpdateDataImport(ctx, src, importDef, importData); err != nil {
-			return fmt.Errorf("unable to create or update data import '%s': %w", importDef.Name, err)
-		}
 	}
 	return nil
 }

--- a/pkg/landscaper/installations/operation_test.go
+++ b/pkg/landscaper/installations/operation_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Operation", func() {
 						Name:       "my-import",
 						TargetType: "test-type",
 					},
+					Type: lsv1alpha1.ImportTypeTarget,
 				},
 			}
 			op.Inst.Imports = map[string]interface{}{

--- a/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root1.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root1.yaml
@@ -11,6 +11,7 @@ annotations:
 
 imports:
 - name: b
+  type: data
   schema:
     type: string
 

--- a/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root2.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root2.yaml
@@ -11,6 +11,7 @@ annotations:
 
 imports:
 - name: b
+  type: data
   schema:
     type: string
 

--- a/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root4.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root4.yaml
@@ -11,6 +11,7 @@ annotations:
 
 imports:
 - name: b
+  type: data
   schema:
     type: string
 

--- a/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root5.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/01-root/blueprint-root5.yaml
@@ -11,6 +11,7 @@ annotations:
 
 imports:
 - name: b
+  type: data
   schema:
     type: string
 

--- a/pkg/landscaper/installations/subinstallations/testdata/02-def1/blueprint.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/02-def1/blueprint.yaml
@@ -11,10 +11,12 @@ annotations:
 
 imports:
 - name: "y"
+  type: data
   schema:
     type: string
 
 exports:
 - name: z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/installations/subinstallations/testdata/03-def2/blueprint.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/03-def2/blueprint.yaml
@@ -11,10 +11,12 @@ annotations:
 
 imports:
 - name: "e"
+  type: data
   schema:
     type: string
 
 exports:
 - name: f
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/installations/testdata/registry/blobs/a/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/a/blueprint.yaml
@@ -11,10 +11,12 @@ annotations:
 
 imports:
 - name: a.b
+  type: data
   schema:
     type: string
 
 exports:
 - name: a.z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/installations/testdata/registry/blobs/b/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/b/blueprint.yaml
@@ -11,10 +11,12 @@ annotations:
 
 imports:
 - name: b.a
+  type: data
   schema:
     type: string
 
 exports:
 - name: b.z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/installations/testdata/registry/blobs/c/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/c/blueprint.yaml
@@ -11,12 +11,16 @@ annotations:
 
 imports:
 - name: c.a
+  type: data
   schema:
     type: string
 - name: c.b
+  type: data
   schema:
     type: string
 
 exports:
-- key: c.z
-  type: string
+- name: c.z
+  type: data
+  schema:
+    type: string

--- a/pkg/landscaper/installations/testdata/registry/blobs/d/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/d/blueprint.yaml
@@ -11,13 +11,16 @@ annotations:
 
 imports:
 - name: d.a
+  type: data
   schema:
     type: string
 - name: d.b
+  type: data
   schema:
     type: string
 
 exports:
 - name: d.z
+  type: data
   schema:
     type: string

--- a/pkg/landscaper/installations/testdata/registry/blobs/e/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/e/blueprint.yaml
@@ -11,4 +11,5 @@ annotations:
 
 exports:
 - name: e.z
+  type: target
   targetType: landscaper.gardener.cloud/mock

--- a/pkg/landscaper/installations/testdata/registry/blobs/f/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/f/blueprint.yaml
@@ -11,4 +11,5 @@ annotations:
 
 imports:
 - name: f.a
+  type: target
   targetType: landscaper.gardener.cloud/mock

--- a/pkg/landscaper/installations/testdata/registry/blobs/root-2/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/root-2/blueprint.yaml
@@ -11,8 +11,10 @@ annotations:
 
 exports:
 - name: root.y
+  type: target
   targetType: landscaper.gardener.cloud/mock
 - name: root.z
+  type: target
   targetType: landscaper.gardener.cloud/mock
 
 exportExecutions:

--- a/pkg/landscaper/installations/testdata/registry/blobs/root-3/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/root-3/blueprint.yaml
@@ -11,4 +11,5 @@ annotations:
 
 imports:
 - name: root.a
+  type: target
   targetType: landscaper.gardener.cloud/mock

--- a/pkg/landscaper/installations/testdata/registry/blobs/root-cond/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/root-cond/blueprint.yaml
@@ -11,11 +11,13 @@ annotations:
 
 imports:
 - name: rootcond.foo
+  type: data
   required: false
   schema:
     type: string
   imports:
   - name: rootcond.bar
+    type: data
     schema:
       type: string
 
@@ -50,14 +52,17 @@ subinstallations:
                   kind: ProviderStatus
         imports:
         - name: internalFoo
+          type: data
           required: false
           schema:
             type: string
         - name: internalBar
+          type: data
           required: false
           schema:
             type: string
         - name: internalBaz
+          type: data
           required: false
           schema:
             type: string
@@ -92,5 +97,6 @@ subinstallations:
               internalBaz: baz
         exports:
         - name: internalBaz
+          type: data
           schema:
             type: string

--- a/pkg/landscaper/installations/testdata/registry/blobs/root/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/root/blueprint.yaml
@@ -11,14 +11,17 @@ annotations:
 
 imports:
 - name: root.a
+  type: data
   schema:
     type: string
 
 exports:
 - name: root.y
+  type: data
   schema:
     type: string
 - name: root.z
+  type: data
   schema:
     type: string
 

--- a/pkg/utils/landscaper/blueprint.go
+++ b/pkg/utils/landscaper/blueprint.go
@@ -276,14 +276,15 @@ func ValidateImports(bp *blueprints.Blueprint,
 			}
 			continue
 		}
-		if importDef.Schema != nil {
+		switch importDef.Type {
+		case lsv1alpha1.ImportTypeData:
 			if err := jsonschemaValidator.ValidateGoStruct(importDef.Schema.RawMessage, value); err != nil {
 				allErr = append(allErr, field.Invalid(
 					fldPath,
 					value,
 					fmt.Sprintf("invalid imported value: %s", err.Error())))
 			}
-		} else {
+		case lsv1alpha1.ImportTypeTarget:
 			// import is a target import
 			targetObj, ok := value.(map[string]interface{})
 			if !ok {
@@ -305,6 +306,8 @@ func ValidateImports(bp *blueprints.Blueprint,
 					fmt.Sprintf("expected target type to be %q but got %q", importDef.TargetType, targetType)))
 				continue
 			}
+		default:
+			allErr = append(allErr, field.Invalid(fldPath, string(importDef.Type), "unknown import type"))
 		}
 	}
 

--- a/vendor/github.com/gardener/landscaper/apis/core/types_blueprint.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_blueprint.go
@@ -11,6 +11,14 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+type ImportType string
+type ExportType string
+
+const ImportTypeData = ImportType("data")
+const ImportTypeTarget = ImportType("target")
+const ExportTypeData = ExportType(ImportTypeData)
+const ExportTypeTarget = ExportType(ImportTypeTarget)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -67,6 +75,11 @@ type ImportDefinitionList []ImportDefinition
 type ImportDefinition struct {
 	FieldValueDefinition `json:",inline"`
 
+	// Type specifies which kind of object is being imported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ImportType `json:"type,omitempty"`
+
 	// Required specifies whether the import is required for the component to run.
 	// Defaults to true.
 	// +optional
@@ -89,6 +102,11 @@ type ExportDefinitionList []ExportDefinition
 // ExportDefinition defines a exported value
 type ExportDefinition struct {
 	FieldValueDefinition `json:",inline"`
+
+	// Type specifies which kind of object is being exported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ExportType `json:"type,omitempty"`
 }
 
 // FieldValueDefinition defines a im- or exported field.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_blueprint.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_blueprint.go
@@ -11,12 +11,22 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+// ImportType is a string alias
 type ImportType string
+
+// ExportType is a string alias
 type ExportType string
 
+// ImportTypeData is the import type for data imports
 const ImportTypeData = ImportType("data")
+
+// ImportTypeTarget is the import type for target imports
 const ImportTypeTarget = ImportType("target")
+
+// ExportTypeData is the export type for data exports
 const ExportTypeData = ExportType(ImportTypeData)
+
+// ExportTypeTarget is the export type for target exports
 const ExportTypeTarget = ExportType(ImportTypeTarget)
 
 // +genclient

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -38,6 +38,10 @@ func SetDefaults_DefinitionImport(imports *ImportDefinitionList) {
 			// type is already set
 			continue
 		}
+		if imp.Schema != nil && len(imp.TargetType) != 0 {
+			// definition is invalid
+			continue
+		}
 		if imp.Schema != nil {
 			imp.Type = ImportTypeData
 		} else if len(imp.TargetType) != 0 {
@@ -55,6 +59,10 @@ func SetDefaults_DefinitionExport(exports *ExportDefinitionList) {
 		exp := &(*exports)[i]
 		if len(exp.Type) != 0 {
 			// type is already set
+			continue
+		}
+		if exp.Schema != nil && len(exp.TargetType) != 0 {
+			// definition is invalid
 			continue
 		}
 		if exp.Schema != nil {

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -19,15 +19,49 @@ func SetDefaults_Blueprint(obj *Blueprint) {
 		obj.JSONSchemaVersion = "https://json-schema.org/draft/2019-09/schema"
 	}
 
-	for i := range obj.Imports {
-		SetDefaults_DefinitionImport(&(obj.Imports[i]))
-	}
+	SetDefaults_DefinitionImport(&obj.Imports)
+	SetDefaults_DefinitionExport(&obj.Exports)
 }
 
 // SetDefaults_DefinitionImport sets default values for the ImportDefinition objects
-func SetDefaults_DefinitionImport(obj *ImportDefinition) {
-	if obj.Required == nil {
-		obj.Required = pointer.BoolPtr(true)
+func SetDefaults_DefinitionImport(imports *ImportDefinitionList) {
+	if imports == nil {
+		return
+	}
+	for i := 0; i < len(*imports); i++ {
+		imp := &(*imports)[i]
+		if imp.Required == nil {
+			imp.Required = pointer.BoolPtr(true)
+		}
+		SetDefaults_DefinitionImport(&imp.ConditionalImports)
+		if len(imp.Type) != 0 {
+			// type is already set
+			continue
+		}
+		if imp.Schema != nil {
+			imp.Type = ImportTypeData
+		} else if len(imp.TargetType) != 0 {
+			imp.Type = ImportTypeTarget
+		}
+	}
+}
+
+// SetDefaults_DefinitionExport sets default values for the ImportDefinition objects
+func SetDefaults_DefinitionExport(exports *ExportDefinitionList) {
+	if exports == nil {
+		return
+	}
+	for i := 0; i < len(*exports); i++ {
+		exp := &(*exports)[i]
+		if len(exp.Type) != 0 {
+			// type is already set
+			continue
+		}
+		if exp.Schema != nil {
+			exp.Type = ExportTypeData
+		} else if len(exp.TargetType) != 0 {
+			exp.Type = ExportTypeTarget
+		}
 	}
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_blueprint.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_blueprint.go
@@ -11,6 +11,14 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+type ImportType string
+type ExportType string
+
+const ImportTypeData = ImportType("data")
+const ImportTypeTarget = ImportType("target")
+const ExportTypeData = ExportType(ImportTypeData)
+const ExportTypeTarget = ExportType(ImportTypeTarget)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -68,6 +76,11 @@ type ImportDefinitionList []ImportDefinition
 type ImportDefinition struct {
 	FieldValueDefinition `json:",inline"`
 
+	// Type specifies which kind of object is being imported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ImportType `json:"type,omitempty"`
+
 	// Required specifies whether the import is required for the component to run.
 	// Defaults to true.
 	// +optional
@@ -88,6 +101,11 @@ type ExportDefinitionList []ExportDefinition
 // ExportDefinition defines a exported value
 type ExportDefinition struct {
 	FieldValueDefinition `json:",inline"`
+
+	// Type specifies which kind of object is being exported.
+	// This field should be set and will likely be mandatory in future.
+	// +optional
+	Type ExportType `json:"type,omitempty"`
 }
 
 // FieldValueDefinition defines a im- or exported field.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_blueprint.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_blueprint.go
@@ -11,12 +11,22 @@ import (
 // BlueprintResourceType is the name of the blueprint resource defined in component descriptors.
 const BlueprintResourceType = "blueprint"
 
+// ImportType is a string alias
 type ImportType string
+
+// ExportType is a string alias
 type ExportType string
 
+// ImportTypeData is the import type for data imports
 const ImportTypeData = ImportType("data")
+
+// ImportTypeTarget is the import type for target imports
 const ImportTypeTarget = ImportType("target")
+
+// ExportTypeData is the export type for data exports
 const ExportTypeData = ExportType(ImportTypeData)
+
+// ExportTypeTarget is the export type for target exports
 const ExportTypeTarget = ExportType(ImportTypeTarget)
 
 // +genclient

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1794,6 +1794,7 @@ func autoConvert_v1alpha1_ExportDefinition_To_core_ExportDefinition(in *ExportDe
 	if err := Convert_v1alpha1_FieldValueDefinition_To_core_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = core.ExportType(in.Type)
 	return nil
 }
 
@@ -1806,6 +1807,7 @@ func autoConvert_core_ExportDefinition_To_v1alpha1_ExportDefinition(in *core.Exp
 	if err := Convert_core_FieldValueDefinition_To_v1alpha1_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = ExportType(in.Type)
 	return nil
 }
 
@@ -1842,6 +1844,7 @@ func autoConvert_v1alpha1_ImportDefinition_To_core_ImportDefinition(in *ImportDe
 	if err := Convert_v1alpha1_FieldValueDefinition_To_core_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = core.ImportType(in.Type)
 	out.Required = (*bool)(unsafe.Pointer(in.Required))
 	if err := Convert_v1alpha1_Default_To_core_Default(&in.Default, &out.Default, s); err != nil {
 		return err
@@ -1859,6 +1862,7 @@ func autoConvert_core_ImportDefinition_To_v1alpha1_ImportDefinition(in *core.Imp
 	if err := Convert_core_FieldValueDefinition_To_v1alpha1_FieldValueDefinition(&in.FieldValueDefinition, &out.FieldValueDefinition, s); err != nil {
 		return err
 	}
+	out.Type = ImportType(in.Type)
 	out.Required = (*bool)(unsafe.Pointer(in.Required))
 	if err := Convert_core_Default_To_v1alpha1_Default(&in.Default, &out.Default, s); err != nil {
 		return err

--- a/vendor/github.com/gardener/landscaper/apis/core/validation/blueprint.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/validation/blueprint.go
@@ -24,6 +24,7 @@ var landscaperScheme = runtime.NewScheme()
 
 func init() {
 	coreinstall.Install(landscaperScheme)
+	relevantConfigFields = computeRelevantConfigFields()
 }
 
 // ValidateBlueprint validates a Blueprint
@@ -153,8 +154,7 @@ func ValidateBlueprintExportDefinitions(fldPath *field.Path, exports []core.Expo
 func validateMutuallyExclusiveConfig(fldPath *field.Path, def interface{}, expectedConfigs []string, defType string) field.ErrorList {
 	allErrs := field.ErrorList{}
 	val := reflect.ValueOf(def)
-	rcf := relevantConfigFields()
-	for key := range rcf {
+	for key := range relevantConfigFields {
 		var f reflect.Value
 		if _, ok := isFieldValueDefinition[key]; ok {
 			f = val.FieldByName("FieldValueDefinition")

--- a/vendor/github.com/gardener/landscaper/apis/core/validation/blueprint.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/validation/blueprint.go
@@ -22,47 +22,6 @@ import (
 
 var landscaperScheme = runtime.NewScheme()
 
-var importTypesWithExpectedConfig = map[string][]string{
-	string(core.ImportTypeData):   {"Schema"},
-	string(core.ImportTypeTarget): {"TargetType"},
-}
-var exportTypesWithExpectedConfig = map[string][]string{
-	string(core.ExportTypeData):   {"Schema"},
-	string(core.ExportTypeTarget): {"TargetType"},
-}
-
-// isFieldValueDefinition lists the fields which are not directly part of an Import/ExportDefinition, but of the FieldValueDefinition
-// (usually the fields which are present in both import and export definitions)
-// This is required for the reflection used below
-// a map is used for easier 'contains' queries, the values are ignored
-var isFieldValueDefinition = map[string]bool{
-	"Schema":     true,
-	"TargetType": true,
-}
-
-func keys(m map[string][]string) []string {
-	res := make([]string, len(m))
-	for k := range m {
-		res = append(res, string(k))
-	}
-	return res
-}
-
-func relevantConfigFields() map[string]bool {
-	res := map[string]bool{}
-	for _, v := range importTypesWithExpectedConfig {
-		for _, e := range v {
-			res[e] = true
-		}
-	}
-	for _, v := range exportTypesWithExpectedConfig {
-		for _, e := range v {
-			res[e] = true
-		}
-	}
-	return res
-}
-
 func init() {
 	coreinstall.Install(landscaperScheme)
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/validation/helper.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/validation/helper.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import "github.com/gardener/landscaper/apis/core"
+
+var importTypesWithExpectedConfig = map[string][]string{
+	string(core.ImportTypeData):   {"Schema"},
+	string(core.ImportTypeTarget): {"TargetType"},
+}
+var exportTypesWithExpectedConfig = map[string][]string{
+	string(core.ExportTypeData):   {"Schema"},
+	string(core.ExportTypeTarget): {"TargetType"},
+}
+
+// isFieldValueDefinition lists the fields which are not directly part of an Import/ExportDefinition, but of the FieldValueDefinition
+// (usually the fields which are present in both import and export definitions)
+// This is required for the reflection used below
+// a map is used for easier 'contains' queries, the values are ignored
+var isFieldValueDefinition = map[string]bool{
+	"Schema":     true,
+	"TargetType": true,
+}
+
+// keys returns all keys of a map as a slice
+func keys(m map[string][]string) []string {
+	res := make([]string, len(m))
+	for k := range m {
+		res = append(res, string(k))
+	}
+	return res
+}
+
+// relevantConfigFields returns the union of the values of importTypesWithExpectedConfig and exportTypesWithExpectedConfig
+// This is used to detect if a config field is set which should not be set for the specified type.
+func relevantConfigFields() map[string]bool {
+	res := map[string]bool{}
+	for _, v := range importTypesWithExpectedConfig {
+		for _, e := range v {
+			res[e] = true
+		}
+	}
+	for _, v := range exportTypesWithExpectedConfig {
+		for _, e := range v {
+			res[e] = true
+		}
+	}
+	return res
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/validation/helper.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/validation/helper.go
@@ -15,6 +15,8 @@ var exportTypesWithExpectedConfig = map[string][]string{
 	string(core.ExportTypeTarget): {"TargetType"},
 }
 
+var relevantConfigFields map[string]bool
+
 // isFieldValueDefinition lists the fields which are not directly part of an Import/ExportDefinition, but of the FieldValueDefinition
 // (usually the fields which are present in both import and export definitions)
 // This is required for the reflection used below
@@ -33,9 +35,10 @@ func keys(m map[string][]string) []string {
 	return res
 }
 
-// relevantConfigFields returns the union of the values of importTypesWithExpectedConfig and exportTypesWithExpectedConfig
+// computeRelevantConfigFields returns the union of the values of importTypesWithExpectedConfig and exportTypesWithExpectedConfig
+// as a map[string]bool for easier 'contains' queries. The value will always be set to 'true'.
 // This is used to detect if a config field is set which should not be set for the specified type.
-func relevantConfigFields() map[string]bool {
+func computeRelevantConfigFields() map[string]bool {
 	res := map[string]bool{}
 	for _, v := range importTypesWithExpectedConfig {
 		for _, e := range v {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind api-change
/priority 2

**What this PR does / why we need it**:
Currently, data and target import definitions in a blueprint are distinguished by whether the `schema` or `targetType` field is specified. However, we plan on adding a few more types and the implicit distinction gets uglier with every new one, therefore we decided to add a `type` field which explicitly states the type of the import.

For backwards compatibility, we cannot make the field mandatory, as this would break all existing blueprints. Thus, the `type` field is optional for now, but will likely become mandatory with the next big api-change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
A `type` field has been added to import and export definitions in blueprints. To preserve backward compatibility, it is currently optional. However, this is expected to change in the future, therefore it is strongly recommended to treat it as mandatory and always set it. Have a look at the [Blueprint documentation](docs/usage/Blueprints.md) for further information.
```
