### PR TITLE
Propagate phase changes from executions/subinstallations to installations

### DIFF
--- a/pkg/landscaper/controllers/installations/reconcile_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_test.go
@@ -5,13 +5,25 @@
 package installations_test
 
 import (
+	"context"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/ctf"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/api"
 	installationsctl "github.com/gardener/landscaper/pkg/landscaper/controllers/installations"
+	lsoperation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	"github.com/gardener/landscaper/test/utils"
+	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
 var _ = Describe("Reconcile", func() {
@@ -42,6 +54,101 @@ var _ = Describe("Reconcile", func() {
 			Expect(c.HandleComponentReference(inst)).To(Succeed())
 			Expect(inst.Spec.ComponentDescriptor.Reference.RepositoryContext.Object).To(Equal(repoCtx.Object))
 		})
+	})
+
+	Context("PhasePropagation", func() {
+
+		var (
+			op   *lsoperation.Operation
+			ctrl reconcile.Reconciler
+
+			state        *envtest.State
+			fakeCompRepo ctf.ComponentResolver
+		)
+
+		BeforeEach(func() {
+			var err error
+			fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata")
+			Expect(err).ToNot(HaveOccurred())
+
+			op = lsoperation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
+
+			ctrl = installationsctl.NewTestActuator(*op, &config.LandscaperConfiguration{
+				Registry: config.RegistryConfiguration{
+					Local: &config.LocalRegistryConfiguration{
+						RootPath: "./testdata",
+					},
+				},
+			})
+		})
+
+		AfterEach(func() {
+			if state != nil {
+				ctx := context.Background()
+				defer ctx.Done()
+				Expect(testenv.CleanupState(ctx, state)).ToNot(HaveOccurred())
+				state = nil
+			}
+		})
+
+		It("should propagate phase changes from executions to installations", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test4")
+			utils.ExpectNoError(err)
+
+			inst := state.Installations[state.Namespace+"/root"]
+			exec := state.Executions[state.Namespace+"/subexec"]
+
+			utils.ShouldReconcile(ctx, ctrl, utils.RequestFromObject(inst))
+			utils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+
+			// set execution phase to 'Failed' and check again
+			exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			utils.ExpectNoError(testenv.Client.Status().Update(ctx, exec))
+			utils.ShouldReconcile(ctx, ctrl, utils.RequestFromObject(inst))
+			utils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseFailed))
+
+			// set execution phase to 'Succeeded' and check again
+			exec.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
+			utils.ExpectNoError(testenv.Client.Status().Update(ctx, exec))
+			utils.ShouldReconcile(ctx, ctrl, utils.RequestFromObject(inst))
+			utils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+		})
+
+		It("should propagate phase changes from subinstallations to installations", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test4")
+			utils.ExpectNoError(err)
+
+			inst := state.Installations[state.Namespace+"/root"]
+			subinst := state.Installations[state.Namespace+"/subinst"]
+
+			utils.ShouldReconcile(ctx, ctrl, utils.RequestFromObject(inst))
+			utils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+
+			// set subinstallation phase to 'Failed' and check again
+			subinst.Status.Phase = lsv1alpha1.ComponentPhaseFailed
+			utils.ExpectNoError(testenv.Client.Status().Update(ctx, subinst))
+			utils.ShouldReconcile(ctx, ctrl, utils.RequestFromObject(inst))
+			utils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseFailed))
+
+			// set subinstallation phase to 'Succeeded' and check again
+			subinst.Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
+			utils.ExpectNoError(testenv.Client.Status().Update(ctx, subinst))
+			utils.ShouldReconcile(ctx, ctrl, utils.RequestFromObject(inst))
+			utils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+		})
+
 	})
 
 })

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/root2/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/root2/blueprint.yaml
@@ -1,0 +1,26 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+annotations:
+  local/name: root2
+  local/version: 1.0.0
+
+deployExecutions:
+- type: Spiff
+  template:
+    deployItems:
+    - name: subexec
+      type: landscaper.gardener.cloud/mock
+      config:
+        apiVersion: mock.deployer.landscaper.gardener.cloud/v1alpha1
+        kind: ProviderConfiguration
+
+subinstallations:
+- apiVersion: landscaper.gardener.cloud/v1alpha1
+  kind: InstallationTemplate
+  name: subinst
+  blueprint:
+    filesystem:
+      blueprint.yaml: |
+        apiVersion: landscaper.gardener.cloud/v1alpha1
+        kind: Blueprint

