### PR TITLE
Fix the handling of landscaper reference protocol schemes within JSON schemas

### DIFF
--- a/pkg/landscaper/jsonschema/jsonschema_suite_test.go
+++ b/pkg/landscaper/jsonschema/jsonschema_suite_test.go
@@ -106,6 +106,19 @@ var _ = Describe("jsonschema", func() {
 			Expect(validator.ValidateBytes(schemaBytes, data)).To(HaveOccurred())
 		})
 
+		It("should pass with a blueprint reference within the schema", func() {
+			localSchema1 := []byte(`{ "$ref": "blueprint://myfile2" }`)
+			Expect(vfs.WriteFile(config.BlueprintFs, "myfile1", localSchema1, os.ModePerm)).To(Succeed())
+
+			localSchema2 := []byte(`{ "type": "string"}`)
+			Expect(vfs.WriteFile(config.BlueprintFs, "myfile2", localSchema2, os.ModePerm)).To(Succeed())
+
+			schemaBytes := []byte(`{ "$ref": "blueprint://myfile1" }`)
+			data := []byte(`"abc"`)
+
+			Expect(validator.ValidateBytes(schemaBytes, data)).To(Succeed())
+		})
+
 		It("should validate with a definition local reference in a blueprint file reference", func() {
 			localSchema := []byte(`{ "definitions": { "myschema": { "type": "string" } } }`)
 			Expect(vfs.WriteFile(config.BlueprintFs, "myfile", localSchema, os.ModePerm)).To(Succeed())

--- a/pkg/landscaper/jsonschema/loader.go
+++ b/pkg/landscaper/jsonschema/loader.go
@@ -116,7 +116,8 @@ func (l *Loader) LoadJSON() (interface{}, error) {
 		return nil, err
 	}
 
-	if err := ValidateSchema(schemaJSONBytes); err != nil {
+	wrappedLoader := NewWrappedLoader(l.LoaderConfig, gojsonschema.NewBytesLoader(schemaJSONBytes))
+	if err := ValidateSchemaWithLoader(wrappedLoader); err != nil {
 		return nil, err
 	}
 

--- a/pkg/landscaper/jsonschema/validate.go
+++ b/pkg/landscaper/jsonschema/validate.go
@@ -22,6 +22,15 @@ func ValidateSchema(schemaBytes []byte) error {
 	return nil
 }
 
+// ValidateSchemaWithLoader validates a jsonschema schema definition by using the given loader.
+func ValidateSchemaWithLoader(loader gojsonschema.JSONLoader) error {
+	_, err := gojsonschema.NewSchemaLoader().Compile(loader)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (v *Validator) ValidateGoStruct(schemaBytes []byte, data interface{}) error {
 	return v.validate(schemaBytes, gojsonschema.NewGoLoader(data))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

The user should be able to use landscaper protocol schemes (`blueprint://`, `cd://`, `local://`) within a JSON schema.
This is currently not working as expected. Using a landscaper protocol scheme in a JSON schema results in the following error message:

`Get "cd://resources/my-schema": unsupported protocol scheme "cd":`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```

```
