### PR TITLE
Patching manifests

### DIFF
--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -261,7 +261,7 @@ func (h *Helm) ApplyObject(ctx context.Context, kubeClient client.Client, obj *u
 				currOp, "ApplyObject", err.Error())
 		}
 	case helmv1alpha1.UpdateStrategyPatch:
-		if err := kubeClient.Patch(ctx, &currObj, client.MergeFrom(obj)); err != nil {
+		if err := kubeClient.Patch(ctx, obj, client.MergeFrom(&currObj)); err != nil {
 			err = fmt.Errorf("unable to patch resource %s: %w", key.String(), err)
 			return lserrors.NewWrappedError(err,
 				currOp, "ApplyObject", err.Error())

--- a/pkg/deployer/manifest/objectapplier.go
+++ b/pkg/deployer/manifest/objectapplier.go
@@ -135,7 +135,7 @@ func (a *ObjectApplier) ApplyObject(ctx context.Context, i int, manifestData man
 			return fmt.Errorf("unable to update resource %s: %w", key.String(), err)
 		}
 	case manifestv1alpha2.UpdateStrategyPatch:
-		if err := a.kubeClient.Patch(ctx, &currObj, client.MergeFrom(obj)); err != nil {
+		if err := a.kubeClient.Patch(ctx, obj, client.MergeFrom(&currObj)); err != nil {
 			return fmt.Errorf("unable to patch resource %s: %w", key.String(), err)
 		}
 	default:

--- a/pkg/deployer/manifest/test/testdata/05-di.yaml
+++ b/pkg/deployer/manifest/test/testdata/05-di.yaml
@@ -1,0 +1,27 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: my-manifests-patch
+spec:
+  type: landscaper.gardener.cloud/kubernetes-manifest
+
+  target: # has to be of type landscaper.gardener.cloud/kubernetes-cluster
+    name: my-cluster
+    namespace: test
+
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+
+    updateStrategy: patch
+
+    manifests:
+    - policy: manage
+      manifest:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: my-secret
+          namespace: default
+        stringData:
+          config: abc

--- a/pkg/deployer/manifest/test/testdata/06-di-patched.yaml
+++ b/pkg/deployer/manifest/test/testdata/06-di-patched.yaml
@@ -1,0 +1,27 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: my-manifests-patch
+spec:
+  type: landscaper.gardener.cloud/kubernetes-manifest
+
+  target: # has to be of type landscaper.gardener.cloud/kubernetes-cluster
+    name: my-cluster
+    namespace: test
+
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+
+    updateStrategy: patch
+
+    manifests:
+    - policy: manage
+      manifest:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: my-secret
+          namespace: default
+        stringData:
+          config: efg


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area manifest-deployer
/kind bug
/priority 3

**What this PR does / why we need it**:
This PR fixes the issue: [Manifest deployer does not update resources #248](https://github.com/gardener/landscaper/issues/248), and adds a corresponding test case.

**Which issue(s) this PR fixes**:
Fixes #248 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed in the manifest and helm deployer that caused kubernetes resources that are reconciled with the patch option to not be updated.
```