--- a/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
@@ -59,3 +59,11 @@ component:
       type: localFilesystemBlob
       mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: d
+  - name: root2
+    type: blueprint
+    version: 1.0.0
+    relation: local
+    access:
+      type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
+      filename: root2

--- a/pkg/landscaper/controllers/installations/testdata/state/test4/00-root.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test4/00-root.yaml
@@ -1,0 +1,33 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root
+  namespace: {{ .Namespace }}
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: root2
+
+status:
+  configGeneration: ""
+  executionRef:
+    name: subexec
+    namespace: {{ .Namespace }}
+  installationRefs:
+  - name: subinst
+    ref:
+      name: subinst
+      namespace: {{ .Namespace }}
+  observedGeneration: 1
+  phase: Succeeded

--- a/pkg/landscaper/controllers/installations/testdata/state/test4/10-exec.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test4/10-exec.yaml
@@ -1,0 +1,30 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: subexec
+  namespace: {{ .Namespace }}
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+  ownerReferences:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Installation
+    name: root
+    uid: abc-def-root
+spec:
+  deployItems:
+  - config:
+      apiVersion: mock.deployer.landscaper.gardener.cloud/v1alpha1
+      kind: ProviderConfiguration
+    name: subexec
+    type: landscaper.gardener.cloud/mock
+status:
+  deployItemRefs:
+  - name: subexec
+    ref:
+      name: root-subexec-abcde
+      namespace: {{ .Namespace }}
+      observedGeneration: 1
+  observedGeneration: 1
+  phase: Succeeded

