### PR TITLE
Add webhooks server commands line flags "webhook-url" and "certificates-namespace"

### DIFF
--- a/cmd/landscaper-webhooks-server/app/app.go
+++ b/cmd/landscaper-webhooks-server/app/app.go
@@ -120,13 +120,14 @@ func registerWebhooks(ctx context.Context,
 		ServicePort:        o.webhook.webhookServicePort,
 		ServiceName:        o.webhook.webhookServiceName,
 		ServiceNamespace:   o.webhook.webhookServiceNamespace,
+		ServiceURL:         o.webhookURL,
 		WebhookedResources: o.webhook.enabledWebhooks,
 	}
 
 	// generate certificates
 	webhookServer.CertDir = filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
 	var err error
-	wo.CABundle, err = webhook.GenerateCertificates(ctx, kubeClient, webhookServer.CertDir, wo.ServiceNamespace, wo.ServiceName)
+	wo.CABundle, err = webhook.GenerateCertificates(ctx, kubeClient, webhookServer.CertDir, o.webhook.certificatesNamespace, wo.ServiceName)
 	if err != nil {
 		return fmt.Errorf("unable to generate webhook certificates: %w", err)
 	}

--- a/cmd/landscaper-webhooks-server/app/app.go
+++ b/cmd/landscaper-webhooks-server/app/app.go
@@ -120,7 +120,7 @@ func registerWebhooks(ctx context.Context,
 		ServicePort:        o.webhook.webhookServicePort,
 		ServiceName:        o.webhook.webhookServiceName,
 		ServiceNamespace:   o.webhook.webhookServiceNamespace,
-		ServiceURL:         o.webhookURL,
+		WebhookURL:         o.webhookURL,
 		WebhookedResources: o.webhook.enabledWebhooks,
 	}
 

--- a/pkg/utils/webhook/add.go
+++ b/pkg/utils/webhook/add.go
@@ -45,7 +45,7 @@ type Options struct {
 	// port of the service
 	ServicePort int32
 	// external service URL
-	ServiceURL string
+	WebhookURL string
 	// LabelSelector that is used to filter all resources handled by this webhook
 	ObjectSelector metav1.LabelSelector
 	// the resources that should be handled by this webhook
@@ -83,9 +83,9 @@ func UpdateValidatingWebhookConfiguration(ctx context.Context, kubeClient client
 		clientConfig := admissionregistrationv1.WebhookClientConfig{
 			CABundle: o.CABundle,
 		}
-		if len(o.ServiceURL) != 0 {
-			serviceURL := path.Join(o.ServiceURL, o.WebhookBasePath, elem.ResourceName)
-			clientConfig.URL = &serviceURL
+		if len(o.WebhookURL) != 0 {
+			webhookURL := path.Join(o.WebhookURL, o.WebhookBasePath, elem.ResourceName)
+			clientConfig.URL = &webhookURL
 		} else {
 			webhookPath := path.Join(o.WebhookBasePath, elem.ResourceName)
 			clientConfig.Service = &admissionregistrationv1.ServiceReference{

--- a/pkg/utils/webhook/add.go
+++ b/pkg/utils/webhook/add.go
@@ -44,6 +44,8 @@ type Options struct {
 	ServiceNamespace string
 	// port of the service
 	ServicePort int32
+	// external service URL
+	ServiceURL string
 	// LabelSelector that is used to filter all resources handled by this webhook
 	ObjectSelector metav1.LabelSelector
 	// the resources that should be handled by this webhook
@@ -78,7 +80,21 @@ func UpdateValidatingWebhookConfiguration(ctx context.Context, kubeClient client
 		rule.Rule.APIGroups = []string{elem.APIGroup}
 		rule.Rule.APIVersions = elem.APIVersions
 		rule.Rule.Resources = []string{elem.ResourceName}
-		webhookPath := path.Join(o.WebhookBasePath, elem.ResourceName)
+		clientConfig := admissionregistrationv1.WebhookClientConfig{
+			CABundle: o.CABundle,
+		}
+		if len(o.ServiceURL) != 0 {
+			serviceURL := path.Join(o.ServiceURL, o.WebhookBasePath, elem.ResourceName)
+			clientConfig.URL = &serviceURL
+		} else {
+			webhookPath := path.Join(o.WebhookBasePath, elem.ResourceName)
+			clientConfig.Service = &admissionregistrationv1.ServiceReference{
+				Namespace: o.ServiceNamespace,
+				Name:      o.ServiceName,
+				Path:      &webhookPath,
+				Port:      &o.ServicePort,
+			}
+		}
 		vwcWebhook := admissionregistrationv1.ValidatingWebhook{
 			Name:                    elem.ResourceName + o.WebhookNameSuffix,
 			SideEffects:             &noSideEffects,
@@ -86,15 +102,7 @@ func UpdateValidatingWebhookConfiguration(ctx context.Context, kubeClient client
 			ObjectSelector:          &o.ObjectSelector,
 			AdmissionReviewVersions: []string{"v1"},
 			Rules:                   []admissionregistrationv1.RuleWithOperations{rule},
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				Service: &admissionregistrationv1.ServiceReference{
-					Namespace: o.ServiceNamespace,
-					Name:      o.ServiceName,
-					Path:      &webhookPath,
-					Port:      &o.ServicePort,
-				},
-				CABundle: o.CABundle,
-			},
+			ClientConfig:            clientConfig,
 		}
 		vwcWebhooks = append(vwcWebhooks, vwcWebhook)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Currently the landscaper webhook server needs to target in the same cluster where the webhook service is created.
When the webhook server is targeting a different cluster, the service reference that is currently being used, does no longer work.
For this use case an URL can be specified in the ValidatingWebhook configuration (see [here](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#url)), which references an _external_ webhook endpoint.

This PR add two new command line flags:

- _webhook-url_: Specifies the URL of the webhook service
- _certificates-namespace_: Allows to specify a namespace in which the webhook certificates are being stored. This is important because the namespace in which the webhook service is running may not be available in the targeting cluster. Therefore it needs to be specified manually.


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add command line flags "webhook-url" and "certificates-namespace" which allow to run the webhooks server in an external cluster.
```
