### PR TITLE
Adapt unmarshal AnyJSON

### DIFF
--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -94,14 +94,15 @@ func (s AnyJSON) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json unmarshaling for a JSON
 func (s *AnyJSON) UnmarshalJSON(data []byte) error {
-	raw := json.RawMessage{}
-
-	if string(data) != "null" {
-		if err := raw.UnmarshalJSON(data); err != nil {
-			return err
-		}
+	if string(data) == "null" {
+		*s = AnyJSON{RawMessage: nil}
+		return nil
 	}
 
+	raw := json.RawMessage{}
+	if err := raw.UnmarshalJSON(data); err != nil {
+		return err
+	}
 	*s = AnyJSON{RawMessage: raw}
 	return nil
 }

--- a/apis/core/v1alpha1/types_shared_test.go
+++ b/apis/core/v1alpha1/types_shared_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Shared Types", func() {
 			err = yaml.Unmarshal(result1, executor2)
 
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(executor2.Template.RawMessage).To(gomega.HaveLen(0))
+			gomega.Expect(executor2.Template.RawMessage).To(gomega.BeNil())
 		})
 
 	})

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -94,14 +94,15 @@ func (s AnyJSON) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json unmarshaling for a JSON
 func (s *AnyJSON) UnmarshalJSON(data []byte) error {
-	raw := json.RawMessage{}
-
-	if string(data) != "null" {
-		if err := raw.UnmarshalJSON(data); err != nil {
-			return err
-		}
+	if string(data) == "null" {
+		*s = AnyJSON{RawMessage: nil}
+		return nil
 	}
 
+	raw := json.RawMessage{}
+	if err := raw.UnmarshalJSON(data); err != nil {
+		return err
+	}
 	*s = AnyJSON{RawMessage: raw}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:
PR #284 has adjusted the unmarshaling of `AnyJSON`, so that "null" was unmarshaled into an `AnyJSON` whose `RawMessage` was a byte slice of length 0. 

The present PR modifies this and unmarshals "null" into an `AnyJSON` whose `RawMessage` is `nil`, so that this can be marshaled again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
