### PR TITLE
Improve execution reporting

### DIFF
--- a/apis/core/v1alpha1/constants.go
+++ b/apis/core/v1alpha1/constants.go
@@ -67,3 +67,11 @@ const (
 	// LandscaperMetricsNamespaceName describes the prometheus metrics namespace for the landscaper component
 	LandscaperMetricsNamespaceName = "ociclient"
 )
+
+// DeployItem care controller constants
+const (
+	PickupTimeoutReason      = "PickupTimeout"    // for error messages
+	PickupTimeoutOperation   = "WaitingForPickup" // for error messages
+	AbortingTimeoutReason    = "AbortingTimeout"  // for error messages
+	AbortingTimeoutOperation = "WaitingForAbort"  // for error messages
+)

--- a/pkg/landscaper/controllers/deployitem/reconcile_test.go
+++ b/pkg/landscaper/controllers/deployitem/reconcile_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Deploy Item Controller Reconcile Test", func() {
 			"Phase": Equal(lsv1alpha1.ExecutionPhaseFailed),
 			"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
 				"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
-				"Reason": Equal(dictrl.PickupTimeoutReason),
+				"Reason": Equal(lsv1alpha1.PickupTimeoutReason),
 			})),
 		}))
 	})
@@ -241,7 +241,7 @@ var _ = Describe("Deploy Item Controller Reconcile Test", func() {
 			"Phase": Equal(lsv1alpha1.ExecutionPhaseFailed),
 			"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
 				"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
-				"Reason": Equal(dictrl.AbortingTimeoutReason),
+				"Reason": Equal(lsv1alpha1.AbortingTimeoutReason),
 			})),
 		}))
 	})

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -79,7 +79,9 @@ func (c *controller) Ensure(ctx context.Context, log logr.Logger, exec *lsv1alph
 
 	if exec.DeletionTimestamp.IsZero() && !kubernetes.HasFinalizer(exec, lsv1alpha1.LandscaperFinalizer) {
 		controllerutil.AddFinalizer(exec, lsv1alpha1.LandscaperFinalizer)
-		return lserrors.NewErrorOrNil(c.client.Update(ctx, exec), "Reconcile", "RemoveFinalizer")
+		if err := c.client.Update(ctx, exec); err != nil {
+			return lserrors.NewError("Reconcile", "AddFinalizer", err.Error())
+		}
 	}
 
 	if !exec.DeletionTimestamp.IsZero() {

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
@@ -76,7 +78,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(item.Spec.Type).To(Equal(lsv1alpha1.DeployItemType("landscaper.gardener.cloud/helm")))
-		Expect(item.Spec.RegistryPullSecrets).To(Equal([]lsv1alpha1.ObjectReference{lsv1alpha1.ObjectReference{Name: "my-secret-1", Namespace: "test4"}}))
+		Expect(item.Spec.RegistryPullSecrets).To(Equal([]lsv1alpha1.ObjectReference{{Name: "my-secret-1", Namespace: "test4"}}))
 		Expect(exec.Status.DeployItemReferences[0].Reference.ObservedGeneration).To(Equal(item.Generation))
 	})
 
@@ -120,18 +122,51 @@ var _ = Describe("Reconcile", func() {
 		Expect(exec.Status.DeployItemReferences[1].Reference.ObservedGeneration).To(Equal(exec.Generation))
 	})
 
