### PR TITLE
Adapted local simple blueprint tutorial for new landscaper-cli commands.

### DIFF
--- a/docs/tutorials/02-local-simple-blueprint.md
+++ b/docs/tutorials/02-local-simple-blueprint.md
@@ -94,8 +94,8 @@ input:
 
 Add the resource to the component descriptor with the component-cli:
 ```
-component-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
-  -r ./docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
+landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
+  ./docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
 ```
 :warning: Note that the directory `./docs/tutorials/resources/local-ingress-nginx` _MUST_ contain the component descriptor at `./docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml`.
 
@@ -188,8 +188,8 @@ input:
 ```
 
 ```
-component-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
-  -r ./docs/tutorials/resources/local-ingress-nginx/blueprint-resource.yaml
+landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
+  ./docs/tutorials/resources/local-ingress-nginx/blueprint-resource.yaml
 ```
 
 With his, the blueprint has been added to the component descriptor as `localFilesystemBlob` and the content has been packaged and copied to the blobs directory, which contains now 2 files.<br>
@@ -229,7 +229,7 @@ component:
 
 Upload the component and its local artifacts with the `component-cli`:
 ```
-component-cli ca remote push ./docs/tutorials/resources/local-ingress-nginx
+landscaper-cli components-cli ca remote push ./docs/tutorials/resources/local-ingress-nginx
 ```
 :warning: make sure to have write permissions for the component registry. (Run `docker login registry` to login into the registry)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug
/priority 4

**What this PR does / why we need it**:
This PR contains small adjustments to the tutorial, which now uses the landscaper-cli instead of the component-cli.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
