### PR TITLE
Update docs

### DIFF
--- a/cmd/landscaper-webhooks-server/app/options.go
+++ b/cmd/landscaper-webhooks-server/app/options.go
@@ -68,8 +68,8 @@ func NewOptions() *options {
 
 func (o *options) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&o.port, "port", 9443, "Specify the port of the webhook server")
-	fs.StringVar(&o.webhookServiceNamespaceName, "webhook-service", "", "Specify namespace and name of the webhook service (format: <namespace>/<name>)")
 	fs.StringVar(&o.disabledWebhooks, "disable-webhooks", "", "Specify validation webhooks that should be disabled ('all' to disable validation completely)")
+	fs.StringVar(&o.webhookServiceNamespaceName, "webhook-service", "", "Specify namespace and name of the webhook service (format: <namespace>/<name>)")
 	fs.Int32Var(&o.webhookServicePort, "webhook-service-port", 9443, "Specify the port of the webhook service")
 	logger.InitFlags(fs)
 

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -110,10 +110,11 @@ cd landscaper
 #### Run the Landscaper
 
 When the Kubernetes cluster is running, start the Landscaper controller with the cluster's kubeconfig.
-The controller must be started without any webhooks as they can only be used inside the cluster.
+The webhooks for validation, mutation and conversion are not included in the Landscaper binary for scalability and availability reasons.
+See [Run Webhook Server](#run-the-landscaper-webhook-server) to see how webhooks can be tested.
 
 ```bash
-go run ./cmd/landscaper-controller --disable-webhooks=all --kubeconfig=$KUBECONFIG
+go run ./cmd/landscaper-controller --kubeconfig=$KUBECONFIG
 ```
 
 (Optional) Configure the landscaper controller
@@ -136,3 +137,17 @@ crdManagement:
   deployCrd: true
   forceUpdate: true
 ```
+
+#### Run the Landscaper Webhook Server
+
+The webhooks for validation, mutation and conversion are served by a specific webhook server that can be found in [cmd/landscaper-webhooks-server](../../cmd/landscaper-webhooks-server).
+
+It can be simply started with 
+```bash
+go run ./cmd/landscaper-webhooks-server --kubeconfig=$KUBECONFIG --port=9443
+```
+
+> Note: The webhook server automatically registers the needed webhooks in the k8s cluster using the flags `--webhook-service` `--webhook-service-port` which should point to a service that is backed by the webhook server.
+
+Specific webhooks for resources can be disabled using the flag `--disable-webhooks=installations,deployitems,...`
+

--- a/docs/gettingstarted/install-landscaper-controller.md
+++ b/docs/gettingstarted/install-landscaper-controller.md
@@ -27,8 +27,9 @@ Landscaper's Helm chart can be configured with a values file.
 
 In case of an OCI registry that is not exposed via https, the `allowPlainHttpRegistries` flag can be used.
 
-Landscaper offloads all deployment specific functionality like deploying Helm charts to deployers.
-For a very simple setup, internal deployers (`helm`, `manifest` and `container`) can be served by the landscaper-controller (but observe the **warining** below).
+> Note: Landscaper offloads all deployment specific functionality like deploying Helm charts to deployers.
+> By default, the Landscaper deployment contains no deployer so you are unable to reconcile any deploy items. 
+> But a subset of internal open-source deployers (`helm`, `manifest` and `container`) can be automatically configured. See [below](#internal-and-external-deployers) for more details.
 
 ## Configuration through `values.yaml`
 

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -91,6 +91,9 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
 	if err := dm.createDeployerTarget(ctx, inst, registration, env); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/priority 3

**What this PR does / why we need it**:

Fixed a bug in the deployer registration where an error is not catched and could lead to misleading errors.

Alos updated some minor issues in the docs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
