### PR TITLE
fix the detection of target exports by a sibling

### DIFF
--- a/pkg/landscaper/installations/imports/testdata/state/test1/00-root.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test1/00-root.yaml
@@ -62,5 +62,13 @@ status:
     ref:
       name: d
       namespace: test1
+  - name: e
+    ref:
+      name: e
+      namespace: test1
+  - name: f
+    ref:
+      name: f
+      namespace: test1
 
   observedGeneration: 0

--- a/pkg/landscaper/installations/imports/testdata/state/test1/50-e.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test1/50-e.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: e
+  namespace: test1
+  labels:
+    "landscaper.gardener.cloud/encompassed-by": root
+  ownerReferences:
+    - apiVersion: landscaper.gardener.cloud/v1alpha1
+      kind: Installation
+      name: root
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      componentName: example.com/root
+      version: 1.0.0
+
+  blueprint:
+    ref:
+      resourceName: res-e
+
+  exports:
+    targets:
+      - name: e.z
+        target: e.z
+
+status:
+  phase: Succeeded
+  configGeneration: "klm"
+
+  observedGeneration: 0
+

--- a/pkg/landscaper/installations/imports/testdata/state/test1/51-e-target.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test1/51-e-target.yaml
@@ -1,0 +1,16 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Target
+
+metadata:
+  name: {{ dataObjectName ( dataObjectContext "test1" "root" )  "e.z" }}
+  namespace: test1
+  labels:
+    "landscaper.gardener.cloud/encompassed-by": root
+  ownerReferences:
+    - apiVersion: landscaper.gardener.cloud/v1alpha1
+      kind: Installation
+      name: e
+
+spec:
+  config:
+    type: landscaper.gardener.cloud/kubernetes-cluster

--- a/pkg/landscaper/installations/imports/testdata/state/test1/60-f.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test1/60-f.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: f
+  namespace: test1
+  labels:
+    "landscaper.gardener.cloud/encompassed-by": root
+  ownerReferences:
+    - apiVersion: landscaper.gardener.cloud/v1alpha1
+      kind: Installation
+      name: root
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      componentName: example.com/root
+      version: 1.0.0
+
+  blueprint:
+    ref:
+      resourceName: res-f
+
+  imports:
+    targets:
+      - name: f.a
+        target: e.z
+
+status:
+  phase: Succeeded
+  configGeneration: "klm"
+
+  imports:
+    - name: f.a
+      type: target
+      configGeneration: "efg"
+      sourceRef:
+        name: e
+        namespace: test1
+
+  observedGeneration: 0
+

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -347,6 +347,7 @@ func (v *Validator) checkStateForParentImport(fldPath *field.Path, importName st
 	return nil
 }
 
+// The IsExportingDataFunc returns true if the passed sibling has a Data/Target export by the given name.
 type IsExportingDataFunc func(*installations.InstallationBase, string) bool
 
 func (v *Validator) checkStateForSiblingDataExport(ctx context.Context, fldPath *field.Path, siblingRef lsv1alpha1.ObjectReference, importName string) error {

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -350,14 +350,14 @@ func (v *Validator) checkStateForParentImport(fldPath *field.Path, importName st
 type IsExportingDataFunc func(*installations.InstallationBase, string) bool
 
 func (v *Validator) checkStateForSiblingDataExport(ctx context.Context, fldPath *field.Path, siblingRef lsv1alpha1.ObjectReference, importName string) error {
-	isExportingFunc := func (sibling  *installations.InstallationBase, name string) bool {
+	isExportingFunc := func(sibling *installations.InstallationBase, name string) bool {
 		return sibling.IsExportingData(name)
 	}
 	return v.checkStateForSiblingExport(ctx, fldPath, siblingRef, importName, isExportingFunc)
 }
 
 func (v *Validator) checkStateForSiblingTargetExport(ctx context.Context, fldPath *field.Path, siblingRef lsv1alpha1.ObjectReference, importName string) error {
-	isExportingFunc := func (sibling  *installations.InstallationBase, name string) bool {
+	isExportingFunc := func(sibling *installations.InstallationBase, name string) bool {
 		return sibling.IsExportingTarget(name)
 	}
 	return v.checkStateForSiblingExport(ctx, fldPath, siblingRef, importName, isExportingFunc)

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -347,8 +347,8 @@ func (v *Validator) checkStateForParentImport(fldPath *field.Path, importName st
 	return nil
 }
 
-// The IsExportingDataFunc returns true if the passed sibling has a Data/Target export by the given name.
-type IsExportingDataFunc func(*installations.InstallationBase, string) bool
+// The isExportingDataFunc returns true if the passed sibling has a Data/Target export by the given name.
+type isExportingDataFunc func(*installations.InstallationBase, string) bool
 
 func (v *Validator) checkStateForSiblingDataExport(ctx context.Context, fldPath *field.Path, siblingRef lsv1alpha1.ObjectReference, importName string) error {
 	isExportingFunc := func(sibling *installations.InstallationBase, name string) bool {
@@ -364,7 +364,7 @@ func (v *Validator) checkStateForSiblingTargetExport(ctx context.Context, fldPat
 	return v.checkStateForSiblingExport(ctx, fldPath, siblingRef, importName, isExportingFunc)
 }
 
-func (v *Validator) checkStateForSiblingExport(ctx context.Context, fldPath *field.Path, siblingRef lsv1alpha1.ObjectReference, importName string, isExporting IsExportingDataFunc) error {
+func (v *Validator) checkStateForSiblingExport(ctx context.Context, fldPath *field.Path, siblingRef lsv1alpha1.ObjectReference, importName string, isExporting isExportingDataFunc) error {
 	sibling := v.getSiblingForObjectReference(siblingRef)
 	if sibling == nil {
 		return fmt.Errorf("%s: installation %s is not a sibling", fldPath.String(), siblingRef.NamespacedName().String())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

Currently when a target is exported by sibling of an installation, this is not correctly detected when importing the target reference by another installation.
This PR fixes the the detection of target exports by installation siblings.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` bugfix user
A bug has been fixed that caused target export from installation to not be consumable by other installations.
```
