### PR TITLE
use semantic names for the pull secrets mounted in the container deployer

### DIFF
--- a/pkg/deployer/container/pod.go
+++ b/pkg/deployer/container/pod.go
@@ -214,13 +214,15 @@ func generatePod(opts PodOptions) (*corev1.Pod, error) {
 
 	initMounts := []corev1.VolumeMount{configurationVolumeMount, initServiceAccountMount, sharedVolumeMount}
 
-	for _, v := range []string{opts.BluePrintPullSecret, opts.ComponentDescriptorPullSecret} {
+	for name, v := range map[string]string{
+		"blueprint-pull-secret": opts.BluePrintPullSecret,
+		"cd-pull-secret":        opts.ComponentDescriptorPullSecret} {
 		if len(v) == 0 {
 			continue
 		}
 
 		volumes = append(volumes, corev1.Volume{
-			Name: v,
+			Name: name,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: v,
@@ -229,9 +231,9 @@ func generatePod(opts PodOptions) (*corev1.Pod, error) {
 		})
 
 		initMounts = append(initMounts, corev1.VolumeMount{
-			Name:      v,
+			Name:      name,
 			ReadOnly:  true,
-			MountPath: filepath.Join(container.RegistrySecretBasePath, v),
+			MountPath: filepath.Join(container.RegistrySecretBasePath, name),
 		})
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority 3

**What this PR does / why we need it**:

Uses semantic names for the pull secret mounts for blueprints and component descriptor secrets.
This also fixes issue #296 but we should check if we could reach the actual secret name limit if we use the current secret naming

**Which issue(s) this PR fixes**:
partially fixes #296 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
