### PR TITLE
add event recorder and report all errors by default

### DIFF
--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package helper
+package errors
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 )
 
 // Error is a wrapper around the landscaper crd error
-// that implements the go error interface
+// that implements the go error interface.
 type Error struct {
 	lsErr lsv1alpha1.Error
 	err   error
@@ -88,8 +88,8 @@ func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.Erro
 	}
 }
 
-// IsError returns the landscaper if the given error is one.
-// If the err does not contain a landsacper error nil is returned.
+// IsError returns the landscaper error if the given error is one.
+// If the err does not contain a landscaper error nil is returned.
 func IsError(err error) (*Error, bool) {
 	if err == nil {
 		return nil, false

--- a/pkg/deployer/container/add.go
+++ b/pkg/deployer/container/add.go
@@ -47,6 +47,7 @@ func AddControllerToManager(logger logr.Logger, hostMgr, lsMgr manager.Manager, 
 		ctrlLogger.WithName("PodReconciler"),
 		lsMgr.GetClient(),
 		hostMgr.GetClient(),
+		lsMgr.GetEventRecorderFor("Lanscaper"),
 		config,
 		deployer)
 

--- a/pkg/deployer/container/container.go
+++ b/pkg/deployer/container/container.go
@@ -11,7 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/utils"
 
@@ -73,20 +74,20 @@ func New(log logr.Logger,
 	providerConfig := &containerv1alpha1.ProviderConfiguration{}
 	decoder := api.NewDecoder(Scheme)
 	if _, _, err := decoder.Decode(item.Spec.Configuration.Raw, nil, providerConfig); err != nil {
-		return nil, lsv1alpha1helper.NewWrappedError(err,
+		return nil, lserrors.NewWrappedError(err,
 			"Init", "DecodeProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
 	applyDefaults(&config, providerConfig)
 
 	if err := container1alpha1validation.ValidateProviderConfiguration(providerConfig); err != nil {
-		return nil, lsv1alpha1helper.NewWrappedError(err,
+		return nil, lserrors.NewWrappedError(err,
 			"Init", "ValidateProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
 	status, err := DecodeProviderStatus(item.Status.ProviderStatus)
 	if err != nil {
-		return nil, lsv1alpha1helper.NewWrappedError(err,
+		return nil, lserrors.NewWrappedError(err,
 			"Init", "DecodeProviderStatus", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 

--- a/pkg/deployer/container/container_delete.go
+++ b/pkg/deployer/container/container_delete.go
@@ -12,6 +12,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	"github.com/gardener/landscaper/apis/deployer/container"
@@ -29,11 +31,11 @@ func (c *Container) Delete(ctx context.Context) error {
 	}
 
 	if err := c.cleanupRBAC(ctx); err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			"Delete", "CleanupRBAC", err.Error())
 	}
 	if err := c.cleanupDeployItem(ctx); err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			"Delete", "CleanupDeployItem", err.Error())
 	}
 	return nil

--- a/pkg/deployer/helm/deployer.go
+++ b/pkg/deployer/helm/deployer.go
@@ -11,10 +11,11 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
 	"github.com/gardener/landscaper/pkg/utils"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	helmv1alpha1 "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1"
 	deployerlib "github.com/gardener/landscaper/pkg/deployer/lib"
 )
@@ -69,7 +70,7 @@ func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, tar
 
 	exports, err := helm.constructExportsFromValues(values)
 	if err != nil {
-		di.Status.LastError = lsv1alpha1helper.UpdatedError(di.Status.LastError,
+		di.Status.LastError = lserrors.UpdatedError(di.Status.LastError,
 			"ConstructExportFromValues", "", err.Error())
 		return err
 	}

--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -60,6 +61,7 @@ var _ = Describe("Helm Deployer", func() {
 			logr.Discard(),
 			testenv.Client,
 			api.LandscaperScheme,
+			record.NewFakeRecorder(1024),
 			testenv.Client,
 			api.LandscaperScheme,
 			deployerlib.DeployerArgs{

--- a/pkg/deployer/lib/targetselector/e2e_suite_test.go
+++ b/pkg/deployer/lib/targetselector/e2e_suite_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/tools/record"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	mockv1alpha1 "github.com/gardener/landscaper/apis/deployer/mock/v1alpha1"
@@ -80,7 +81,7 @@ var _ = Describe("E2E", func() {
 		testutils.ExpectNoError(err)
 		testutils.ExpectNoError(state.Create(ctx, testenv.Client, di))
 
-		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, mockv1alpha1.Configuration{
+		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{
 			TargetSelector: []lsv1alpha1.TargetSelector{
 				{
 					Annotations: []lsv1alpha1.Requirement{
@@ -129,7 +130,7 @@ var _ = Describe("E2E", func() {
 		testutils.ExpectNoError(err)
 		testutils.ExpectNoError(state.Create(ctx, testenv.Client, di))
 
-		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, mockv1alpha1.Configuration{
+		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{
 			TargetSelector: []lsv1alpha1.TargetSelector{
 				{
 					Annotations: []lsv1alpha1.Requirement{

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
+	lserrors "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 	"github.com/gardener/landscaper/pkg/utils/kubernetes/health"
 )
@@ -29,7 +29,7 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 
 	_, targetClient, err := m.TargetClient(ctx)
 	if err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			currOp, "TargetClusterClient", err.Error())
 	}
 
@@ -67,11 +67,11 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 
 	m.DeployItem.Status.ProviderStatus, err = encodeStatus(m.ProviderStatus)
 	if err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			currOp, "ProviderStatus", err.Error())
 	}
 	if err := m.lsKubeClient.Status().Update(ctx, m.DeployItem); err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			currOp, "UpdateStatus", err.Error())
 	}
 
@@ -103,7 +103,7 @@ func (m *Manifest) Delete(ctx context.Context) error {
 
 	_, kubeClient, err := m.TargetClient(ctx)
 	if err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			currOp, "TargetClusterClient", err.Error())
 	}
 
@@ -118,7 +118,7 @@ func (m *Manifest) Delete(ctx context.Context) error {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			return lsv1alpha1helper.NewWrappedError(err,
+			return lserrors.NewWrappedError(err,
 				currOp, "DeleteManifest", err.Error())
 		}
 		completed = false
@@ -188,7 +188,7 @@ func (m *Manifest) defaultCheckResourcesHealth(ctx context.Context, client clien
 
 	timeout := m.ProviderConfiguration.HealthChecks.Timeout.Duration
 	if err := health.WaitForObjectsHealthy(ctx, timeout, m.log, client, objects); err != nil {
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			currOp, "CheckResourcesHealth", err.Error(), lsv1alpha1.ErrorHealthCheckTimeout)
 	}
 

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -17,12 +17,13 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
 	"github.com/gardener/landscaper/pkg/deployer/lib"
 
 	"github.com/gardener/landscaper/pkg/utils"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	manifestinstall "github.com/gardener/landscaper/apis/deployer/manifest/install"
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 
@@ -73,12 +74,12 @@ func New(log logr.Logger,
 	currOp := "InitManifestOperation"
 	manifestDecoder := api.NewDecoder(Scheme)
 	if _, _, err := manifestDecoder.Decode(item.Spec.Configuration.Raw, nil, config); err != nil {
-		return nil, lsv1alpha1helper.NewWrappedError(err,
+		return nil, lserrors.NewWrappedError(err,
 			currOp, "ParseProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
 	if err := manifestvalidation.ValidateProviderConfiguration(config); err != nil {
-		return nil, lsv1alpha1helper.NewWrappedError(err,
+		return nil, lserrors.NewWrappedError(err,
 			currOp, "ValidateProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
@@ -86,7 +87,7 @@ func New(log logr.Logger,
 	if item.Status.ProviderStatus != nil {
 		status = &manifestv1alpha2.ProviderStatus{}
 		if _, _, err := manifestDecoder.Decode(item.Status.ProviderStatus.Raw, nil, status); err != nil {
-			return nil, lsv1alpha1helper.NewWrappedError(err,
+			return nil, lserrors.NewWrappedError(err,
 				currOp, "ParseProviderStatus", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 		}
 	}

--- a/pkg/deployer/manifest/objectapplier.go
+++ b/pkg/deployer/manifest/objectapplier.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
+	lserrors "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 )
 
@@ -62,14 +62,14 @@ func (a *ObjectApplier) Apply(ctx context.Context) error {
 	wg.Wait()
 	if len(allErrs) != 0 {
 		aggErr := apimacherrors.NewAggregate(allErrs)
-		return lsv1alpha1helper.NewWrappedError(apimacherrors.NewAggregate(allErrs),
+		return lserrors.NewWrappedError(apimacherrors.NewAggregate(allErrs),
 			"ApplyObjects", "ApplyNewObject", aggErr.Error())
 	}
 
 	// remove old objects
 	if err := a.cleanupOrphanedResources(ctx, oldManagedResources); err != nil {
 		err = fmt.Errorf("unable to cleanup orphaned resources: %w", err)
-		return lsv1alpha1helper.NewWrappedError(err,
+		return lserrors.NewWrappedError(err,
 			"ApplyObjects", "CleanupOrphanedObects", err.Error())
 	}
 	return nil

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -53,6 +54,7 @@ var _ = Describe("Manifest Deployer", func() {
 			logr.Discard(),
 			testenv.Client,
 			api.LandscaperScheme,
+			record.NewFakeRecorder(1024),
 			testenv.Client,
 			api.LandscaperScheme,
 			deployerlib.DeployerArgs{

--- a/pkg/deployer/mock/add.go
+++ b/pkg/deployer/mock/add.go
@@ -7,6 +7,7 @@ package mock
 import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -41,7 +42,7 @@ func AddDeployerToManager(logger logr.Logger, lsMgr, hostMgr manager.Manager, co
 
 // NewController creates a new simple controller.
 // This method should only be used for testing.
-func NewController(log logr.Logger, kubeClient client.Client, scheme *runtime.Scheme, config mockv1alpha1.Configuration) (reconcile.Reconciler, error) {
+func NewController(log logr.Logger, kubeClient client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, config mockv1alpha1.Configuration) (reconcile.Reconciler, error) {
 	d, err := NewDeployer(
 		log,
 		kubeClient,
@@ -53,7 +54,7 @@ func NewController(log logr.Logger, kubeClient client.Client, scheme *runtime.Sc
 	}
 
 	return deployerlib.NewController(log,
-		kubeClient, scheme,
+		kubeClient, scheme, eventRecorder,
 		kubeClient, scheme,
 		deployerlib.DeployerArgs{
 			Type:            Type,

--- a/pkg/landscaper/controllers/deployitem/controller.go
+++ b/pkg/landscaper/controllers/deployitem/controller.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lscore "github.com/gardener/landscaper/apis/core"
@@ -185,7 +187,7 @@ func (con *controller) detectPickupTimeouts(log logr.Logger, di *lsv1alpha1.Depl
 		// => pickup timeout
 		logger.V(5).Info("pickup timeout occurred")
 		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-		di.Status.LastError = lsv1alpha1helper.UpdatedError(di.Status.LastError, PickupTimeoutOperation, PickupTimeoutReason, fmt.Sprintf("no deployer has reconciled this deployitem within %d seconds", con.pickupTimeout/time.Second), lsv1alpha1.ErrorTimeout)
+		di.Status.LastError = lserrors.UpdatedError(di.Status.LastError, PickupTimeoutOperation, PickupTimeoutReason, fmt.Sprintf("no deployer has reconciled this deployitem within %d seconds", con.pickupTimeout/time.Second), lsv1alpha1.ErrorTimeout)
 		return nil, nil
 	}
 
@@ -227,7 +229,7 @@ func (con *controller) detectAbortingTimeouts(log logr.Logger, di *lsv1alpha1.De
 		logger.V(5).Info("aborting timeout occurred")
 		lsv1alpha1helper.RemoveAbortOperationAndTimestamp(&di.ObjectMeta)
 		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-		di.Status.LastError = lsv1alpha1helper.UpdatedError(di.Status.LastError,
+		di.Status.LastError = lserrors.UpdatedError(di.Status.LastError,
 			AbortingTimeoutOperation,
 			AbortingTimeoutReason,
 			fmt.Sprintf("deployer has not aborted progressing this deploy item within %d seconds",

--- a/pkg/landscaper/controllers/deployitem/reconcile_test.go
+++ b/pkg/landscaper/controllers/deployitem/reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -41,7 +42,7 @@ var _ = Describe("Deploy Item Controller Reconcile Test", func() {
 		deployItemController, err = dictrl.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, &testPickupTimeoutDuration, &testAbortingTimeoutDuration, &testProgressingTimeoutDuration)
 		Expect(err).ToNot(HaveOccurred())
 
-		mockController, err = mockctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, mockv1alpha1.Configuration{})
+		mockController, err = mockctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/landscaper/controllers/execution/add.go
+++ b/pkg/landscaper/controllers/execution/add.go
@@ -19,6 +19,7 @@ func AddControllerToManager(logger logr.Logger, mgr manager.Manager) error {
 		log,
 		mgr.GetClient(),
 		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("Landscaper"),
 	)
 	if err != nil {
 		return err

--- a/pkg/landscaper/controllers/installations/add.go
+++ b/pkg/landscaper/controllers/installations/add.go
@@ -22,6 +22,7 @@ func AddControllerToManager(logger logr.Logger, mgr manager.Manager, overwriter 
 		log,
 		mgr.GetClient(),
 		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("Landscaper"),
 		overwriter,
 		config,
 	)

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -36,7 +37,7 @@ var _ = Describe("Delete", func() {
 		fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata")
 		Expect(err).ToNot(HaveOccurred())
 
-		op = lsoperation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme).SetComponentsRegistry(fakeCompRepo)
+		op = lsoperation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 	})
 
 	AfterEach(func() {

--- a/pkg/landscaper/execution/delete_test.go
+++ b/pkg/landscaper/execution/delete_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -41,7 +42,7 @@ var _ = Describe("Delete", func() {
 
 		fakeExecutions = state.Executions
 		fakeDeployItems = state.DeployItems
-		op = operation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme)
+		op = operation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
 	})
 
 	It("should block deletion if deploy items still exist", func() {

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -39,7 +40,7 @@ var _ = Describe("Reconcile", func() {
 
 		fakeExecutions = state.Executions
 		fakeDeployItems = state.DeployItems
-		op = operation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme)
+		op = operation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
 	})
 
 	It("should deploy the specified deploy items", func() {

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -9,6 +9,7 @@ import (
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	. "github.com/onsi/ginkgo"
@@ -45,7 +46,7 @@ var _ = Describe("Context", func() {
 		fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
-		op = lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme).SetComponentsRegistry(fakeCompRepo)
+		op = lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 	})
 
 	It("should show no parent nor siblings for the test1 root", func() {

--- a/pkg/landscaper/installations/exports/constructor_test.go
+++ b/pkg/landscaper/installations/exports/constructor_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -51,7 +52,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme).
+			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/conditional_imports_test.go
+++ b/pkg/landscaper/installations/imports/conditional_imports_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -55,7 +56,7 @@ var _ = Describe("ConditionalImports", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme).
+			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -49,7 +50,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme).
+			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/outdated_test.go
+++ b/pkg/landscaper/installations/imports/outdated_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -46,7 +47,7 @@ var _ = Describe("OutdatedImports", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme).
+			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/validation_test.go
+++ b/pkg/landscaper/installations/imports/validation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -47,7 +48,7 @@ var _ = Describe("Validation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme).
+			Operation: lsoperation.NewOperation(logr.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -20,8 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	lserrors "github.com/gardener/landscaper/apis/errors"
 
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
@@ -52,8 +55,8 @@ type Operation struct {
 }
 
 // NewInstallationOperation creates a new installation operation
-func NewInstallationOperation(ctx context.Context, log logr.Logger, c client.Client, scheme *runtime.Scheme, cRegistry ctf.ComponentResolver, inst *Installation) (*Operation, error) {
-	return NewInstallationOperationFromOperation(ctx, lsoperation.NewOperation(log, c, scheme).SetComponentsRegistry(cRegistry), inst, nil)
+func NewInstallationOperation(ctx context.Context, log logr.Logger, c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, cRegistry ctf.ComponentResolver, inst *Installation) (*Operation, error) {
+	return NewInstallationOperationFromOperation(ctx, lsoperation.NewOperation(log, c, scheme, recorder).SetComponentsRegistry(cRegistry), inst, nil)
 }
 
 // NewInstallationOperationFromOperation creates a new installation operation from an existing common operation
@@ -248,35 +251,13 @@ func (o *Operation) GetImportedTargets(ctx context.Context) (map[string]*dataobj
 
 // NewError creates a new error with the current operation
 func (o *Operation) NewError(err error, reason, message string, codes ...lsv1alpha1.ErrorCode) error {
-	return lsv1alpha1helper.NewWrappedError(err,
+	return lserrors.NewWrappedError(err,
 		o.CurrentOperation, reason, message, codes...)
 }
 
 // CreateEventFromCondition creates a new event based on the given condition
 func (o *Operation) CreateEventFromCondition(ctx context.Context, inst *lsv1alpha1.Installation, cond lsv1alpha1.Condition) error {
-	event := &corev1.Event{}
-	event.GenerateName = "inst-"
-	event.Namespace = inst.Namespace
-	event.Type = "Warning"
-	event.Source = corev1.EventSource{
-		Component: "landscaper", // todo: make configurable by the caller
-	}
-	event.InvolvedObject = corev1.ObjectReference{
-		Kind:            inst.Kind,
-		Namespace:       inst.Namespace,
-		Name:            inst.Name,
-		UID:             inst.UID,
-		APIVersion:      inst.APIVersion,
-		ResourceVersion: inst.ResourceVersion,
-	}
-	event.Reason = cond.Reason
-	event.Message = cond.Message
-	event.Action = string(cond.Type)
-
-	if err := o.Client().Create(ctx, event); err != nil {
-		o.Log().Error(err, "unable to set installation status")
-		return err
-	}
+	o.Operation.EventRecorder().Event(inst, corev1.EventTypeWarning, cond.Reason, cond.Message)
 	return nil
 }
 
@@ -501,7 +482,7 @@ func (o *Operation) createOrUpdateDataImport(ctx context.Context, src string, im
 			lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 				"CreateDataObjects",
 				fmt.Sprintf("unable to create data object for import '%s'", importDef.Name)))
-		o.Inst.Info.Status.LastError = lsv1alpha1helper.UpdatedError(o.Inst.Info.Status.LastError,
+		o.Inst.Info.Status.LastError = lserrors.UpdatedError(o.Inst.Info.Status.LastError,
 			"CreateDataObjects", fmt.Sprintf("unable to create dataobjects for import '%s'", importDef.Name),
 			err.Error())
 		return fmt.Errorf("unable to build data object for import '%s': %w", importDef.Name, err)
@@ -518,7 +499,7 @@ func (o *Operation) createOrUpdateDataImport(ctx context.Context, src string, im
 			lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 				"CreateDataObjects",
 				fmt.Sprintf("unable to create data object for import '%s'", importDef.Name)))
-		o.Inst.Info.Status.LastError = lsv1alpha1helper.UpdatedError(o.Inst.Info.Status.LastError,
+		o.Inst.Info.Status.LastError = lserrors.UpdatedError(o.Inst.Info.Status.LastError,
 			"CreateDatatObjects", fmt.Sprintf("unable to create data objects for import '%s'", importDef.Name),
 			err.Error())
 		return fmt.Errorf("unable to create or update data object '%s' for import '%s': %w", raw.Name, importDef.Name, err)
@@ -551,7 +532,7 @@ func (o *Operation) createOrUpdateTargetImport(ctx context.Context, src string, 
 			lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 				"CreateTargets",
 				fmt.Sprintf("unable to create target for import '%s'", importDef.Name)))
-		o.Inst.Info.Status.LastError = lsv1alpha1helper.UpdatedError(o.Inst.Info.Status.LastError,
+		o.Inst.Info.Status.LastError = lserrors.UpdatedError(o.Inst.Info.Status.LastError,
 			"CreateTargets", fmt.Sprintf("unable to create target for import '%s'", importDef.Name),
 			err.Error())
 		return fmt.Errorf("unable to build target for import '%s': %w", importDef.Name, err)
@@ -568,7 +549,7 @@ func (o *Operation) createOrUpdateTargetImport(ctx context.Context, src string, 
 			lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 				"CreateTargets",
 				fmt.Sprintf("unable to create target for import '%s'", importDef.Name)))
-		o.Inst.Info.Status.LastError = lsv1alpha1helper.UpdatedError(o.Inst.Info.Status.LastError,
+		o.Inst.Info.Status.LastError = lserrors.UpdatedError(o.Inst.Info.Status.LastError,
 			"CreateTargets", fmt.Sprintf("unable to create target for import '%s'", importDef.Name),
 			err.Error())
 		return fmt.Errorf("unable to create or update target '%s' for import '%s': %w", target.Name, importDef.Name, err)

--- a/pkg/landscaper/installations/operation_test.go
+++ b/pkg/landscaper/installations/operation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -32,7 +33,7 @@ var _ = Describe("Operation", func() {
 
 	BeforeEach(func() {
 		kubeClient = fake.NewClientBuilder().WithScheme(api.LandscaperScheme).Build()
-		commonOp := operation.NewOperation(logr.Discard(), kubeClient, api.LandscaperScheme)
+		commonOp := operation.NewOperation(logr.Discard(), kubeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
 		op = &installations.Operation{
 			Inst: &installations.Installation{
 				InstallationBase: installations.InstallationBase{Info: &lsv1alpha1.Installation{}},

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -52,7 +53,7 @@ var _ = Describe("SubInstallation", func() {
 		fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata")
 		Expect(err).ToNot(HaveOccurred())
 
-		op = lsoperation.NewOperation(logr.Discard(), mockClient, api.LandscaperScheme).SetComponentsRegistry(fakeCompRepo)
+		op = lsoperation.NewOperation(logr.Discard(), mockClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 
 		defaultTestConfig = &utils.TestInstallationConfig{
 			MockClient:                   mockClient,

--- a/pkg/landscaper/operation/operation.go
+++ b/pkg/landscaper/operation/operation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,15 +24,17 @@ type Operation struct {
 	client            client.Client
 	directReader      client.Reader
 	scheme            *runtime.Scheme
+	eventRecorder     record.EventRecorder
 	componentRegistry ctf.ComponentResolver
 }
 
 // NewOperation creates a new internal installation Operation object.
-func NewOperation(log logr.Logger, c client.Client, scheme *runtime.Scheme) *Operation {
+func NewOperation(log logr.Logger, c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *Operation {
 	return &Operation{
-		log:    log,
-		client: c,
-		scheme: scheme,
+		log:           log,
+		client:        c,
+		scheme:        scheme,
+		eventRecorder: recorder,
 	}
 }
 
@@ -67,6 +70,11 @@ func (o *Operation) DirectReader() client.Reader {
 // Scheme returns a kubernetes scheme
 func (o *Operation) Scheme() *runtime.Scheme {
 	return o.scheme
+}
+
+// EventRecorder returns an event recorder to create events.
+func (o *Operation) EventRecorder() record.EventRecorder {
+	return o.eventRecorder
 }
 
 // ComponentsRegistry returns a component blueprintsRegistry instance

--- a/test/landscaper/e2e/inlinecd_test.go
+++ b/test/landscaper/e2e/inlinecd_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/landscaper/apis/config"
@@ -43,7 +44,7 @@ var _ = Describe("Inline Component Descriptor", func() {
 		fakeComponentRegistry, err = componentsregistry.NewLocalClient(logr.Discard(), filepath.Join(projectRoot, "examples", "02-inline-cd"))
 		Expect(err).ToNot(HaveOccurred())
 
-		op := operation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme).
+		op := operation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 			SetComponentsRegistry(fakeComponentRegistry)
 
 		instActuator = instctlr.NewTestActuator(*op, &config.LandscaperConfiguration{
@@ -52,10 +53,10 @@ var _ = Describe("Inline Component Descriptor", func() {
 			},
 		})
 
-		execActuator, err = execctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme)
+		execActuator, err = execctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024))
 		Expect(err).ToNot(HaveOccurred())
 
-		mockActuator, err = mockctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, mockv1alpha1.Configuration{})
+		mockActuator, err = mockctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/landscaper/apis/config"
@@ -43,7 +44,7 @@ var _ = Describe("Simple", func() {
 		fakeComponentRegistry, err = componentsregistry.NewLocalClient(logr.Discard(), filepath.Join(projectRoot, "examples", "01-simple"))
 		Expect(err).ToNot(HaveOccurred())
 
-		op := operation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme).SetComponentsRegistry(fakeComponentRegistry)
+		op := operation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeComponentRegistry)
 
 		instActuator = instctlr.NewTestActuator(*op, &config.LandscaperConfiguration{
 			Registry: config.RegistryConfiguration{
@@ -51,10 +52,10 @@ var _ = Describe("Simple", func() {
 			},
 		})
 
-		execActuator, err = execctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme)
+		execActuator, err = execctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024))
 		Expect(err).ToNot(HaveOccurred())
 
-		mockActuator, err = mockctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, mockv1alpha1.Configuration{})
+		mockActuator, err = mockctlr.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/vendor/github.com/gardener/landscaper/apis/errors/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/errors/error.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package helper
+package errors
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 )
 
 // Error is a wrapper around the landscaper crd error
-// that implements the go error interface
+// that implements the go error interface.
 type Error struct {
 	lsErr lsv1alpha1.Error
 	err   error
@@ -88,8 +88,8 @@ func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.Erro
 	}
 }
 
-// IsError returns the landscaper if the given error is one.
-// If the err does not contain a landsacper error nil is returned.
+// IsError returns the landscaper error if the given error is one.
+// If the err does not contain a landscaper error nil is returned.
 func IsError(err error) (*Error, bool) {
 	if err == nil {
 		return nil, false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,6 +108,7 @@ github.com/gardener/landscaper/apis/deployer/manifest/validation
 github.com/gardener/landscaper/apis/deployer/mock
 github.com/gardener/landscaper/apis/deployer/mock/install
 github.com/gardener/landscaper/apis/deployer/mock/v1alpha1
+github.com/gardener/landscaper/apis/errors
 github.com/gardener/landscaper/apis/mediatype
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR adds a event decode to the operation struct so that it is now possible to write events in the the reconcile loop.
In addition every reconcile error is now automatically reported as an event.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The Landscaper and all internal deployers to now create events for errors that occur.
```