-	It("should set the status of the execution to failed if a execution failed", func() {
-		ctx := context.Background()
-		exec := fakeExecutions["test2/exec-1"]
-		eOp := execution.NewOperation(op, exec, false)
+	Context("Propagate Phase", func() {
+		It("should set the status of the execution to failed if a deployitem failed", func() {
+			ctx := context.Background()
+			exec := fakeExecutions["test2/exec-1"]
+			eOp := execution.NewOperation(op, exec, false)
 
-		deployItemA := fakeDeployItems["test2/di-a"]
-		deployItemA.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-		Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
+			deployItemA := fakeDeployItems["test2/di-a"]
+			deployItemA.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
-		err := eOp.Reconcile(ctx)
-		Expect(err).To(HaveOccurred())
-		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+			err := eOp.Reconcile(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+		})
+
+		It("should not set the status of the execution to failed if a deployitem failed but the generation is outdated", func() {
+			ctx := context.Background()
+			exec := fakeExecutions["test5/exec-1"]
+			eOp := execution.NewOperation(op, exec, false)
+
+			deployItemA := fakeDeployItems["test5/di-a"]
+			deployItemA.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			deployItemA.Status.ObservedGeneration = 0
+			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
+
+			err := eOp.Reconcile(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseProgressing))
+		})
+
+		It("should set the status of the execution to failed if a deployitem failed due to an pickup timeout and its generation is outdated", func() {
+			ctx := context.Background()
+			exec := fakeExecutions["test2/exec-1"]
+			eOp := execution.NewOperation(op, exec, false)
+
+			deployItemA := fakeDeployItems["test2/di-a"]
+			deployItemA.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			deployItemA.Status.ObservedGeneration = 0
+			deployItemA.Status.LastError = lserrors.UpdatedError(deployItemA.Status.LastError, lsv1alpha1.PickupTimeoutOperation, lsv1alpha1.PickupTimeoutReason, "")
+			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
+
+			err := eOp.Reconcile(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+		})
 	})
 
 	It("should not deploy new items if a execution failed", func() {

--- a/pkg/landscaper/execution/testdata/state/test5/00-execution.yaml
+++ b/pkg/landscaper/execution/testdata/state/test5/00-execution.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: exec-1
+  namespace: test5
+  generation: 2
+spec:
+
+  deployItems:
+  - name: a
+    type: landscaper.gardener.cloud/helm
+    config:
+      my-val: val1
+
+status:
+  phase: Init
+
+  observedGeneration: 0
+
+  deployItemRefs:
+  - name: a
+    ref:
+      name: di-a
+      namespace: test2
+      observedGeneration: 2

--- a/pkg/landscaper/execution/testdata/state/test5/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test5/10-deploy-item.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-a
+  namespace: test5
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: a
+  generation: 1
+spec:
+  type: landscaper.gardener.cloud/helm
+  config:
+    my-val: val1
+
+status:
+  phase: Progressing
+  observedGeneration: 1

--- a/test/integration/deployitems/timeouts.go
+++ b/test/integration/deployitems/timeouts.go
@@ -18,7 +18,6 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	dictrl "github.com/gardener/landscaper/pkg/landscaper/controllers/deployitem"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
@@ -168,7 +167,7 @@ func TimeoutTests(f *framework.Framework) {
 				"Phase": Equal(lsv1alpha1.ExecutionPhaseFailed),
 				"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
 					"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
-					"Reason": Equal(dictrl.PickupTimeoutReason),
+					"Reason": Equal(lsv1alpha1.PickupTimeoutReason),
 				})),
 			}), "deploy item of the dummy installation should have had a pickup timeout")
 			Eventually(func() lsv1alpha1.DeployItem {
@@ -198,7 +197,7 @@ func TimeoutTests(f *framework.Framework) {
 				"Phase": Equal(lsv1alpha1.ExecutionPhaseFailed),
 				"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
 					"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
-					"Reason": Equal(dictrl.AbortingTimeoutReason),
+					"Reason": Equal(lsv1alpha1.AbortingTimeoutReason),
 				})),
 			}))
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -67,3 +67,11 @@ const (
 	// LandscaperMetricsNamespaceName describes the prometheus metrics namespace for the landscaper component
 	LandscaperMetricsNamespaceName = "ociclient"
 )
+
+// DeployItem care controller constants
+const (
+	PickupTimeoutReason      = "PickupTimeout"    // for error messages
+	PickupTimeoutOperation   = "WaitingForPickup" // for error messages
+	AbortingTimeoutReason    = "AbortingTimeout"  // for error messages
+	AbortingTimeoutOperation = "WaitingForAbort"  // for error messages
+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a bug that a failed state is not propagated when there is no deployer that reconciles a deploy item.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/179

**Special notes for your reviewer**:

This PR depends on https://github.com/gardener/landscaper/pull/233 as also differnt error states are now reported though events

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed, that caused a Installation to hang in `Progressing` state although the corresponding deploy item is already failed.
The state is now correctly propagated and displayed to the user.
```
