### PR TITLE
blueprint layer mediatype must be set to a gzipped type

### DIFF
--- a/pkg/landscaper/blueprints/bputils/utils.go
+++ b/pkg/landscaper/blueprints/bputils/utils.go
@@ -37,7 +37,7 @@ func BuildNewBlueprint(cache cache.Cache, fs vfs.FileSystem, path string) (*ocis
 	if err != nil {
 		return nil, err
 	}
-	defLayer.MediaType = mediatype.BlueprintArtifactsLayerMediaTypeV1
+	defLayer.MediaType = mediatype.NewBuilder(mediatype.BlueprintArtifactsLayerMediaTypeV1).Compression(mediatype.GZipCompression).String()
 
 	manifest := &ocispecv1.Manifest{
 		Versioned: specs.Versioned{SchemaVersion: 2},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

The mediatype of the blueprint layer was not correctly set to a gzipped type.
This results in error while reading the blueprint layer:

```
{"level":"error","ts":"2021-08-18T16:15:08.100+0200","logger":"setup.controllers.Installations.controller.installation","msg":"Reconciler error","reconciler group":"landscaper.gardener.cloud","reconciler kind":"Installation","name":"virtual-landscaper","namespace":"default","error":"unable to extract blueprint from blob: archive/tar: invalid tar header"}
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```

```
