### PR TITLE
fix possible deadlock in ResolveBlueprintFromBlobResolver

### DIFF
--- a/pkg/landscaper/blueprints/resolve.go
+++ b/pkg/landscaper/blueprints/resolve.go
@@ -131,6 +131,8 @@ func ResolveBlueprintFromBlobResolver(
 		}
 	}
 	blueprint, err := GetStore().Store(ctx, cd, resource, blobReader)
+	// drain the pipe reader, otherwise the error group wait may block indefinitely
+	_, _ = io.Copy(io.Discard, pr)
 	if err != nil {
 		if err2 := eg.Wait(); err2 != nil {
 			return nil, errorsutil.NewAggregate([]error{err, err2})

--- a/pkg/landscaper/blueprints/resolve.go
+++ b/pkg/landscaper/blueprints/resolve.go
@@ -101,6 +101,9 @@ func ResolveBlueprintFromBlobResolver(
 	}
 
 	pr, pw := io.Pipe()
+	// close the writer to unblock any pending io writes
+	defer pw.Close()
+
 	mediaType, err := mediatype.Parse(blobInfo.MediaType)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse media type: %w", err)
@@ -134,7 +137,7 @@ func ResolveBlueprintFromBlobResolver(
 	if err != nil {
 		// cancel early to unblock the blob resolver
 		cancel()
-		// close the writer to unblock any pending io writes
+		// close the writer early to unblock any pending io writes
 		_ = pw.Close()
 		if err2 := eg.Wait(); err2 != nil {
 			return nil, errorsutil.NewAggregate([]error{err, err2})

--- a/pkg/landscaper/blueprints/resolve.go
+++ b/pkg/landscaper/blueprints/resolve.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/landscaper/blueprints/resolve_test.go
+++ b/pkg/landscaper/blueprints/resolve_test.go
@@ -6,14 +6,15 @@ package blueprints_test
 
 import (
 	"context"
+	"io"
+	"math/rand"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io"
-	"math/rand"
 
 	"github.com/gardener/landscaper/apis/mediatype"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"

--- a/pkg/landscaper/blueprints/resolve_test.go
+++ b/pkg/landscaper/blueprints/resolve_test.go
@@ -6,8 +6,12 @@ package blueprints_test
 
 import (
 	"context"
+	"io"
+	"math/rand"
+	"time"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	. "github.com/onsi/ginkgo"
@@ -23,6 +27,33 @@ import (
 	"github.com/gardener/landscaper/apis/config"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 )
+
+type dummyBlobResolver struct {
+}
+
+func newDummyBlobResolver() ctf.BlobResolver {
+	return dummyBlobResolver{}
+}
+
+func (r dummyBlobResolver) Info(_ context.Context, _ cdv2.Resource) (*ctf.BlobInfo, error) {
+	return &ctf.BlobInfo{
+		MediaType: mediatype.NewBuilder(mediatype.BlueprintArtifactsLayerMediaTypeV1).String(),
+	}, nil
+}
+
+func (r dummyBlobResolver) Resolve(_ context.Context, _ cdv2.Resource, writer io.Writer) (*ctf.BlobInfo, error) {
+	data := make([]byte, 256)
+	rand.Read(data)
+
+	for i := 0; i < 20; i++ {
+		if _, err := writer.Write(data); err != nil {
+			return nil, err
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, nil
+}
 
 var _ = Describe("Resolve", func() {
 
@@ -126,6 +157,35 @@ var _ = Describe("Resolve", func() {
 			blobResolver := componentsregistry.NewLocalFilesystemBlobResolver(memFs)
 			localFSAccess, err := cdv2.NewUnstructured(cdv2.NewLocalFilesystemBlobAccess("bp.tar",
 				mediatype.NewBuilder(mediatype.BlueprintArtifactsLayerMediaTypeV1).Compression(mediatype.GZipCompression).String()))
+			Expect(err).ToNot(HaveOccurred())
+
+			cd := &cdv2.ComponentDescriptor{}
+			cd.Name = "example.com/a"
+			cd.Version = "0.0.1"
+			cd.Resources = append(cd.Resources, cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "my-bp",
+					Version: "1.2.3",
+					Type:    mediatype.BlueprintType,
+				},
+				Relation: cdv2.ExternalRelation,
+				Access:   &localFSAccess,
+			})
+
+			_, err = blueprints.ResolveBlueprintFromBlobResolver(ctx, cd, blobResolver, "my-bp")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should throw an error if a blueprint is received corrupted", func() {
+			ctx := context.Background()
+
+			store, err := blueprints.NewStore(logr.Discard(), memoryfs.New(), defaultStoreConfig)
+			Expect(err).ToNot(HaveOccurred())
+			blueprints.SetStore(store)
+
+			blobResolver := newDummyBlobResolver()
+			localFSAccess, err := cdv2.NewUnstructured(cdv2.NewLocalFilesystemBlobAccess("bp.tar",
+				mediatype.NewBuilder(mediatype.BlueprintArtifactsLayerMediaTypeV1).String()))
 			Expect(err).ToNot(HaveOccurred())
 
 			cd := &cdv2.ComponentDescriptor{}

--- a/pkg/landscaper/blueprints/resolve_test.go
+++ b/pkg/landscaper/blueprints/resolve_test.go
@@ -6,16 +6,14 @@ package blueprints_test
 
 import (
 	"context"
-	"io"
-	"math/rand"
-	"time"
-
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io"
+	"math/rand"
 
 	"github.com/gardener/landscaper/apis/mediatype"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
@@ -49,8 +47,6 @@ func (r dummyBlobResolver) Resolve(_ context.Context, _ cdv2.Resource, writer io
 		if _, err := writer.Write(data); err != nil {
 			return nil, err
 		}
-
-		time.Sleep(100 * time.Millisecond)
 	}
 	return nil, nil
 }

--- a/pkg/utils/context_aware_writer.go
+++ b/pkg/utils/context_aware_writer.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"io"
+)
+
+// ContextAwareWriter wraps a context and an io writer.
+// When the context is cancelled, the write function will return early before calling write on the io writer.
+type ContextAwareWriter struct {
+	// ctx is the wrapping context
+	ctx context.Context
+	// writer is the underlying io writer
+	writer io.Writer
+}
+
+// Write will check the wrapping context for errors.
+// If the context doesn't return any error, the underlying io writer is called.
+func (w *ContextAwareWriter) Write(p []byte) (n int, err error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return w.writer.Write(p)
+}
+
+// NewContextAwareWriter creates a new context aware writer.
+func NewContextAwareWriter(ctx context.Context, writer io.Writer) io.Writer {
+	return &ContextAwareWriter{
+		ctx:    ctx,
+		writer: writer,
+	}
+}

--- a/pkg/utils/context_aware_writer.go
+++ b/pkg/utils/context_aware_writer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

If reading the blob fails, the pipe reader is not drained.
This will result in a deadlock inside the go routine while trying to write to the pipe.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```

```
