### PR TITLE
fixed the handling of the webhook-url command line flag

### DIFF
--- a/cmd/landscaper-webhooks-server/app/app.go
+++ b/cmd/landscaper-webhooks-server/app/app.go
@@ -127,20 +127,15 @@ func registerWebhooks(ctx context.Context,
 	// generate certificates
 	webhookServer.CertDir = filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
 	var err error
-	var dnsNamesConfig webhook.DNSNamesConfig
+	var dnsNames []string
 	if len(wo.WebhookURL) != 0 {
-		conf := webhook.DNSWebhookURLConfig{}
-		err = conf.Set(wo.WebhookURL)
-		if err != nil {
+		if dnsNames, err = webhook.GetDNSNamesFromURL(wo.WebhookURL); err != nil {
 			return fmt.Errorf("unable to create webhook certificate configuration: %w", err)
 		}
-		dnsNamesConfig = &conf
 	} else {
-		conf := webhook.DNSNamespacedNameConfig{}
-		conf.Set(wo.ServiceName, wo.ServiceNamespace)
-		dnsNamesConfig = &conf
+		dnsNames = webhook.GeDNSNamesFromNamespacedName(wo.ServiceNamespace, wo.ServiceName)
 	}
-	wo.CABundle, err = webhook.GenerateCertificates(ctx, kubeClient, webhookServer.CertDir, o.webhook.certificatesNamespace, dnsNamesConfig)
+	wo.CABundle, err = webhook.GenerateCertificates(ctx, kubeClient, webhookServer.CertDir, o.webhook.certificatesNamespace, "landscaper-webhook", dnsNames)
 	if err != nil {
 		return fmt.Errorf("unable to generate webhook certificates: %w", err)
 	}

--- a/cmd/landscaper-webhooks-server/app/app.go
+++ b/cmd/landscaper-webhooks-server/app/app.go
@@ -132,7 +132,7 @@ func registerWebhooks(ctx context.Context,
 		conf := webhook.DNSWebhookURLConfig{}
 		err = conf.Set(wo.WebhookURL)
 		if err != nil {
-			return fmt.Errorf("unabble to create webhook certificate configuration: %w", err)
+			return fmt.Errorf("unable to create webhook certificate configuration: %w", err)
 		}
 		dnsNamesConfig = &conf
 	} else {

--- a/pkg/utils/webhook/certificates.go
+++ b/pkg/utils/webhook/certificates.go
@@ -169,7 +169,7 @@ func GenerateNewCAAndServerCert(dnsNamesConfig DNSNamesConfig, caConfig certific
 	)
 
 	serverConfig := &certificates.CertificateSecretConfig{
-		CommonName:  "webhook-ca",
+		CommonName:  "landscaper-webhooks",
 		DNSNames:    dnsNamesConfig.Get(),
 		IPAddresses: ipAddresses,
 		CertType:    certificates.ServerCert,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority 3

**What this PR does / why we need it**:

When the `--webhook-url` flag was passed, the `URL` field in the `WebhookClientConfig` was not calculated correctly.
Additionally it is also no longer possible to derive the DNS names from the service name and namespace when using the `--webhook-url` flag.
With this change, the DNS name is directly derived from the webhook url.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```

```
