### PR TITLE
fix defaulting for container deploy items

### DIFF
--- a/pkg/deployer/container/container.go
+++ b/pkg/deployer/container/container.go
@@ -105,6 +105,10 @@ func New(log logr.Logger,
 }
 
 func applyDefaults(config *containerv1alpha1.Configuration, providerConfig *containerv1alpha1.ProviderConfiguration) {
+	// default configuration
+	DefaultConfiguration(config)
+
+	// default provider configuration
 	if len(providerConfig.Image) == 0 {
 		providerConfig.Image = config.DefaultImage.Image
 	}

--- a/pkg/deployer/container/container.go
+++ b/pkg/deployer/container/container.go
@@ -105,7 +105,6 @@ func New(log logr.Logger,
 }
 
 func applyDefaults(config *containerv1alpha1.Configuration, providerConfig *containerv1alpha1.ProviderConfiguration) {
-	// default configuration
 	DefaultConfiguration(config)
 
 	// default provider configuration


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area container-deployer
/kind bug
/priority 3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug regarding the defaulting of the container deployer which could cause it to generate invalid pod manifests.
```
