### PR TITLE
Fix data reconcile trigger for secrets and configmaps

### DIFF
--- a/apis/core/v1alpha1/types_dataobject.go
+++ b/apis/core/v1alpha1/types_dataobject.go
@@ -35,6 +35,9 @@ const DataObjectKeyLabel = "data.landscaper.gardener.cloud/key"
 // DataObjectSourceLabel defines the name of the label that specifies the source of the dataobject.
 const DataObjectSourceLabel = "data.landscaper.gardener.cloud/source"
 
+// DataObjectHashAnnotation defines the name of the annotation that specifies the hash of the data.
+const DataObjectHashAnnotation = "data.landscaper.gardener.cloud/hash"
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DataObjectList contains a list of DataObject

--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -151,7 +151,7 @@ func (c *Constructor) aggregateDataObjectsInContext(ctx context.Context) (map[st
 
 	aggDataObjects := map[string]interface{}{}
 	for _, do := range dataObjectList.Items {
-		meta := dataobjects.GetMetadataFromObject(&do)
+		meta := dataobjects.GetMetadataFromObject(&do, do.Data.RawMessage)
 		var data interface{}
 		if err := yaml.Unmarshal(do.Data.RawMessage, &data); err != nil {
 			return nil, fmt.Errorf("error while decoding data object %s: %w", do.Name, err)
@@ -170,7 +170,7 @@ func (c *Constructor) aggregateTargetsInContext(ctx context.Context) (map[string
 
 	aggTargets := map[string]interface{}{}
 	for _, target := range targetList.Items {
-		meta := dataobjects.GetMetadataFromObject(&target)
+		meta := dataobjects.GetMetadataFromObject(&target, target.Spec.Configuration.RawMessage)
 		raw, err := json.Marshal(target)
 		if err != nil {
 			return nil, fmt.Errorf("error while encoding target %s: %w", target.Name, err)

--- a/pkg/landscaper/installations/helper.go
+++ b/pkg/landscaper/installations/helper.go
@@ -109,8 +109,12 @@ func CreateInternalInstallationBase(inst *lsv1alpha1.Installation) *Installation
 }
 
 // GetDataImport fetches the data import from the cluster.
-func GetDataImport(ctx context.Context, kubeClient client.Client, contextName string, inst *InstallationBase,
+func GetDataImport(ctx context.Context,
+	kubeClient client.Client,
+	contextName string,
+	inst *InstallationBase,
 	dataImport lsv1alpha1.DataImport) (*dataobjects.DataObject, *v1.OwnerReference, error) {
+
 	var rawDataObject *lsv1alpha1.DataObject
 	// get deploy item from current context
 	if len(dataImport.DataRef) != 0 {
@@ -131,8 +135,6 @@ func GetDataImport(ctx context.Context, kubeClient client.Client, contextName st
 		}
 		rawDataObject = &lsv1alpha1.DataObject{}
 		rawDataObject.Data.RawMessage = data
-		// set the generation as it is used to detect outdated imports.
-		rawDataObject.SetGeneration(secret.Generation)
 	}
 	if dataImport.ConfigMapRef != nil {
 		cm := &corev1.ConfigMap{}
@@ -145,8 +147,6 @@ func GetDataImport(ctx context.Context, kubeClient client.Client, contextName st
 		}
 		rawDataObject = &lsv1alpha1.DataObject{}
 		rawDataObject.Data.RawMessage = []byte(data)
-		// set the generation as it is used to detect outdated imports.
-		rawDataObject.SetGeneration(cm.Generation)
 	}
 
 	do, err := dataobjects.NewFromDataObject(rawDataObject)

--- a/pkg/landscaper/installations/imports/outdated_test.go
+++ b/pkg/landscaper/installations/imports/outdated_test.go
@@ -137,7 +137,9 @@ var _ = Describe("OutdatedImports", func() {
 
 		It("should return that no imports are outdated", func() {
 			ctx := context.Background()
-			inInstRoot, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), fakeInstallations["test1/root"])
+			instRoot := fakeInstallations["test1/root"]
+			instRoot.Status.Imports[0].ConfigGeneration = "d62a6724cde91ae43d5946a9dcb581b873194b74"
+			inInstRoot, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), instRoot)
 			Expect(err).ToNot(HaveOccurred())
 
 			op.Inst = inInstRoot

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -143,7 +143,7 @@ func (v *Validator) checkDataImportIsOutdated(ctx context.Context, fldPath *fiel
 
 	// we cannot validate if the source is not an installation
 	if owner == nil || owner.Kind != "Installation" {
-		if strconv.Itoa(int(do.Raw.Generation)) != importStatus.ConfigGeneration {
+		if do.Metadata.Hash != importStatus.ConfigGeneration {
 			return true, nil
 		}
 

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -172,7 +172,7 @@ func (o *Operation) GetImportedDataObjects(ctx context.Context) (map[string]*dat
 
 		var (
 			sourceRef *lsv1alpha1.ObjectReference
-			configGen = strconv.Itoa(int(do.Raw.Generation))
+			configGen = do.Metadata.Hash
 			owner     = kutil.GetOwner(do.Raw.ObjectMeta)
 		)
 		if owner != nil && owner.Kind == "Installation" {

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_dataobject.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_dataobject.go
@@ -35,6 +35,9 @@ const DataObjectKeyLabel = "data.landscaper.gardener.cloud/key"
 // DataObjectSourceLabel defines the name of the label that specifies the source of the dataobject.
 const DataObjectSourceLabel = "data.landscaper.gardener.cloud/source"
 
+// DataObjectHashAnnotation defines the name of the annotation that specifies the hash of the data.
+const DataObjectHashAnnotation = "data.landscaper.gardener.cloud/hash"
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DataObjectList contains a list of DataObject


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/landscaper/issues/243

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed that caused the Landscaper to not detect data changes in secrets or configmaps
```
