### PR TITLE
Updated local setup documentation

### DIFF
--- a/docs/tutorials/00-local-setup.md
+++ b/docs/tutorials/00-local-setup.md
@@ -149,26 +149,17 @@ If the landscaper is deployed via helm, the credentials can be configured using 
 landscaper:
   # the local harbor registry only serves http so the landscaper has to be configured to do a fallback to http.
   registryConfig: # contains optional oci secrets
-    blueprints:
-      allowPlainHttpRegistries: false
-      secrets:
-        default:  {
-                    "auths": {
-                      "http://registry-harbor-registry.harbor:5000/": {
-                        "auth": "${AUTH_TOKEN}"
-                      }
+    cache: {}
+    allowPlainHttpRegistries: false
+    insecureSkipVerify: false
+    secrets:
+      default:  {
+                  "auths": {
+                    "http://registry-harbor-registry.harbor:5000/": {
+                      "auth": "${AUTH_TOKEN}"
                     }
                   }
-    components:
-      allowPlainHttpRegistries: false
-      secrets:
-        default:  {
-                    "auths": {
-                      "http://registry-harbor-registry.harbor:5000/": {
-                        "auth": "${AUTH_TOKEN}"
-                      }
-                    }
-                  }
+                }
 ```
 
 ### Common Pitfalls
@@ -178,6 +169,11 @@ In order for the `landscaper-cli` to work with the registry, it needs valid cred
 ```shell
 docker login -u my-user localhost:5000 # use the user name and pwd as specified in the harbor chart values.yaml
 ```
+On some systems `docker login` will fail when using `localhost` as the registry URL.
+```shell
+Error response from daemon: Get http://localhost:5000/v2/: dial tcp [::1]:5000: connect: connection refused
+```
+A workaround for this issue is to add an alias hostname to `/etc/hosts` that points to localhost and use this alias for `docker login`.
 
 Later, when dealing with artifacts like the component descriptor, be aware that the URLs used to push and access the artifacts differ due to the port-forwarding. Make sure the base URL points to the cluster-internal representation of the registry:
 
@@ -189,7 +185,7 @@ Later, when dealing with artifacts like the component descriptor, be aware that 
 But push explicitly to `localhost` instead implicitly using the baseUrl:
 
 ```shell
-landscaper-cli  componentdescriptor push localhost:5000/comp/ github.com/gardener/landscaper/ingress-nginx v0.1.0 component-descriptor.yaml
+landscaper-cli components-cli ca remote push ./path-to-componentdescriptor --repo-ctx localhost:5000/comp/
 ```
 
 #### Targets


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug
/priority 4

**What this PR does / why we need it**:
The documentation of the local Landscaper setup was out-of-sync with the latest changes to the Helm Chart
and the changes in the landscaper-cli.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
