### PR TITLE
improve deployer logging and print config on startup

### DIFF
--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -118,6 +118,7 @@ var _ = Describe("Helm Deployer", func() {
 		// Get the managed objects from Status and set them in Ready status
 		status := &helm.ProviderStatus{}
 		Expect(testenv.Client.Get(ctx, testutil.Request(di.GetName(), di.GetNamespace()).NamespacedName, di)).To(Succeed())
+		Expect(di.Status.ProviderStatus).ToNot(BeNil())
 
 		helmDecoder := serializer.NewCodecFactory(helmctrl.HelmScheme).UniversalDecoder()
 		_, _, err = helmDecoder.Decode(di.Status.ProviderStatus.Raw, nil, status)

--- a/pkg/deployer/lib/cmd/default.go
+++ b/pkg/deployer/lib/cmd/default.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/logger"
@@ -141,6 +142,16 @@ func (o *DefaultOptions) GetConfig(obj runtime.Object) error {
 
 	if _, _, err := o.decoder.Decode(data, nil, obj); err != nil {
 		return err
+	}
+
+	if o.Log.V(2).Enabled() {
+		// print configuration if enabled
+		configBytes, err := yaml.Marshal(obj)
+		if err != nil {
+			o.Log.Error(err, "unable to marshal configuration")
+		} else {
+			fmt.Println(string(configBytes))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind quality
/priority 3

**What this PR does / why we need it**:

Improves the logging (debugging) for the deployers regarding configuration and target selectors

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The logging of deployers has been improved so that the configuration and additional target selector information can be logged with the according verbosity level.
```
