### PR TITLE
reflect the renaming of "components-cli" to "component-cli"

### DIFF
--- a/docs/tutorials/00-local-setup.md
+++ b/docs/tutorials/00-local-setup.md
@@ -185,7 +185,7 @@ Later, when dealing with artifacts like the component descriptor, be aware that 
 But push explicitly to `localhost` instead implicitly using the baseUrl:
 
 ```shell
-landscaper-cli components-cli ca remote push ./path-to-componentdescriptor --repo-ctx localhost:5000/comp/
+landscaper-cli component-cli ca remote push ./path-to-componentdescriptor --repo-ctx localhost:5000/comp/
 ```
 
 #### Targets

--- a/docs/tutorials/01-create-simple-blueprint.md
+++ b/docs/tutorials/01-create-simple-blueprint.md
@@ -392,11 +392,11 @@ Finally, the Component Descriptor must be uploaded to an OCI registry. This is d
 ```shell script
 
 # replace the values to match your registry and file locations
-landscaper-cli components-cli ca remote push <path to directory with component-descriptor.yaml>
+landscaper-cli component-cli ca remote push <path to directory with component-descriptor.yaml>
 
 # e.g. if you were to use the provided sample content
 # (this will fail as you have no write access to gardener-project on eu.gcr.io)
-landscaper-cli components-cli ca remote push ./docs/tutorials/resources/ingress-nginx
+landscaper-cli component-cli ca remote push ./docs/tutorials/resources/ingress-nginx
 ```
 
 Once the upload succeeds, the Component Descriptor should be accessible at `eu.gcr.io/gardener-project/landscaper/tutorials/components/component-descriptors/github.com/gardener/landscaper/ingress-nginx/v0.3.0` in the registry.

--- a/docs/tutorials/02-local-simple-blueprint.md
+++ b/docs/tutorials/02-local-simple-blueprint.md
@@ -94,7 +94,7 @@ input:
 
 Add the resource to the component descriptor with the component-cli:
 ```
-landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
+landscaper-cli component-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
   ./docs/tutorials/resources/local-ingress-nginx/helm-resource.yaml
 ```
 :warning: Note that the directory `./docs/tutorials/resources/local-ingress-nginx` _MUST_ contain the component descriptor at `./docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml`.
@@ -188,7 +188,7 @@ input:
 ```
 
 ```
-landscaper-cli components-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
+landscaper-cli component-cli ca resources add ./docs/tutorials/resources/local-ingress-nginx \
   ./docs/tutorials/resources/local-ingress-nginx/blueprint-resource.yaml
 ```
 
@@ -229,7 +229,7 @@ component:
 
 Upload the component and its local artifacts with the `component-cli`:
 ```
-landscaper-cli components-cli ca remote push ./docs/tutorials/resources/local-ingress-nginx
+landscaper-cli component-cli ca remote push ./docs/tutorials/resources/local-ingress-nginx
 ```
 :warning: make sure to have write permissions for the component registry. (Run `docker login registry` to login into the registry)
 
@@ -239,7 +239,7 @@ During the upload the `localFilesystemBlob` are converted to `localOciBlob` as t
 
 :information_source: The uploaded component descriptor can be checked by running
 ```
-landscaper-cli components-cli ca remote get eu.gcr.io/gardener-project/landscaper/tutorials/components github.com/gardener/landscaper/local/ingress-nginx v0.2.0
+landscaper-cli component-cli ca remote get eu.gcr.io/gardener-project/landscaper/tutorials/components github.com/gardener/landscaper/local/ingress-nginx v0.2.0
 ```
 
 ```yaml

--- a/docs/tutorials/03-simple-import.md
+++ b/docs/tutorials/03-simple-import.md
@@ -196,7 +196,7 @@ component:
 ```
 
 ```shell script
-landscaper-cli components-cli ca remote push docs/tutorials/resources/echo-server
+landscaper-cli component-cli ca remote push docs/tutorials/resources/echo-server
 ```
 
 ### Installation

--- a/docs/tutorials/04-aggregated-blueprint.md
+++ b/docs/tutorials/04-aggregated-blueprint.md
@@ -273,7 +273,7 @@ component:
 ```
 
 ```shell script
-landscaper-cli components-cli ca remote push docs/tutorials/resources/aggregated
+landscaper-cli component-cli ca remote push docs/tutorials/resources/aggregated
 ```
 
 ### Installation

--- a/docs/tutorials/05-external-jsonschema.md
+++ b/docs/tutorials/05-external-jsonschema.md
@@ -101,11 +101,11 @@ component:
 ```
 
 ```
-landscaper-cli components-cli ca resources add ./docs/tutorials/resources/external-jsonschema/definitions ./docs/tutorials/resources/external-jsonschema/definitions/jsonscheme-resource.yaml
+landscaper-cli component-cli ca resources add ./docs/tutorials/resources/external-jsonschema/definitions ./docs/tutorials/resources/external-jsonschema/definitions/jsonscheme-resource.yaml
 ```
 
 ```
-landscaper-cli components-cli ca remote push ./docs/tutorials/resources/external-jsonschema/definitions
+landscaper-cli component-cli ca remote push ./docs/tutorials/resources/external-jsonschema/definitions
 ```
 
 </details>
@@ -300,11 +300,11 @@ input:
 ```
 
 ```
-landscaper-cli components-cli ca resources add ./docs/tutorials/resources/external-jsonschema/echo-server ./docs/tutorials/resources/external-jsonschema/echo-server/blueprint-resource.yaml
+landscaper-cli component-cli ca resources add ./docs/tutorials/resources/external-jsonschema/echo-server ./docs/tutorials/resources/external-jsonschema/echo-server/blueprint-resource.yaml
 ```
 
 ```
-landscaper-cli components-cli ca remote push ./docs/tutorials/resources/external-jsonschema/echo-server
+landscaper-cli component-cli ca remote push ./docs/tutorials/resources/external-jsonschema/echo-server
 ```
 
 </details>


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind regression
/priority 4

**What this PR does / why we need it**:
The "components-cli" command has been renamed to "component-cli".
This PR reflects this change in the tutorials.


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```

```
