### PR TITLE
Propagate phase changes from deploy items to execution

### DIFF
--- a/pkg/landscaper/controllers/execution/reconcile_test.go
+++ b/pkg/landscaper/controllers/execution/reconcile_test.go
@@ -82,4 +82,57 @@ var _ = Describe("Reconcile", func() {
 		Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))).To(BeTrue(), "expect the execution to be deleted")
 	})
 
+	It("should adapt the status of the execution if a deploy item changes from Failed to Succeeded and vice versa", func() {
+		ctx := context.Background()
+		// first deploy reconcile a simple execution with one deploy item
+		exec := &lsv1alpha1.Execution{}
+		exec.GenerateName = "test-"
+		exec.Namespace = state.Namespace
+		exec.Spec.DeployItems = []lsv1alpha1.DeployItemTemplate{
+			{
+				Name: "def",
+				Type: "test-type",
+				Configuration: &runtime.RawExtension{
+					Raw: []byte(`
+{
+  "apiVersion": "sometest",
+  "kind": "somekind"
+}
+`),
+				},
+			},
+		}
+		testutils.ExpectNoError(state.Create(ctx, testenv.Client, exec))
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+
+		// expect a deploy item
+		items := &lsv1alpha1.DeployItemList{}
+		testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
+		Expect(items.Items).To(HaveLen(1))
+		di := &items.Items[0]
+		//set item to failed state
+		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+		di.Status.ObservedGeneration = di.Generation
+		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+
+		// then reconcile the execution and expect the execution to be Failed
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+
+		// set deployitem phase to Succeeded and check again
+		di.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
+		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+
+		// verify that from Succeeded to Failed also works
+		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+	})
+
 })

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -57,11 +57,13 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
 					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name)))
-				return lserrors.NewError(
+				o.exec.Status.LastError = lserrors.UpdatedError(
+					o.exec.Status.LastError,
 					"DeployItemReconcile",
 					"DeployItemFailed",
 					fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name),
 				)
+				return nil
 			}
 
 			if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) || !deployItemStatusUpToDate {
@@ -88,11 +90,13 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
 					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) is in failed state", item.Info.Name, item.DeployItem.Name)))
-				return lserrors.NewError(
+				o.exec.Status.LastError = lserrors.UpdatedError(
+					o.exec.Status.LastError,
 					"DeployItemReconcile",
 					"DeployItemFailed",
 					fmt.Sprintf("reconciliation of deploy item %q failed", item.DeployItem.Name),
 				)
+				return nil
 			}
 
 			if lastAppliedGeneration == o.exec.Generation {

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 			err := eOp.Reconcile(ctx)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 			err := eOp.Reconcile(ctx)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 		})
 	})
@@ -179,7 +179,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 		err := eOp.Reconcile(ctx)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 		Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
 	})
 

--- a/pkg/landscaper/execution/testdata/state/test5/00-execution.yaml
+++ b/pkg/landscaper/execution/testdata/state/test5/00-execution.yaml
@@ -25,5 +25,5 @@ status:
   - name: a
     ref:
       name: di-a
-      namespace: test2
+      namespace: test5
       observedGeneration: 2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**Which issue(s) this PR fixes**:
This is part of #239 / #275

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Phase changes in deploy items are now properly propagated to their owning execution, even if the execution was already in a final phase and there weren't any changes to the installation.
```