--- a/pkg/landscaper/controllers/installations/testdata/state/test4/10-subinst.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test4/10-subinst.yaml
@@ -1,0 +1,38 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  annotations:
+    landscaper.gardener.cloud/subinstallation-name: subinst
+  labels:
+    landscaper.gardener.cloud/encompassed-by: root
+  name: subinst
+  namespace: {{ .Namespace }}
+  ownerReferences:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Installation
+    name: root
+    uid: abc-def-root
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    inline:
+      filesystem:
+        blueprint.yaml: |
+          apiVersion: landscaper.gardener.cloud/v1alpha1
+          kind: Blueprint
+
+status:
+  configGeneration: ""
+  observedGeneration: 1
+  phase: Succeeded

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -129,10 +129,15 @@ func (o *Operation) JSONSchemaValidator() *jsonschema.Validator {
 // ListSubinstallations returns a list of all subinstallations of the given installation.
 // Returns nil if no installations can be found
 func (o *Operation) ListSubinstallations(ctx context.Context) ([]*lsv1alpha1.Installation, error) {
+	return listSubinstallations(ctx, o.Client(), o.Inst.Info)
+}
+
+// listSubinstallations is a helper function which doesn't require an operation
+func listSubinstallations(ctx context.Context, kubeClient client.Client, inst *lsv1alpha1.Installation) ([]*lsv1alpha1.Installation, error) {
 	installationList := &lsv1alpha1.InstallationList{}
 
-	err := o.Client().List(ctx, installationList, client.InNamespace(o.Inst.Info.Namespace), client.MatchingLabels{
-		lsv1alpha1.EncompassedByLabel: o.Inst.Info.Name,
+	err := kubeClient.List(ctx, installationList, client.InNamespace(inst.Namespace), client.MatchingLabels{
+		lsv1alpha1.EncompassedByLabel: inst.Name,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/landscaper/registry/components/mock/resolver_mock.go
+++ b/pkg/landscaper/registry/components/mock/resolver_mock.go
@@ -13,30 +13,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockComponentResolver is a mock of ComponentResolver interface.
+// MockComponentResolver is a mock of ComponentResolver interface
 type MockComponentResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockComponentResolverMockRecorder
 }
 
-// MockComponentResolverMockRecorder is the mock recorder for MockComponentResolver.
+// MockComponentResolverMockRecorder is the mock recorder for MockComponentResolver
 type MockComponentResolverMockRecorder struct {
 	mock *MockComponentResolver
 }
 
-// NewMockComponentResolver creates a new mock instance.
+// NewMockComponentResolver creates a new mock instance
 func NewMockComponentResolver(ctrl *gomock.Controller) *MockComponentResolver {
 	mock := &MockComponentResolver{ctrl: ctrl}
 	mock.recorder = &MockComponentResolverMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockComponentResolver) EXPECT() *MockComponentResolverMockRecorder {
 	return m.recorder
 }
 
-// Resolve mocks base method.
+// Resolve mocks base method
 func (m *MockComponentResolver) Resolve(arg0 context.Context, arg1 v2.Repository, arg2, arg3 string) (*v2.ComponentDescriptor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", arg0, arg1, arg2, arg3)
@@ -45,13 +45,13 @@ func (m *MockComponentResolver) Resolve(arg0 context.Context, arg1 v2.Repository
 	return ret0, ret1
 }
 
-// Resolve indicates an expected call of Resolve.
+// Resolve indicates an expected call of Resolve
 func (mr *MockComponentResolverMockRecorder) Resolve(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockComponentResolver)(nil).Resolve), arg0, arg1, arg2, arg3)
 }
 
-// ResolveWithBlobResolver mocks base method.
+// ResolveWithBlobResolver mocks base method
 func (m *MockComponentResolver) ResolveWithBlobResolver(arg0 context.Context, arg1 v2.Repository, arg2, arg3 string) (*v2.ComponentDescriptor, ctf.BlobResolver, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithBlobResolver", arg0, arg1, arg2, arg3)
@@ -61,7 +61,7 @@ func (m *MockComponentResolver) ResolveWithBlobResolver(arg0 context.Context, ar
 	return ret0, ret1, ret2
 }
 
-// ResolveWithBlobResolver indicates an expected call of ResolveWithBlobResolver.
+// ResolveWithBlobResolver indicates an expected call of ResolveWithBlobResolver
 func (mr *MockComponentResolverMockRecorder) ResolveWithBlobResolver(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithBlobResolver", reflect.TypeOf((*MockComponentResolver)(nil).ResolveWithBlobResolver), arg0, arg1, arg2, arg3)

--- a/pkg/utils/kubernetes/mock/client_mock.go
+++ b/pkg/utils/kubernetes/mock/client_mock.go
@@ -15,30 +15,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...client.CreateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -50,14 +50,14 @@ func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...cl
 	return ret0
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockClientMockRecorder) Create(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), varargs...)
 }
 
-// Delete mocks base method.
+// Delete mocks base method
 func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -69,14 +69,14 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...cl
 	return ret0
 }
 
-// Delete indicates an expected call of Delete.
+// Delete indicates an expected call of Delete
 func (mr *MockClientMockRecorder) Delete(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
 }
 
-// DeleteAllOf mocks base method.
+// DeleteAllOf mocks base method
 func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteAllOfOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -88,14 +88,14 @@ func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 
 	return ret0
 }
 
-// DeleteAllOf indicates an expected call of DeleteAllOf.
+// DeleteAllOf indicates an expected call of DeleteAllOf
 func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOf", reflect.TypeOf((*MockClient)(nil).DeleteAllOf), varargs...)
 }
 
-// Get mocks base method.
+// Get mocks base method
 func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 client.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
@@ -103,13 +103,13 @@ func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 c
 	return ret0
 }
 
-// Get indicates an expected call of Get.
+// Get indicates an expected call of Get
 func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1, arg2)
 }
 
