### PR TITLE
Improve execution reconcile

### DIFF
--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -66,11 +66,13 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	if lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) {
 		op := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, false)
-		err := op.HandleDeployItemPhaseChanges(ctx, logger)
+		err := op.HandleDeployItemPhaseAndGenerationChanges(ctx, logger)
 		if err != nil {
-			return reconcile.Result{}, lserrors.NewWrappedError(err, "Reconcile", "HandleDeployItemPhaseChanges", err.Error())
+			return reconcile.Result{}, lserrors.NewWrappedError(err, "Reconcile", "HandleDeployItemPhaseAndGenerationChanges", err.Error())
 		}
-		return reconcile.Result{}, nil
+		if lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) {
+			return reconcile.Result{}, nil
+		}
 	}
 
 	return reconcile.Result{}, errHdl(ctx, c.Ensure(ctx, logger, exec))

--- a/pkg/landscaper/controllers/execution/reconcile_test.go
+++ b/pkg/landscaper/controllers/execution/reconcile_test.go
@@ -82,4 +82,57 @@ var _ = Describe("Reconcile", func() {
 		Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))).To(BeTrue(), "expect the execution to be deleted")
 	})
 
+	It("should adapt the status of the execution if a deploy item changes from Failed to Succeeded and vice versa", func() {
+		ctx := context.Background()
+		// first deploy reconcile a simple execution with one deploy item
+		exec := &lsv1alpha1.Execution{}
+		exec.GenerateName = "test-"
+		exec.Namespace = state.Namespace
+		exec.Spec.DeployItems = []lsv1alpha1.DeployItemTemplate{
+			{
+				Name: "def",
+				Type: "test-type",
+				Configuration: &runtime.RawExtension{
+					Raw: []byte(`
+{
+  "apiVersion": "sometest",
+  "kind": "somekind"
+}
+`),
+				},
+			},
+		}
+		testutils.ExpectNoError(state.Create(ctx, testenv.Client, exec))
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+
+		// expect a deploy item
+		items := &lsv1alpha1.DeployItemList{}
+		testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
+		Expect(items.Items).To(HaveLen(1))
+		di := &items.Items[0]
+		//set item to failed state
+		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+		di.Status.ObservedGeneration = di.Generation
+		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+
+		// then reconcile the execution and expect the execution to be Failed
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+
+		// set deployitem phase to Succeeded and check again
+		di.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
+		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+
+		// verify that from Succeeded to Failed also works
+		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+	})
+
 })

--- a/pkg/landscaper/execution/helper.go
+++ b/pkg/landscaper/execution/helper.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,17 +80,38 @@ func (o *Operation) getExecutionItems(items []lsv1alpha1.DeployItem) ([]executio
 	return execItems, orphaned
 }
 
