### PR TITLE
add support for digests in landscaper charts

### DIFF
--- a/charts/container-deployer/templates/_helpers.tpl
+++ b/charts/container-deployer/templates/_helpers.tpl
@@ -73,12 +73,12 @@ identity: {{ .Values.deployer.identity }}
 {{- end }}
 namespace: {{ .Values.deployer.namespace | default .Release.Namespace  }}
 initContainer:
-  image: "{{ .Values.deployer.initContainer.repository }}:{{ .Values.deployer.initContainer.tag | default .Chart.AppVersion }}"
+  image: "{{ include "init-image" . }}"
 waitContainer:
-  image: "{{ .Values.deployer.waitContainer.repository }}:{{ .Values.deployer.waitContainer.tag | default .Chart.AppVersion }}"
+  image: "{{ include "wait-image" . }}"
 {{- if .Values.deployer.defaultImage }}
 defaultImage:
-  image: "{{ required .Values.deployer.defaultImage.repository }}:{{ required .Values.deployer.defaultImage.tag }}"
+  image: "{{ include "utils-templates.image" .Values.deployer.defaultImage }}"
 {{- end }}
 {{- if .Values.deployer.oci }}
 oci:
@@ -96,3 +96,29 @@ targetSelector:
 {{ toYaml . }}
 {{- end }}
 {{- end }}
