### PR TITLE
Container deployer fixes

### DIFF
--- a/charts/container-deployer/templates/rbac.yaml
+++ b/charts/container-deployer/templates/rbac.yaml
@@ -35,6 +35,10 @@ rules:
   - "events"
   verbs:
   - create
+  - get
+  - watch
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/charts/helm-deployer/templates/clusterrole.yaml
+++ b/charts/helm-deployer/templates/clusterrole.yaml
@@ -34,6 +34,10 @@ rules:
   - "events"
   verbs:
   - create
+  - get
+  - watch
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/charts/landscaper/templates/rbac-controller.yaml
+++ b/charts/landscaper/templates/rbac-controller.yaml
@@ -23,6 +23,10 @@ rules:
   - "events"
   verbs:
   - create
+  - get
+  - watch
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/charts/manifest-deployer/templates/clusterrole.yaml
+++ b/charts/manifest-deployer/templates/clusterrole.yaml
@@ -34,4 +34,8 @@ rules:
   - "events"
   verbs:
   - create
+  - get
+  - watch
+  - patch
+  - update
 {{- end }}

--- a/examples/deploy-items/33-DeployItem-Container-blueprint.yaml
+++ b/examples/deploy-items/33-DeployItem-Container-blueprint.yaml
@@ -13,13 +13,16 @@ spec:
     apiVersion: container.deployer.landscaper.gardener.cloud/v1alpha1
     kind: ProviderConfiguration
 
-    blueprint:
+    componentDescriptor:
       ref:
         repositoryContext:
           baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components/
           type: ociRegistry
         componentName: github.com/gardener/landscaper/ingress-nginx
         version: v0.2.1
+
+    blueprint:
+      ref:
         resourceName: ingress-nginx-blueprint
 
     registryPullSecrets:
@@ -33,5 +36,7 @@ spec:
     args:
     - |
       env
-      ls -laR $CONTENT_PATH
-      ls -laR $REGISTRY_SECRETS_DIR
+      ls -la $CONTENT_PATH
+      ls -la $REGISTRY_SECRETS_DIR
+      ls -la $CONTENT_PATH > $EXPORTS_PATH
+

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -401,7 +401,7 @@ func (c *Container) syncSecrets(ctx context.Context, secretName, imageReference 
 
 	imageref, err := dockerreference.ParseDockerRef(imageReference)
 	if err != nil {
-		return "", fmt.Errorf("Not a valid imageReference reference %s: %w", c.ProviderConfiguration.Image, err)
+		return "", fmt.Errorf("not a valid imageReference reference %s: %w", imageReference, err)
 	}
 
 	host := dockerreference.Domain(imageref)

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -261,6 +261,11 @@ func (dm *DeployerManagement) EnsureRBACRoles(ctx context.Context) error {
 				Resources: []string{"deployitems/status"},
 				Verbs:     []string{"get", "watch", "list", "update", "patch"},
 			},
+			{
+				APIGroups: []string{corev1.SchemeGroupVersion.Group},
+				Resources: []string{"events"},
+				Verbs:     []string{"create", "get", "watch", "patch", "update"},
+			},
 		}
 		return nil
 	}); err != nil {

--- a/pkg/landscaper/controllers/deployitem/controller.go
+++ b/pkg/landscaper/controllers/deployitem/controller.go
@@ -67,7 +67,7 @@ type controller struct {
 
 func (con *controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := con.log.WithValues("resource", req.NamespacedName.String())
-	logger.Info("reconcile")
+	logger.V(7).Info("reconcile")
 
 	di := &lsv1alpha1.DeployItem{}
 	if err := con.c.Get(ctx, req.NamespacedName, di); err != nil {

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -47,7 +47,7 @@ type controller struct {
 
 func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := c.log.WithValues("resource", req.NamespacedName)
-	logger.Info("reconcile")
+	logger.V(5).Info("reconcile")
 
 	exec := &lsv1alpha1.Execution{}
 	if err := c.client.Get(ctx, req.NamespacedName, exec); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

fixes several bugs in the deployers:
- fixes the event permissions for deployers
- fixed the example container deployitem with component descriptor and blueprint
- fixed the pull secret sync for component descriptor secrets in the container deployer
- adjusted the reconcile logging

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The permissions for deployers have been fixed so that they are now allowed to create, update and patch events.
```
```bugfix operator
A bug in the pull secrets sync of the container deployer has been fixed.
```
```other operator
The logging verbosity of reconciles has been adjusted to output more useful logs.
```