-// HandleDeployItemPhaseChanges updates the phase of the given execution, if its phase doesn't match the combined phase of its deploy items anymore.
-// If the phase changed to 'Succeeded', it also updates the deployitems' exports.
-func (o *Operation) HandleDeployItemPhaseChanges(ctx context.Context, logger logr.Logger) error {
-	deployitems, err := o.listManagedDeployItems(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to list deploy items: %w", err)
-	}
+// HandleDeployItemPhaseAndGenerationChanges updates the phase of the given execution, if its phase doesn't match the combined phase of its deploy items anymore.
+// If a deploy item's generation differs from the observed one or a deploy item doesn't exist, the phase is set to 'Progressing'.
+// If the phase is changed to 'Succeeded', the exports of the deploy items are updated.
+func (o *Operation) HandleDeployItemPhaseAndGenerationChanges(ctx context.Context, logger logr.Logger) error {
+	deployitems := []lsv1alpha1.DeployItem{}
 	phases := []lsv1alpha1.ExecutionPhase{}
-	for _, di := range deployitems {
+	// fetch all managed deploy items and check their phase and generation
+	for _, managedDi := range o.exec.Status.DeployItemReferences {
+		di := &lsv1alpha1.DeployItem{}
+		err := o.Client().Get(ctx, managedDi.Reference.NamespacedName(), di)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("unable to get deploy item %q: %w", managedDi.Reference.NamespacedName().String(), err)
+			} else {
+				di = nil
+			}
+		}
+
+		if di == nil || managedDi.Reference.ObservedGeneration != di.Generation {
+			// at least one deploy item is outdated or got deleted, a reconcile is required
+			logger.V(7).Info("deploy item cannot be found or does not match last observed generation")
+			o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
+			err := o.Client().Status().Update(ctx, o.exec)
+			if err != nil {
+				return fmt.Errorf("error updating execution status for %s/%s: %w", o.exec.Namespace, o.exec.Name, err)
+			}
+			return nil
+		}
 		phases = append(phases, di.Status.Phase)
+		deployitems = append(deployitems, *di)
 	}
+
 	cp := lsv1alpha1helper.CombinedExecutionPhase(phases...)
 	if o.exec.Status.Phase != cp {
 		// Phase is completed but doesn't fit to the deploy items' phases

--- a/pkg/landscaper/execution/helper.go
+++ b/pkg/landscaper/execution/helper.go
@@ -6,11 +6,14 @@ package execution
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
@@ -74,4 +77,42 @@ func (o *Operation) getExecutionItems(items []lsv1alpha1.DeployItem) ([]executio
 		}
 	}
 	return execItems, orphaned
+}
+
+// HandleDeployItemPhaseChanges updates the phase of the given execution, if its phase doesn't match the combined phase of its deploy items anymore.
+// If the phase changed to 'Succeeded', it also updates the deployitems' exports.
+func (o *Operation) HandleDeployItemPhaseChanges(ctx context.Context, logger logr.Logger) error {
+	deployitems, err := o.listManagedDeployItems(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to list deploy items: %w", err)
+	}
+	phases := []lsv1alpha1.ExecutionPhase{}
+	for _, di := range deployitems {
+		phases = append(phases, di.Status.Phase)
+	}
+	cp := lsv1alpha1helper.CombinedExecutionPhase(phases...)
+	if o.exec.Status.Phase != cp {
+		// Phase is completed but doesn't fit to the deploy items' phases
+		logger.V(5).Info("execution phase mismatch", "phase", string(o.exec.Status.Phase), "combinedPhase", string(cp))
+		o.exec.Status.Phase = cp
+		err := o.Client().Status().Update(ctx, o.exec)
+		if err != nil {
+			return fmt.Errorf("error updating execution status for %s/%s: %w", o.exec.Namespace, o.exec.Name, err)
+		}
+
+		if cp == lsv1alpha1.ExecutionPhaseSucceeded {
+			// phase changed to Succeeded, it might be necessary to generate the exports again
+			logger.V(5).Info("phase changed to %q, compute deploy item exports again", string(lsv1alpha1.ExecutionPhaseSucceeded))
+			execItems, _ := o.getExecutionItems(deployitems)
+			err = o.collectAndUpdateExports(ctx, execItems)
+			if err != nil {
+				return fmt.Errorf("error while updating exports of execution %s/%s: %w", o.exec.Namespace, o.exec.Name, err)
+			}
+		}
+
+		return nil
+	}
+	logger.V(7).Info("execution is in a final state and deployitems are up-to-date")
+
+	return nil
 }

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -43,64 +43,68 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 
 	var phase lsv1alpha1.ExecutionPhase
 	for _, item := range executionItems {
-		if item.DeployItem != nil && !o.forceReconcile {
-			phase = lsv1alpha1helper.CombinedExecutionPhase(phase, item.DeployItem.Status.Phase)
-			deployItemStatusUpToDate := item.DeployItem.Status.ObservedGeneration == item.DeployItem.GetGeneration()
-
-			// we need to check if the deployitem is failed due to that its not picked up by a deployer.
-			// This is a error scenario that needs special handling as other detections in this code will not work.
-			// Mostly due to outdated observed generation
-			if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed &&
-				(item.DeployItem.Status.LastError != nil && item.DeployItem.Status.LastError.Reason == lsv1alpha1.PickupTimeoutReason) {
-				o.exec.Status.ObservedGeneration = o.exec.Generation
-				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
-					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
-						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name)))
-				o.exec.Status.LastError = lserrors.UpdatedError(
-					o.exec.Status.LastError,
-					"DeployItemReconcile",
-					"DeployItemFailed",
-					fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name),
-				)
-				return nil
-			}
-
-			if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) || !deployItemStatusUpToDate {
-				o.EventRecorder().Eventf(o.exec, corev1.EventTypeNormal,
-					"DeployItemCompleted",
-					"deploy item %s not triggered because it already exists and is not completed", item.Info.Name,
-				)
-				o.Log().V(5).Info("deploy item not triggered because already existing and not completed", "name", item.Info.Name)
-				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
-				phase = lsv1alpha1.ExecutionPhaseProgressing
-				continue
-			}
-
+		if item.DeployItem != nil {
 			// get last applied status from own status
 			var lastAppliedGeneration int64
 			if ref, ok := lsv1alpha1helper.GetVersionedNamedObjectReference(o.exec.Status.DeployItemReferences, item.Info.Name); ok {
 				lastAppliedGeneration = ref.Reference.ObservedGeneration
 			}
 
-			if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed && lastAppliedGeneration == o.exec.Generation {
-				// TODO: check if need to wait for other deploy items to finish
-				o.exec.Status.ObservedGeneration = o.exec.Generation
-				o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
-					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
-						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) is in failed state", item.Info.Name, item.DeployItem.Name)))
-				o.exec.Status.LastError = lserrors.UpdatedError(
-					o.exec.Status.LastError,
-					"DeployItemReconcile",
-					"DeployItemFailed",
-					fmt.Sprintf("reconciliation of deploy item %q failed", item.DeployItem.Name),
-				)
-				return nil
-			}
+			deployItemLastAppliedUpToDate := lastAppliedGeneration == item.DeployItem.GetGeneration()
 
