### PR TITLE
fix blueprint store directory name length

### DIFF
--- a/pkg/landscaper/blueprints/store.go
+++ b/pkg/landscaper/blueprints/store.go
@@ -6,7 +6,8 @@ package blueprints
 
 import (
 	"context"
-	"encoding/base32"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -307,9 +308,12 @@ func (s *Store) RunGarbageCollection() {
 	}
 }
 
+// blueprintID generates a unique blueprint id that can be used a a file/directory name.
+// The ID is calculated by hashing (sha256) the component descriptor and the blueprint resource.
 func blueprintID(cd *cdv2.ComponentDescriptor, resource cdv2.Resource) string {
-	// the value is b32 encoded to be a compliant filesystem directory name
-	return base32.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s-%s-%s-%s", cd.Name, cd.Version, resource.Name, resource.Version)))
+	h := sha256.New()
+	_, _ = h.Write([]byte(fmt.Sprintf("%s-%s-%s-%s", cd.Name, cd.Version, resource.Name, resource.Version)))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func blueprintPath(bpID string) string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a bug where the generated blueprint id for the store exceeded max allowed name for a file/directory.
This PR fixes this by always using a hex encoded `sha256` hash of the id.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed that caused the blueprint store to panic when the generated blueprint id exceeded the max allowed characters for a directory name.
```
