### PR TITLE
Adapt json parser of type AnyJson

### DIFF
--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -95,9 +95,13 @@ func (s AnyJSON) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json unmarshaling for a JSON
 func (s *AnyJSON) UnmarshalJSON(data []byte) error {
 	raw := json.RawMessage{}
-	if err := raw.UnmarshalJSON(data); err != nil {
-		return err
+
+	if string(data) != "null" {
+		if err := raw.UnmarshalJSON(data); err != nil {
+			return err
+		}
 	}
+
 	*s = AnyJSON{RawMessage: raw}
 	return nil
 }

--- a/apis/core/v1alpha1/types_shared_test.go
+++ b/apis/core/v1alpha1/types_shared_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("Shared Types", func() {
+
+	Context("ExportDefinitions", func() {
+		It("parsing null should result in empty raw message", func() {
+
+			executor1 := TemplateExecutor{}
+			result1, err := yaml.Marshal(executor1)
+
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(result1).NotTo(gomega.HaveLen(0))
+
+			executor2 := &TemplateExecutor{}
+			err = yaml.Unmarshal(result1, executor2)
+
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(executor2.Template.RawMessage).To(gomega.HaveLen(0))
+		})
+
+	})
+
+})

--- a/apis/core/v1alpha1/types_suite_test.go
+++ b/apis/core/v1alpha1/types_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	gomega.RegisterFailHandler(Fail)
+	RunSpecs(t, "Types Testing")
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -95,9 +95,13 @@ func (s AnyJSON) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json unmarshaling for a JSON
 func (s *AnyJSON) UnmarshalJSON(data []byte) error {
 	raw := json.RawMessage{}
-	if err := raw.UnmarshalJSON(data); err != nil {
-		return err
+
+	if string(data) != "null" {
+		if err := raw.UnmarshalJSON(data); err != nil {
+			return err
+		}
 	}
+
 	*s = AnyJSON{RawMessage: raw}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

If an AnyJson object is marshalled and the raw data are nil this results in the string "null". If objects like TemplateExecutor contain such an element they are not correctly handled when they are unmarshalled again, e.g. the in the unmarshalled object it is checkt if the raw data are empty, but in this case they contain "null". This PR resolves this problem by checking  during unmarshalling if the raw data contain "null" and resolves this to empty raw data.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Landscaper is now able to parse json.RawMessage values that are `null`.
```