+
+{{- define "deployer-image" -}}
+{{- $tag := ( .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "init-image" -}}
+{{- $tag := ( .Values.deployer.initContainer.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.deployer.initContainer.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "wait-image" -}}
+{{- $tag := ( .Values.deployer.waitContainer.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.deployer.waitContainer.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/container-deployer/templates/deployment.yaml
+++ b/charts/container-deployer/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "deployer-image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"

--- a/charts/helm-deployer/templates/_helpers.tpl
+++ b/charts/helm-deployer/templates/_helpers.tpl
@@ -88,3 +88,17 @@ targetSelector:
 {{ toYaml . }}
 {{- end }}
 {{- end }}
+
+{{- define "deployer-image" -}}
+{{- $tag := ( .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/helm-deployer/templates/deployment.yaml
+++ b/charts/helm-deployer/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "deployer-image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"

--- a/charts/landscaper-agent/templates/_helpers.tpl
+++ b/charts/landscaper-agent/templates/_helpers.tpl
@@ -99,3 +99,17 @@ oci:
 {{ end }}
 
 {{- end }}
+
+{{- define "landscaper-agent-image" -}}
+{{- $tag := ( .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/landscaper-agent/templates/deployment.yaml
+++ b/charts/landscaper-agent/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "landscaper-agent-image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"

--- a/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/templates/_helpers.tpl
@@ -126,3 +126,23 @@ deployItemTimeouts:
 {{- end }}
 
 {{- end }}
+
+{{- define "landscaper-image" -}}
+{{- $tag := ( .Values.controller.image.tag | default .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.controller.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "landscaper-webhook-image" -}}
+{{- $tag := ( .Values.webhooksServer.image.tag | default .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.webhooksServer.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/landscaper/templates/deployment-controller.yaml
+++ b/charts/landscaper/templates/deployment-controller.yaml
@@ -36,7 +36,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "landscaper-image" . }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"

--- a/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/templates/deployment-webhooks.yaml
@@ -36,7 +36,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.webhooksServer.image.repository }}:{{ .Values.webhooksServer.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "landscaper-webhook-image" . }}"
           imagePullPolicy: {{ .Values.webhooksServer.image.pullPolicy }}
           args:
           - "-v={{ .Values.landscaper.verbosity }}"

--- a/charts/manifest-deployer/templates/_helpers.tpl
+++ b/charts/manifest-deployer/templates/_helpers.tpl
@@ -77,3 +77,17 @@ targetSelector:
 {{ toYaml . }}
 {{- end }}
 {{- end }}
+
+{{- define "deployer-image" -}}
+{{- $tag := ( .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/manifest-deployer/templates/deployment.yaml
+++ b/charts/manifest-deployer/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "deployer-image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/mock-deployer/templates/_helpers.tpl
+++ b/charts/mock-deployer/templates/_helpers.tpl
@@ -76,3 +76,17 @@ targetSelector:
 {{ toYaml . }}
 {{- end }}
 {{- end }}
+
+{{- define "deployer-image" -}}
+{{- $tag := ( .Values.image.tag | default .Chart.AppVersion )  -}}
+{{- $image :=  dict "repository" .Values.image.repository "tag" $tag  -}}
+{{- include "utils-templates.image" $image }}
+{{- end -}}
+
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/mock-deployer/templates/deployment.yaml
+++ b/charts/mock-deployer/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "deployer-image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - "--config=/app/ls/config/config.yaml"

--- a/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
@@ -41,7 +41,7 @@ func LandscaperTplFuncMap(fs vfs.FileSystem, cd *cdv2.ComponentDescriptor, cdLis
 
 		"toYaml": toYAML,
 
-		"parseOCIRef":   parseOCIReference,
+		"parseOCIRef":   lstmpl.ParseOCIReference,
 		"ociRefRepo":    getOCIReferenceRepository,
 		"ociRefVersion": getOCIReferenceVersion,
 		"resolve":       resolveArtifactFunc(blobResolver),
@@ -93,28 +93,14 @@ func toYAML(v interface{}) string {
 	return strings.TrimSuffix(string(data), "\n")
 }
 
-// parseOCIReference parses a oci reference string into its repository and version.
-// e.g. host:5000/myrepo/myimage:1.0.0 -> ["host:5000/myrepo/myimage:1.0.0", "1.0.0"]
-func parseOCIReference(ref string) [2]string {
-	splitRef := strings.Split(ref, ":")
-	if len(splitRef) < 2 {
-		panic("invalid reference")
-	}
-
-	return [2]string{
-		strings.Join(splitRef[:len(splitRef)-1], ":"),
-		splitRef[len(splitRef)-1],
-	}
-}
-
 // getOCIReferenceVersion returns the version of a oci reference
 func getOCIReferenceVersion(ref string) string {
-	return parseOCIReference(ref)[1]
+	return lstmpl.ParseOCIReference(ref)[1]
 }
 
 // getOCIReferenceRepository returns the repository of a oci reference
 func getOCIReferenceRepository(ref string) string {
-	return parseOCIReference(ref)[0]
+	return lstmpl.ParseOCIReference(ref)[0]
 }
 
 // resolveArtifactFunc returns a function that can resolve artifact defined by a component descriptor access

--- a/pkg/landscaper/installations/executions/template/spiff/funcs.go
+++ b/pkg/landscaper/installations/executions/template/spiff/funcs.go
@@ -23,6 +23,9 @@ func LandscaperSpiffFuncs(functions spiffing.Functions, cd *cdv2.ComponentDescri
 	functions.RegisterFunction("getResource", spiffResolveResources(cd))
 	functions.RegisterFunction("getComponent", spiffResolveComponent(cd, cdList))
 	functions.RegisterFunction("generateImageOverwrite", spiffGenerateImageOverwrite(cd, cdList))
+	functions.RegisterFunction("parseOCIRef", parseOCIReference)
+	functions.RegisterFunction("ociRefRepo", getOCIReferenceRepository)
+	functions.RegisterFunction("ociRefVersion", getOCIReferenceVersion)
 }
 
 func spiffResolveResources(cd *cdv2.ComponentDescriptor) func(arguments []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
@@ -169,4 +172,76 @@ func spiffGenerateImageOverwrite(cd *cdv2.ComponentDescriptor, cdList *cdv2.Comp
 
 		return result.Value(), info, true
 	}
+}
+
+func parseOCIReference(arguments []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+	info := dynaml.DefaultInfo()
+	if len(arguments) > 1 {
+		return info.Error("Too many arguments for parseOCIReference. Expected 1 reference.")
+	}
+	ref := arguments[0].(string)
+	data, err := yaml.Marshal(template.ParseOCIReference(ref))
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	node, err := spiffyaml.Parse("", data)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	result, err := binding.Flow(node, false)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	return result.Value(), info, true
+}
+
+func getOCIReferenceRepository(arguments []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+	info := dynaml.DefaultInfo()
+	if len(arguments) > 1 {
+		return info.Error("Too many arguments for parseOCIReference. Expected 1 reference.")
+	}
+	ref := arguments[0].(string)
+	data, err := yaml.Marshal(template.ParseOCIReference(ref)[0])
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	node, err := spiffyaml.Parse("", data)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	result, err := binding.Flow(node, false)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	return result.Value(), info, true
+}
+
+func getOCIReferenceVersion(arguments []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+	info := dynaml.DefaultInfo()
+	if len(arguments) > 1 {
+		return info.Error("Too many arguments for parseOCIReference. Expected 1 reference.")
+	}
+	ref := arguments[0].(string)
+	data, err := yaml.Marshal(template.ParseOCIReference(ref)[1])
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	node, err := spiffyaml.Parse("", data)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	result, err := binding.Flow(node, false)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	return result.Value(), info, true
 }

--- a/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-13.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-13.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: GoTemplate
+  template: |
+    deployItems:
+    - name: init
+      type: container
+      config:
+        apiVersion: example.test/v1
+        kind: Configuration
+        {{- $image := parseOCIRef .imports.ref1 }}
+        image0: "{{ index $image 0 }}:{{ index $image 1 }}"
+        image1: "{{ ociRefRepo .imports.ref1 }}:{{ ociRefVersion .imports.ref1 }}"
+        image2: "{{ ociRefRepo .imports.ref2 }}@{{ ociRefVersion .imports.ref2 }}"

--- a/pkg/landscaper/installations/executions/template/testdata/spifftemplate/template-13.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/spifftemplate/template-13.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: Spiff
+  template:
+    deployItems:
+    - name: init
+      type: container
+      config:
+        apiVersion: example.test/v1
+        kind: Configuration
+        tmp: (( parseOCIRef( imports.ref1 ) ))
+        image0: (( tmp[0] ":" tmp[1] ))
+        image1: (( ociRefRepo( imports.ref1 ) ":" ociRefVersion( imports.ref1 ) ))
+        image2: (( ociRefRepo( imports.ref2 ) "@" ociRefVersion( imports.ref2 ) ))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

It is now possible to provide digest in the landscaper helm charts

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
It is now possible to provide oci images addressed by their digest in all landscaper provided helm charts.
```