-			if lastAppliedGeneration == o.exec.Generation {
-				continue
+			if deployItemLastAppliedUpToDate && !o.forceReconcile {
+				phase = lsv1alpha1helper.CombinedExecutionPhase(phase, item.DeployItem.Status.Phase)
+				deployItemStatusUpToDate := item.DeployItem.Status.ObservedGeneration == item.DeployItem.GetGeneration()
+
+				// we need to check if the deployitem is failed due to that its not picked up by a deployer.
+				// This is a error scenario that needs special handling as other detections in this code will not work.
+				// Mostly due to outdated observed generation
+				if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed &&
+					(item.DeployItem.Status.LastError != nil && item.DeployItem.Status.LastError.Reason == lsv1alpha1.PickupTimeoutReason) {
+					o.exec.Status.ObservedGeneration = o.exec.Generation
+					o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+					o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
+						lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
+							"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name)))
+					o.exec.Status.LastError = lserrors.UpdatedError(
+						o.exec.Status.LastError,
+						"DeployItemReconcile",
+						"DeployItemFailed",
+						fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name),
+					)
+					return nil
+				}
+
+				if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) || !deployItemStatusUpToDate {
+					o.EventRecorder().Eventf(o.exec, corev1.EventTypeNormal,
+						"DeployItemCompleted",
+						"deploy item %s not triggered because it already exists and is not completed", item.Info.Name,
+					)
+					o.Log().V(5).Info("deploy item not triggered because already existing and not completed", "name", item.Info.Name)
+					o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
+					phase = lsv1alpha1.ExecutionPhaseProgressing
+					continue
+				}
+
+				if item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed && lastAppliedGeneration == o.exec.Generation {
+					// TODO: check if need to wait for other deploy items to finish
+					o.exec.Status.ObservedGeneration = o.exec.Generation
+					o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+					o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
+						lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
+							"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) is in failed state", item.Info.Name, item.DeployItem.Name)))
+					o.exec.Status.LastError = lserrors.UpdatedError(
+						o.exec.Status.LastError,
+						"DeployItemReconcile",
+						"DeployItemFailed",
+						fmt.Sprintf("reconciliation of deploy item %q failed", item.DeployItem.Name),
+					)
+					return nil
+				}
+
+				if lastAppliedGeneration == o.exec.Generation {
+					continue
+				}
 			}
 		}
 		runnable, err := o.checkRunnable(ctx, item, executionItems)
@@ -171,7 +175,7 @@ func (o *Operation) deployOrTrigger(ctx context.Context, item executionItem) err
 	ref.Name = item.Info.Name
 	ref.Reference.Name = item.DeployItem.Name
 	ref.Reference.Namespace = item.DeployItem.Namespace
