### PR TITLE
Properly reconcile DeployItems from Executions

### DIFF
--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -43,60 +43,63 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 
 	var phase lsv1alpha1.ExecutionPhase
 	for _, item := range executionItems {
-		if item.DeployItem != nil && !o.forceReconcile {
-			phase = lsv1alpha1helper.CombinedExecutionPhase(phase, item.DeployItem.Status.Phase)
-			deployItemStatusUpToDate := item.DeployItem.Status.ObservedGeneration == item.DeployItem.GetGeneration()
-
-			// we need to check if the deployitem is failed due to that its not picked up by a deployer.
-			// This is a error scenario that needs special handling as other detections in this code will not work.
-			// Mostly due to outdated observed generation
-			if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed &&
-				(item.DeployItem.Status.LastError != nil && item.DeployItem.Status.LastError.Reason == lsv1alpha1.PickupTimeoutReason) {
-				o.exec.Status.ObservedGeneration = o.exec.Generation
-				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
-					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
-						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name)))
-				return lserrors.NewError(
-					"DeployItemReconcile",
-					"DeployItemFailed",
-					fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name),
-				)
-			}
-
-			if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) || !deployItemStatusUpToDate {
-				o.EventRecorder().Eventf(o.exec, corev1.EventTypeNormal,
-					"DeployItemCompleted",
-					"deploy item %s not triggered because it already exists and is not completed", item.Info.Name,
-				)
-				o.Log().V(5).Info("deploy item not triggered because already existing and not completed", "name", item.Info.Name)
-				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
-				phase = lsv1alpha1.ExecutionPhaseProgressing
-				continue
-			}
-
+		if item.DeployItem != nil {
 			// get last applied status from own status
 			var lastAppliedGeneration int64
 			if ref, ok := lsv1alpha1helper.GetVersionedNamedObjectReference(o.exec.Status.DeployItemReferences, item.Info.Name); ok {
 				lastAppliedGeneration = ref.Reference.ObservedGeneration
 			}
+			deployItemLastAppliedUpToDate := lastAppliedGeneration == item.DeployItem.GetGeneration()
 
-			if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed && lastAppliedGeneration == o.exec.Generation {
-				// TODO: check if need to wait for other deploy items to finish
-				o.exec.Status.ObservedGeneration = o.exec.Generation
-				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
-					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
-						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) is in failed state", item.Info.Name, item.DeployItem.Name)))
-				return lserrors.NewError(
-					"DeployItemReconcile",
-					"DeployItemFailed",
-					fmt.Sprintf("reconciliation of deploy item %q failed", item.DeployItem.Name),
-				)
-			}
+			if deployItemLastAppliedUpToDate && !o.forceReconcile {
+				phase = lsv1alpha1helper.CombinedExecutionPhase(phase, item.DeployItem.Status.Phase)
+				deployItemStatusUpToDate := item.DeployItem.Status.ObservedGeneration == item.DeployItem.GetGeneration()
 
-			if lastAppliedGeneration == o.exec.Generation {
-				continue
+				// we need to check if the deployitem is failed due to that its not picked up by a deployer.
+				// This is a error scenario that needs special handling as other detections in this code will not work.
+				// Mostly due to outdated observed generation
+				if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed &&
+					(item.DeployItem.Status.LastError != nil && item.DeployItem.Status.LastError.Reason == lsv1alpha1.PickupTimeoutReason) {
+					o.exec.Status.ObservedGeneration = o.exec.Generation
+					o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+					o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
+						lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
+							"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name)))
+					return lserrors.NewError(
+						"DeployItemReconcile",
+						"DeployItemFailed",
+						fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name),
+					)
+				}
+
+				if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) || !deployItemStatusUpToDate {
+					o.EventRecorder().Eventf(o.exec, corev1.EventTypeNormal,
+						"DeployItemCompleted",
+						"deploy item %s not triggered because it already exists and is not completed", item.Info.Name,
+					)
+					o.Log().V(5).Info("deploy item not triggered because already existing and not completed", "name", item.Info.Name)
+					o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
+					phase = lsv1alpha1.ExecutionPhaseProgressing
+					continue
+				}
+
+				if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed && lastAppliedGeneration == o.exec.Generation {
+					// TODO: check if need to wait for other deploy items to finish
+					o.exec.Status.ObservedGeneration = o.exec.Generation
+					o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+					o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
+						lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
+							"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) is in failed state", item.Info.Name, item.DeployItem.Name)))
+					return lserrors.NewError(
+						"DeployItemReconcile",
+						"DeployItemFailed",
+						fmt.Sprintf("reconciliation of deploy item %q failed", item.DeployItem.Name),
+					)
+				}
+
+				if lastAppliedGeneration == o.exec.Generation {
+					continue
+				}
 			}
 		}
 		runnable, err := o.checkRunnable(ctx, item, executionItems)
@@ -152,6 +155,7 @@ func (o *Operation) deployOrTrigger(ctx context.Context, item executionItem) err
 		item.DeployItem = &lsv1alpha1.DeployItem{}
 		item.DeployItem.GenerateName = fmt.Sprintf("%s-%s-", o.exec.Name, item.Info.Name)
 		item.DeployItem.Namespace = o.exec.Namespace
+		item.DeployItem.Generation = o.exec.Generation
 	}
 	item.DeployItem.Spec.RegistryPullSecrets = o.exec.Spec.RegistryPullSecrets
 
@@ -167,7 +171,7 @@ func (o *Operation) deployOrTrigger(ctx context.Context, item executionItem) err
 	ref.Name = item.Info.Name
 	ref.Reference.Name = item.DeployItem.Name
 	ref.Reference.Namespace = item.DeployItem.Namespace
-	ref.Reference.ObservedGeneration = o.exec.Generation
+	ref.Reference.ObservedGeneration = item.DeployItem.Generation
 
 	old := o.exec.DeepCopy()
 	o.exec.Status.DeployItemReferences = lsv1alpha1helper.SetVersionedNamedObjectReference(o.exec.Status.DeployItemReferences, ref)

--- a/pkg/landscaper/execution/testdata/state/test2/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test2/10-deploy-item.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     execution.landscaper.gardener.cloud/managed-by: exec-1
     execution.landscaper.gardener.cloud/name: a
-  generation: 1
+  generation: 2
 spec:
   type: landscaper.gardener.cloud/helm
   config:
@@ -18,4 +18,4 @@ spec:
 
 status:
   phase: Progressing
-  observedGeneration: 1
+  observedGeneration: 2

--- a/pkg/landscaper/execution/testdata/state/test5/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test5/10-deploy-item.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     execution.landscaper.gardener.cloud/managed-by: exec-1
     execution.landscaper.gardener.cloud/name: a
-  generation: 1
+  generation: 2
 spec:
   type: landscaper.gardener.cloud/helm
   config:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:
So far, the landscaper-controller did not fully follow the K8S pattern of reconciliation - it would only reconcile dependent resources if the parent got modified in any way.
This PR changes the reconciliation logic of Execution -> DeployItem so that any changes to DeployItems will trigger the reconciler and make sure that the desired state (as described by the Execution) will match the actual state (as represented by the DeployItems).

**Which issue(s) this PR fixes**:
one of mutliple PRs to deal with #239
Fixes #103 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improves reconciliation logic for Executions and their dependent DeployItems.
```