-// List mocks base method.
+// List mocks base method
 func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...client.ListOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -121,14 +121,14 @@ func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...
 	return ret0
 }
 
-// List indicates an expected call of List.
+// List indicates an expected call of List
 func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
-// Patch mocks base method.
+// Patch mocks base method
 func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -140,14 +140,14 @@ func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client
 	return ret0
 }
 
-// Patch indicates an expected call of Patch.
+// Patch indicates an expected call of Patch
 func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), varargs...)
 }
 
-// RESTMapper mocks base method.
+// RESTMapper mocks base method
 func (m *MockClient) RESTMapper() meta.RESTMapper {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RESTMapper")
@@ -155,13 +155,13 @@ func (m *MockClient) RESTMapper() meta.RESTMapper {
 	return ret0
 }
 
-// RESTMapper indicates an expected call of RESTMapper.
+// RESTMapper indicates an expected call of RESTMapper
 func (mr *MockClientMockRecorder) RESTMapper() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTMapper", reflect.TypeOf((*MockClient)(nil).RESTMapper))
 }
 
-// Scheme mocks base method.
+// Scheme mocks base method
 func (m *MockClient) Scheme() *runtime.Scheme {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scheme")
@@ -169,13 +169,13 @@ func (m *MockClient) Scheme() *runtime.Scheme {
 	return ret0
 }
 
-// Scheme indicates an expected call of Scheme.
+// Scheme indicates an expected call of Scheme
 func (mr *MockClientMockRecorder) Scheme() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scheme", reflect.TypeOf((*MockClient)(nil).Scheme))
 }
 
-// Status mocks base method.
+// Status mocks base method
 func (m *MockClient) Status() client.StatusWriter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
@@ -183,13 +183,13 @@ func (m *MockClient) Status() client.StatusWriter {
 	return ret0
 }
 
-// Status indicates an expected call of Status.
+// Status indicates an expected call of Status
 func (mr *MockClientMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockClient)(nil).Status))
 }
 
-// Update mocks base method.
+// Update mocks base method
 func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -201,37 +201,37 @@ func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...cl
 	return ret0
 }
 
-// Update indicates an expected call of Update.
+// Update indicates an expected call of Update
 func (mr *MockClientMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockClient)(nil).Update), varargs...)
 }
 
-// MockStatusWriter is a mock of StatusWriter interface.
+// MockStatusWriter is a mock of StatusWriter interface
 type MockStatusWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockStatusWriterMockRecorder
 }
 
-// MockStatusWriterMockRecorder is the mock recorder for MockStatusWriter.
+// MockStatusWriterMockRecorder is the mock recorder for MockStatusWriter
 type MockStatusWriterMockRecorder struct {
 	mock *MockStatusWriter
 }
 
-// NewMockStatusWriter creates a new mock instance.
+// NewMockStatusWriter creates a new mock instance
 func NewMockStatusWriter(ctrl *gomock.Controller) *MockStatusWriter {
 	mock := &MockStatusWriter{ctrl: ctrl}
 	mock.recorder = &MockStatusWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockStatusWriter) EXPECT() *MockStatusWriterMockRecorder {
 	return m.recorder
 }
 
-// Patch mocks base method.
+// Patch mocks base method
 func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -243,14 +243,14 @@ func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 
 	return ret0
 }
 
-// Patch indicates an expected call of Patch.
+// Patch indicates an expected call of Patch
 func (mr *MockStatusWriterMockRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockStatusWriter)(nil).Patch), varargs...)
 }
 
-// Update mocks base method.
+// Update mocks base method
 func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -262,7 +262,7 @@ func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2
 	return ret0
 }
 
-// Update indicates an expected call of Update.
+// Update indicates an expected call of Update
 func (mr *MockStatusWriterMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

See also #276

**Which issue(s) this PR fixes**:
This is part of #239 / #275

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Phase changes in executions and subinstallations are now properly propagated to their owning installation, even if the installation was already in a final phase and there weren't any changes to the spec.
```
