### PR TITLE
add support for compressed jsonschema definitions

### DIFF
--- a/pkg/landscaper/jsonschema/jsonschema_suite_test.go
+++ b/pkg/landscaper/jsonschema/jsonschema_suite_test.go
@@ -5,13 +5,20 @@
 package jsonschema_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"os"
 	"testing"
 
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper/apis/mediatype"
+	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/landscaper/jsonschema"
@@ -187,6 +194,120 @@ var _ = Describe("jsonschema", func() {
 			Expect(validator.ValidateBytes(schemaBytes, pass)).To(Succeed())
 			Expect(validator.ValidateBytes(schemaBytes, fail)).To(HaveOccurred())
 		})
+	})
+
+	Context("ComponentDescriptorReference", func() {
+		var (
+			config *jsonschema.LoaderConfig
+			blobFs vfs.FileSystem
+		)
+		BeforeEach(func() {
+			blobFs = memoryfs.New()
+			Expect(blobFs.Mkdir(ctf.BlobsDirectoryName, os.ModePerm)).To(Succeed())
+
+			repoCtx, err := cdv2.NewUnstructured(cdv2.NewOCIRegistryRepository("example.com/reg", ""))
+			Expect(err).ToNot(HaveOccurred())
+			cd := &cdv2.ComponentDescriptor{}
+			cd.Name = "example.com/test"
+			cd.Version = "v0.0.0"
+			cd.RepositoryContexts = []*cdv2.UnstructuredTypedObject{&repoCtx}
+			compRes, err := ctf.NewListResolver(&cdv2.ComponentDescriptorList{
+				Components: []cdv2.ComponentDescriptor{*cd},
+			}, componentsregistry.NewLocalFilesystemBlobResolver(blobFs))
+			Expect(err).To(Not(HaveOccurred()))
+
+			localSchema := []byte(`{ "type": "string"}`)
+			Expect(vfs.WriteFile(blobFs, ctf.BlobPath("default.json"), localSchema, os.ModePerm)).To(Succeed())
+			acc, err := cdv2.NewUnstructured(cdv2.NewLocalFilesystemBlobAccess("default.json", mediatype.JSONSchemaArtifactsMediaTypeV1))
+			Expect(err).ToNot(HaveOccurred())
+			cd.Resources = append(cd.Resources, cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "default",
+					Version: cd.Version,
+				},
+				Relation: cdv2.LocalRelation,
+				Access:   &acc,
+			})
+
+			config = &jsonschema.LoaderConfig{
+				ComponentDescriptor: cd,
+				ComponentResolver:   compRes,
+			}
+
+			validator = &jsonschema.Validator{
+				Config: config,
+			}
+		})
+
+		It("should pass with a schema from a component descriptor resource", func() {
+			schemaBytes := []byte(`{ "$ref": "cd://resources/default"}`)
+			data := []byte(`"valid"`)
+
+			Expect(validator.ValidateBytes(schemaBytes, data)).To(Succeed())
+		})
+
+		It("should fail with a schema from a blueprint file reference", func() {
+			schemaBytes := []byte(`{ "$ref": "cd://resources/default"}`)
+			data := []byte("7")
+
+			Expect(validator.ValidateBytes(schemaBytes, data)).To(HaveOccurred())
+		})
+
+		It("should fail when the configured blueprint file reference cannot be found", func() {
+			schemaBytes := []byte(`{ "$ref": "cd://resources/fail"}`)
+			data := []byte("7")
+
+			Expect(validator.ValidateBytes(schemaBytes, data)).To(HaveOccurred())
+		})
+
+		It("should pass with a gzip compressed schema from a component descriptor resource", func() {
+			var localSchema bytes.Buffer
+
+			w := gzip.NewWriter(&localSchema)
+			_, err := w.Write([]byte(`{ "type": "string"}`))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(w.Close()).To(Succeed())
+
+			Expect(vfs.WriteFile(blobFs, ctf.BlobPath("default.json"), localSchema.Bytes(), os.ModePerm)).To(Succeed())
+			acc, err := cdv2.NewUnstructured(cdv2.NewLocalFilesystemBlobAccess("default.json",
+				mediatype.NewBuilder(mediatype.JSONSchemaArtifactsMediaTypeV1).Compression(mediatype.GZipCompression).Build().String()))
+			Expect(err).ToNot(HaveOccurred())
+			config.ComponentDescriptor.Resources = append(config.ComponentDescriptor.Resources, cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "comp",
+					Version: config.ComponentDescriptor.Version,
+				},
+				Relation: cdv2.LocalRelation,
+				Access:   &acc,
+			})
+
+			schemaBytes := []byte(`{ "$ref": "cd://resources/comp"}`)
+			data := []byte(`"valid"`)
+
+			Expect(validator.ValidateBytes(schemaBytes, data)).To(Succeed())
+		})
+
+		It("should throw an error if a wrong media type is used", func() {
+			Expect(vfs.WriteFile(blobFs, ctf.BlobPath("default.json"), []byte(`{ "type": "string"}`), os.ModePerm)).To(Succeed())
+			acc, err := cdv2.NewUnstructured(cdv2.NewLocalFilesystemBlobAccess("default.json", "application/unknown"))
+			Expect(err).ToNot(HaveOccurred())
+			config.ComponentDescriptor.Resources = append(config.ComponentDescriptor.Resources, cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "unknown",
+					Version: config.ComponentDescriptor.Version,
+				},
+				Relation: cdv2.LocalRelation,
+				Access:   &acc,
+			})
+
+			schemaBytes := []byte(`{ "$ref": "cd://resources/unknown"}`)
+			data := []byte(`"valid"`)
+
+			err = validator.ValidateBytes(schemaBytes, data)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown media type"))
+		})
+
 	})
 
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind usability
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/297

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support for compressed jsonschema definitions has been added
```
