### PR TITLE
make the key in secret and configmap imports optional

### DIFF
--- a/apis/.schemes/core-v1alpha1-Blueprint.json
+++ b/apis/.schemes/core-v1alpha1-Blueprint.json
@@ -15,8 +15,7 @@
       "description": "ConfigMapReference is reference to data in a configmap. The configmap can also be in a different namespace.",
       "type": "object",
       "required": [
-        "name",
-        "key"
+        "name"
       ],
       "properties": {
         "key": {
@@ -235,8 +234,7 @@
       "description": "SecretReference is reference to data in a secret. The secret can also be in a different namespace.",
       "type": "object",
       "required": [
-        "name",
-        "key"
+        "name"
       ],
       "properties": {
         "key": {

--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -262,6 +262,7 @@ type VersionedNamedObjectReference struct {
 type SecretReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the secret that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 
@@ -270,6 +271,7 @@ type SecretReference struct {
 type ConfigMapReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the configmap that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -272,6 +272,7 @@ type VersionedNamedObjectReference struct {
 type SecretReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the secret that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 
@@ -280,6 +281,7 @@ type SecretReference struct {
 type ConfigMapReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the configmap that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 

--- a/apis/core/validation/installation.go
+++ b/apis/core/validation/installation.go
@@ -276,23 +276,13 @@ func ValidateObjectReferenceList(orl []core.ObjectReference, fldPath *field.Path
 // ValidateSecretReference validates that the secret reference is valid
 func ValidateSecretReference(sr core.SecretReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
 	allErrs = append(allErrs, ValidateObjectReference(sr.ObjectReference, fldPath)...)
-	if sr.Key == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("key"), "key must not be empty"))
-	}
-
 	return allErrs
 }
 
 // ValidateConfigMapReference validates that the secret reference is valid
 func ValidateConfigMapReference(cmr core.ConfigMapReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
 	allErrs = append(allErrs, ValidateObjectReference(cmr.ObjectReference, fldPath)...)
-	if cmr.Key == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("key"), "key must not be empty"))
-	}
-
 	return allErrs
 }

--- a/apis/core/validation/installation_test.go
+++ b/apis/core/validation/installation_test.go
@@ -402,10 +402,6 @@ var _ = Describe("Installation", func() {
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("imports.data[0].secretRef.namespace"),
 			}))))
-			Expect(allErrs).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("imports.data[0].secretRef.key"),
-			}))))
 		})
 
 		It("should fail if secret imports contain empty values", func() {
@@ -426,10 +422,6 @@ var _ = Describe("Installation", func() {
 			Expect(allErrs).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("imports.data[0].configMapRef.namespace"),
-			}))))
-			Expect(allErrs).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("imports.data[0].configMapRef.key"),
 			}))))
 		})
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -2774,7 +2774,7 @@ func schema_landscaper_apis_core_v1alpha1_ConfigMapReference(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"name", "key"},
+				Required: []string{"name"},
 			},
 		},
 	}
@@ -4940,7 +4940,7 @@ func schema_landscaper_apis_core_v1alpha1_SecretReference(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name", "key"},
+				Required: []string{"name"},
 			},
 		},
 	}

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1776,6 +1776,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Key is the name of the key in the configmap that holds the data.</p>
 </td>
 </tr>
@@ -3965,6 +3966,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Key is the name of the key in the secret that holds the data.</p>
 </td>
 </tr>

--- a/docs/usage/Installations.md
+++ b/docs/usage/Installations.md
@@ -291,6 +291,25 @@ By default dataobjects are used but for usability users can directly specify sec
 Dataobjects are the internal format of the landscaper for its data flow, therefore they are [contextified](../concepts/Context.md) by default and can also be referenced directly by their name. 
 To reference a dataobject directly, prefix the `dataRef` with `#`.
 
+Data can be also imported using secrets or configmaps.
+A secret/configmap is referenced using its name, namespace and key inside data section.
+The namespace is optional and will be defaulted to the namespace of the installation.
+The key is also optional and if omitted the whole data section is used as object.
+
+e.g. 
+```yaml
+apiVersion: v1
+kind: Secret
+data:
+  seedBackupCredentials: <base64 of accessKeyID + secretAccessKey>
+# can be also written as
+apiVersion: v1
+kind: Secret
+data:
+  accessKeyID: <id>
+  secretAccessKey: <more secret stuff>
+```
+
 ```yaml
 imports:
   data:
@@ -299,13 +318,13 @@ imports:
   - name: my-import
     secretRef: 
       name: ""
-      namespace: ""
-      key: ""
+      namespace: "" #  optional, defaulted to installation namespace
+      key: "" # optional
   - name: my-import
     configMapRef: 
       name: ""
-      namespace: ""
-      key: ""
+      namespace: "" #  optional, defaulted to installation namespace
+      key: "" # optional
 ```
 
 ### Target Imports

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployerregistrations.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployerregistrations.yaml
@@ -408,7 +408,6 @@ spec:
                                   type: string
                               required:
                               - name
-                              - key
                               type: object
                             dataRef:
                               description: DataRef is the name of the in-cluster data
@@ -438,7 +437,6 @@ spec:
                                   type: string
                               required:
                               - name
-                              - key
                               type: object
                             version:
                               description: Version specifies the imported data version.

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
@@ -446,7 +446,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                         dataRef:
                           description: DataRef is the name of the in-cluster data
@@ -474,7 +473,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                         version:
                           description: Version specifies the imported data version.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -262,6 +262,7 @@ type VersionedNamedObjectReference struct {
 type SecretReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the secret that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 
@@ -270,6 +271,7 @@ type SecretReference struct {
 type ConfigMapReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the configmap that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -272,6 +272,7 @@ type VersionedNamedObjectReference struct {
 type SecretReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the secret that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 
@@ -280,6 +281,7 @@ type SecretReference struct {
 type ConfigMapReference struct {
 	ObjectReference `json:",inline"`
 	// Key is the name of the key in the configmap that holds the data.
+	// +optional
 	Key string `json:"key"`
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/validation/installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/validation/installation.go
@@ -276,23 +276,13 @@ func ValidateObjectReferenceList(orl []core.ObjectReference, fldPath *field.Path
 // ValidateSecretReference validates that the secret reference is valid
 func ValidateSecretReference(sr core.SecretReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
 	allErrs = append(allErrs, ValidateObjectReference(sr.ObjectReference, fldPath)...)
-	if sr.Key == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("key"), "key must not be empty"))
-	}
-
 	return allErrs
 }
 
 // ValidateConfigMapReference validates that the secret reference is valid
 func ValidateConfigMapReference(cmr core.ConfigMapReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
 	allErrs = append(allErrs, ValidateObjectReference(cmr.ObjectReference, fldPath)...)
-	if cmr.Key == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("key"), "key must not be empty"))
-	}
-
 	return allErrs
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/235

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to omit the key for secret and configmap imports. These imports do now use the whole data section as object.
See the documentation for details.
```
