### PR TITLE
Fix pod volume permissions to not run as root

### DIFF
--- a/docs/deployer/container.md
+++ b/docs/deployer/container.md
@@ -94,8 +94,13 @@ When the image with your program is executed, it gets access to particular infor
 - If *componentDescriptor* and *blueprint* is specified, a *content blob* can be accessed at the directory given by 
   the env var `CONTENT_PATH`. The *content blob* consists of all data stored in the blueprint, consisting of the blueprint 
   yaml file and all other files and folders you stored together with this.
+- The container is not executed as root user due to security reasons.
+  Instead, the following user/group is used (see the [Kubernetes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for details):
+  - **User**: 1000
+  - **Group**: 3000
+  - **FSGroup**: 2000
   
-Again you will find a more detailed explanation of these env variable
+Again you will find a more detailed explanation of these env variables
 [here](https://github.com/gardener/landscapercli/blob/master/docs/commands/container_deployer/add_container_di.md).
 
 ### Status

--- a/pkg/deployer/container/pod.go
+++ b/pkg/deployer/container/pod.go
@@ -294,6 +294,11 @@ func generatePod(opts PodOptions) (*corev1.Pod, error) {
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 	pod.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(300)
 	pod.Spec.Volumes = volumes
+	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsUser:  pointer.Int64(1000),
+		RunAsGroup: pointer.Int64(3000),
+		FSGroup:    pointer.Int64(2000),
+	}
 	pod.Spec.InitContainers = []corev1.Container{initContainer}
 	pod.Spec.Containers = []corev1.Container{mainContainer, waitContainer}
 	if len(opts.ImagePullSecret) != 0 {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area container-deployer
/kind bug
/priority 3

**What this PR does / why we need it**:

Currently the init and wait containers are executed as root user which is an issue as soon as the main execution container is not as root as the export and satte folder cannot be used anymore.
Therefore the container deployer now runs all container as the same user and group.
This also disabled the ability to run a container as root.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/264

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug has been fixed that caused the container that are executed by the container-deployer to be unable to write to the export or state directory.
```