-	ref.Reference.ObservedGeneration = o.exec.Generation
+	ref.Reference.ObservedGeneration = item.DeployItem.Generation
 
 	old := o.exec.DeepCopy()
 	o.exec.Status.DeployItemReferences = lsv1alpha1helper.SetVersionedNamedObjectReference(o.exec.Status.DeployItemReferences, ref)

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -57,11 +57,13 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
 					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name)))
-				return lserrors.NewError(
+				o.exec.Status.LastError = lserrors.UpdatedError(
+					o.exec.Status.LastError,
 					"DeployItemReconcile",
 					"DeployItemFailed",
 					fmt.Sprintf("DeployItem %s (%s) has not been picked up by a Deployer", item.Info.Name, item.DeployItem.Name),
 				)
+				return nil
 			}
 
 			if !lsv1alpha1helper.IsCompletedExecutionPhase(item.DeployItem.Status.Phase) || !deployItemStatusUpToDate {
@@ -88,11 +90,13 @@ func (o *Operation) Reconcile(ctx context.Context) error {
 				o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions,
 					lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 						"DeployItemFailed", fmt.Sprintf("DeployItem %s (%s) is in failed state", item.Info.Name, item.DeployItem.Name)))
-				return lserrors.NewError(
+				o.exec.Status.LastError = lserrors.UpdatedError(
+					o.exec.Status.LastError,
 					"DeployItemReconcile",
 					"DeployItemFailed",
 					fmt.Sprintf("reconciliation of deploy item %q failed", item.DeployItem.Name),
 				)
+				return nil
 			}
 
 			if lastAppliedGeneration == o.exec.Generation {

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(item.Spec.Type).To(Equal(lsv1alpha1.DeployItemType("landscaper.gardener.cloud/helm")))
-		Expect(exec.Status.DeployItemReferences[1].Reference.ObservedGeneration).To(Equal(exec.Generation))
+		Expect(exec.Status.DeployItemReferences[1].Reference.ObservedGeneration).To(Equal(item.Generation))
 	})
 
 	Context("Propagate Phase", func() {
@@ -166,6 +166,22 @@ var _ = Describe("Reconcile", func() {
 			err := eOp.Reconcile(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+		})
+
+		It("should set the status of a previously failed execution to progressing if a deployitem has a newer generation than the last observed generation", func() {
+			ctx := context.Background()
+			exec := fakeExecutions["test2/exec-1"]
+			exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			eOp := execution.NewOperation(op, exec, false)
+
+			deployItemA := fakeDeployItems["test2/di-a"]
+			deployItemA.Generation = 3
+			deployItemA.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
+
+			err := eOp.Reconcile(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseProgressing))
 		})
 	})
 

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 			err := eOp.Reconcile(ctx)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 			err := eOp.Reconcile(ctx)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 		})
 	})
@@ -179,7 +179,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
 		err := eOp.Reconcile(ctx)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
 		Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
 	})
 

--- a/pkg/landscaper/execution/testdata/state/test2/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test2/10-deploy-item.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     execution.landscaper.gardener.cloud/managed-by: exec-1
     execution.landscaper.gardener.cloud/name: a
-  generation: 1
+  generation: 2
 spec:
   type: landscaper.gardener.cloud/helm
   config:
@@ -18,4 +18,4 @@ spec:
 
 status:
   phase: Progressing
-  observedGeneration: 1
+  observedGeneration: 2

--- a/pkg/landscaper/execution/testdata/state/test5/00-execution.yaml
+++ b/pkg/landscaper/execution/testdata/state/test5/00-execution.yaml
@@ -25,5 +25,5 @@ status:
   - name: a
     ref:
       name: di-a
-      namespace: test2
+      namespace: test5
       observedGeneration: 2

--- a/pkg/landscaper/execution/testdata/state/test5/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test5/10-deploy-item.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     execution.landscaper.gardener.cloud/managed-by: exec-1
     execution.landscaper.gardener.cloud/name: a
-  generation: 1
+  generation: 2
 spec:
   type: landscaper.gardener.cloud/helm
   config:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:
This is a combination of the PRs #276 and #272 

**Which issue(s) this PR fixes**:
This is part of #239 / #275

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Phase changes in deploy items are now properly propagated to their owning execution, even if the execution was already in a final phase and there weren't any changes to the installation.
```
```other operator
Reconciliation of executions will now detect missing or outdated deployitems.
```
