### PR TITLE
added new landscaper controller option "--landscaper-kubeconfig"

### DIFF
--- a/charts/landscaper/templates/cluster-kubeconfig-secret.yaml
+++ b/charts/landscaper/templates/cluster-kubeconfig-secret.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.controller.clusterKubeconfig.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "landscaper.fullname" . }}-controller-cluster-kubeconfig
+  labels:
+    {{- include "landscaper.labels" . | nindent 4 }}
+data:
+  kubeconfig: {{ .Values.controller.clusterKubeconfig.kubeconfig | b64enc }}
+{{- end }}
+{{- if .Values.webhooksServer.clusterKubeconfig.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "landscaper.fullname" . }}-webhooks-cluster-kubeconfig
+  labels:
+    {{- include "landscaper.labels" . | nindent 4 }}
+data:
+  kubeconfig: {{ .Values.webhooksServer.clusterKubeconfig.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/landscaper/templates/cluster-kubeconfig-secret.yaml
+++ b/charts/landscaper/templates/cluster-kubeconfig-secret.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.controller.clusterKubeconfig.kubeconfig }}
+{{- if .Values.controller.landscaperKubeconfig.kubeconfig }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,9 +11,9 @@ metadata:
   labels:
     {{- include "landscaper.labels" . | nindent 4 }}
 data:
-  kubeconfig: {{ .Values.controller.clusterKubeconfig.kubeconfig | b64enc }}
+  kubeconfig: {{ .Values.controller.landscaperKubeconfig.kubeconfig | b64enc }}
 {{- end }}
-{{- if .Values.webhooksServer.clusterKubeconfig.kubeconfig }}
+{{- if .Values.webhooksServer.landscaperKubeconfig.kubeconfig }}
 ---
 apiVersion: v1
 kind: Secret
@@ -22,5 +22,5 @@ metadata:
   labels:
     {{- include "landscaper.labels" . | nindent 4 }}
 data:
-  kubeconfig: {{ .Values.webhooksServer.clusterKubeconfig.kubeconfig | b64enc }}
+  kubeconfig: {{ .Values.webhooksServer.landscaperKubeconfig.kubeconfig | b64enc }}
 {{- end }}

--- a/charts/landscaper/templates/deployment-controller.yaml
+++ b/charts/landscaper/templates/deployment-controller.yaml
@@ -39,6 +39,9 @@ spec:
           image: "{{ include "landscaper-image" . }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
+          {{- if .Values.controller.clusterKubeconfig }}
+          - "--landscaper-kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          {{- end }}
           - "--config=/app/ls/config/config.yaml"
           - "-v={{ .Values.landscaper.verbosity }}"
           {{- if .Values.landscaper.deployers }}
@@ -65,6 +68,10 @@ spec:
           - name: deployers-config
             mountPath: /app/ls/deployers
           {{- end }}
+          {{- if .Values.controller.clusterKubeconfig }}
+          - name: landscaper-cluster-kubeconfig
+            mountPath: /app/ls/landscaper-cluster-kubeconfig
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -82,6 +89,15 @@ spec:
       - name: deployers-config
         secret:
           secretName: {{ include "landscaper.fullname" . }}-deployers-config
+      {{- end }}
+      {{- if .Values.controller.clusterKubeconfig }}
+      - name: landscaper-cluster-kubeconfig
+        secret:
+          {{- if .Values.controller.clusterKubeconfig.kubeconfig }}
+          secretName: {{ include "landscaper.fullname" . }}-controller-cluster-kubeconfig
+          {{- else }}
+          secretName: {{ .Values.controller.clusterKubeconfig.secretRef }}
+          {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/landscaper/templates/deployment-controller.yaml
+++ b/charts/landscaper/templates/deployment-controller.yaml
@@ -39,7 +39,7 @@ spec:
           image: "{{ include "landscaper-image" . }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
-          {{- if .Values.controller.clusterKubeconfig }}
+          {{- if .Values.controller.landscaperKubeconfig }}
           - "--landscaper-kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
           {{- end }}
           - "--config=/app/ls/config/config.yaml"
@@ -68,7 +68,7 @@ spec:
           - name: deployers-config
             mountPath: /app/ls/deployers
           {{- end }}
-          {{- if .Values.controller.clusterKubeconfig }}
+          {{- if .Values.controller.landscaperKubeconfig }}
           - name: landscaper-cluster-kubeconfig
             mountPath: /app/ls/landscaper-cluster-kubeconfig
           {{- end }}
@@ -90,13 +90,13 @@ spec:
         secret:
           secretName: {{ include "landscaper.fullname" . }}-deployers-config
       {{- end }}
-      {{- if .Values.controller.clusterKubeconfig }}
+      {{- if .Values.controller.landscaperKubeconfig }}
       - name: landscaper-cluster-kubeconfig
         secret:
-          {{- if .Values.controller.clusterKubeconfig.kubeconfig }}
+          {{- if .Values.controller.landscaperKubeconfig.kubeconfig }}
           secretName: {{ include "landscaper.fullname" . }}-controller-cluster-kubeconfig
           {{- else }}
-          secretName: {{ .Values.controller.clusterKubeconfig.secretRef }}
+          secretName: {{ .Values.controller.landscaperKubeconfig.secretRef }}
           {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/templates/deployment-webhooks.yaml
@@ -28,7 +28,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
+      {{- if not .Values.webhooksServer.landscaperKubeconfig }}
       serviceAccountName: {{ include "landscaper.webhooks.serviceAccountName" . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.webhooksServer.landscaperKubeconfig }}
+      automountServiceAccountToken: false
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/templates/deployment-webhooks.yaml
@@ -27,13 +27,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
-      {{- if not .Values.webhooksServer.landscaperKubeconfig }}
-      serviceAccountName: {{ include "landscaper.webhooks.serviceAccountName" . }}
-      {{- end }}
-      {{- end }}
       {{- if .Values.webhooksServer.landscaperKubeconfig }}
       automountServiceAccountToken: false
+      {{- else }}
+      serviceAccountName: {{ include "landscaper.webhooks.serviceAccountName" . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/templates/deployment-webhooks.yaml
@@ -39,15 +39,36 @@ spec:
           image: "{{ include "landscaper-webhook-image" . }}"
           imagePullPolicy: {{ .Values.webhooksServer.image.pullPolicy }}
           args:
-          - "-v={{ .Values.landscaper.verbosity }}"
-          - --port={{ .Values.webhooksServer.servicePort }}
+          {{- if .Values.webhooksServer.clusterKubeconfig }}
+          - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          - --webhook-url=https://{{ include "landscaper.webhooks.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.webhooksServer.servicePort }}
+          - --certificates-namespace={{ .Values.webhooksServer.certificatesNamespace }}
+          {{- else }}
           - --webhook-service={{ .Release.Namespace }}/{{ include "landscaper.webhooks.fullname" . }}
           - --webhook-service-port={{ .Values.webhooksServer.servicePort }}
+          {{- end }}
+          - "-v={{ .Values.landscaper.verbosity }}"
+          - --port={{ .Values.webhooksServer.servicePort }}
           {{- if .Values.webhooksServer.disableWebhooks }}
           - --disable-webhooks={{ .Values.webhooksServer.disableWebhooks | join "," }}
           {{- end }}
+          {{- if .Values.webhooksServer.clusterKubeconfig }}
+          volumeMounts:
+          - name: landscaper-cluster-kubeconfig
+            mountPath: /app/ls/landscaper-cluster-kubeconfig
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.webhooksServer.clusterKubeconfig }}
+      volumes:
+      - name: landscaper-cluster-kubeconfig
+        secret:
+          {{- if .Values.webhooksServer.clusterKubeconfig.kubeconfig }}
+          secretName: {{ include "landscaper.fullname" . }}-webhooks-cluster-kubeconfig
+          {{- else }}
+          secretName: {{ .Values.webhooksServer.clusterKubeconfig.secretRef }}
+          {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/templates/deployment-webhooks.yaml
@@ -39,7 +39,7 @@ spec:
           image: "{{ include "landscaper-webhook-image" . }}"
           imagePullPolicy: {{ .Values.webhooksServer.image.pullPolicy }}
           args:
-          {{- if .Values.webhooksServer.clusterKubeconfig }}
+          {{- if .Values.webhooksServer.landscaperKubeconfig }}
           - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
           - --webhook-url=https://{{ include "landscaper.webhooks.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.webhooksServer.servicePort }}
           - --certificates-namespace={{ .Values.webhooksServer.certificatesNamespace }}
@@ -52,21 +52,21 @@ spec:
           {{- if .Values.webhooksServer.disableWebhooks }}
           - --disable-webhooks={{ .Values.webhooksServer.disableWebhooks | join "," }}
           {{- end }}
-          {{- if .Values.webhooksServer.clusterKubeconfig }}
+          {{- if .Values.webhooksServer.landscaperKubeconfig }}
           volumeMounts:
           - name: landscaper-cluster-kubeconfig
             mountPath: /app/ls/landscaper-cluster-kubeconfig
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.webhooksServer.clusterKubeconfig }}
+      {{- if .Values.webhooksServer.landscaperKubeconfig }}
       volumes:
       - name: landscaper-cluster-kubeconfig
         secret:
-          {{- if .Values.webhooksServer.clusterKubeconfig.kubeconfig }}
+          {{- if .Values.webhooksServer.landscaperKubeconfig.kubeconfig }}
           secretName: {{ include "landscaper.fullname" . }}-webhooks-cluster-kubeconfig
           {{- else }}
-          secretName: {{ .Values.webhooksServer.clusterKubeconfig.secretRef }}
+          secretName: {{ .Values.webhooksServer.landscaperKubeconfig.secretRef }}
           {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/landscaper/templates/rbac-agent.yaml
+++ b/charts/landscaper/templates/rbac-agent.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if and (.Values.serviceAccount.create) (.Values.controller.landscaperKubeconfig) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "landscaper.fullname" . }}
+  labels:
+    {{- include "landscaper.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+    - landscaper.gardener.cloud
+  resources:
+    - "*"
+  verbs:
+    - "*"
+# the agent contains a helm deployer to deploy other deployers.
+# Its unknown what deployers might need we have to give the agent all possible permissions for resources.
+- apiGroups:
+    - "*"
+  resources:
+    - "*"
+  verbs:
+    - "*"
+{{- end -}}

--- a/charts/landscaper/templates/rbac-controller.yaml
+++ b/charts/landscaper/templates/rbac-controller.yaml
@@ -4,6 +4,7 @@
 */}}
 
 {{- if .Values.serviceAccount.create -}}
+{{- if not .Values.controller.landscaperKubeconfig -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -75,4 +76,5 @@ rules:
   - "*"
   verbs:
   - "*"
-{{-  end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/landscaper/templates/rbac-webhooks.yaml
+++ b/charts/landscaper/templates/rbac-webhooks.yaml
@@ -4,6 +4,7 @@
 */}}
 
 {{- if .Values.serviceAccount.create -}}
+{{- if not .Values.webhooksServer.landscaperKubeconfig -}}
 {{- if not (has "all" .Values.webhooksServer.disableWebhooks) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -24,5 +25,6 @@ rules:
   - "secrets"
   verbs:
   - "*"
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/landscaper/templates/rolebinding.yaml
+++ b/charts/landscaper/templates/rolebinding.yaml
@@ -20,6 +20,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 {{- if not (has "all" .Values.webhooksServer.disableWebhooks) }}
+{{- if not .Values.webhooksServer.landscaperKubeconfig }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -34,5 +35,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "landscaper.webhooks.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/landscaper/templates/serviceaccount.yaml
+++ b/charts/landscaper/templates/serviceaccount.yaml
@@ -16,6 +16,7 @@ metadata:
   {{- end }}
 ---
 {{- if not (has "all" .Values.webhooksServer.disableWebhooks) }}
+{{- if not .Values.webhooksServer.landscaperKubeconfig }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,5 +27,6 @@ metadata:
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/landscaper/values.yaml
+++ b/charts/landscaper/values.yaml
@@ -63,7 +63,7 @@ controller:
   # Provide the kubeconfig to access the remote Landscaper cluster here (inline or via secretRef).
   # When providing a secretRef, see ./templates/cluster-kubeconfig-secret.yaml for the correct secret format.
   # If no value is provided at all, the controller will default to the in-cluster kubeconfig.
-  clusterKubeconfig: {}
+  landscaperKubeconfig: {}
   #   secretRef: my-kubeconfig-secret
   #   kubeconfig: |
   #     <cluster-kubeconfig>
@@ -80,7 +80,7 @@ webhooksServer:
   # Provide the kubeconfig to access the remote Landscaper cluster here (inline or via secretRef).
   # When providing a secretRef, see ./templates/cluster-kubeconfig-secret.yaml for the correct secret format.
   # If no value is provided at all, the webhooks server will default to the in-cluster kubeconfig.
-  clusterKubeconfig: {}
+  landscaperKubeconfig: {}
   #   secretRef: my-kubeconfig-secret
   #   kubeconfig: |
   #     <cluster-kubeconfig>
@@ -95,7 +95,7 @@ webhooksServer:
   servicePort: 9443 # required unless disableWebhooks contains "all"
   disableWebhooks: [] # options: installation, deployitem, execution, all
   # Specify the namespace where the webhooks server certificate secret is stored.
-  # Required when "clusterKubeconfig" is defined.
+  # Required when "landscaperKubeconfig" is defined.
   certificatesNamespace: ""
 
 imagePullSecrets: []

--- a/charts/landscaper/values.yaml
+++ b/charts/landscaper/values.yaml
@@ -59,6 +59,15 @@ image: {}
 #  tag: ""
 
 controller:
+  # Allows to target a different cluster than the hosting cluster of the controller instance.
+  # Provide the kubeconfig to access the remote Landscaper cluster here (inline or via secretRef).
+  # When providing a secretRef, see ./templates/cluster-kubeconfig-secret.yaml for the correct secret format.
+  # If no value is provided at all, the controller will default to the in-cluster kubeconfig.
+  clusterKubeconfig: {}
+  #   secretRef: my-kubeconfig-secret
+  #   kubeconfig: |
+  #     <cluster-kubeconfig>
+
   replicaCount: 1
   image:
     repository: eu.gcr.io/gardener-project/landscaper/landscaper-controller
@@ -67,6 +76,15 @@ controller:
     #tag: ""
 
 webhooksServer:
+  # Allows to target a different cluster than the hosting cluster of the webhooks server instance.
+  # Provide the kubeconfig to access the remote Landscaper cluster here (inline or via secretRef).
+  # When providing a secretRef, see ./templates/cluster-kubeconfig-secret.yaml for the correct secret format.
+  # If no value is provided at all, the webhooks server will default to the in-cluster kubeconfig.
+  clusterKubeconfig: {}
+  #   secretRef: my-kubeconfig-secret
+  #   kubeconfig: |
+  #     <cluster-kubeconfig>
+
   replicaCount: 1
   image:
     repository: eu.gcr.io/gardener-project/landscaper/landscaper-webhooks-server
@@ -76,6 +94,9 @@ webhooksServer:
 
   servicePort: 9443 # required unless disableWebhooks contains "all"
   disableWebhooks: [] # options: installation, deployitem, execution, all
+  # Specify the namespace where the webhooks server certificate secret is stored.
+  # Required when "clusterKubeconfig" is defined.
+  certificatesNamespace: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -96,12 +96,12 @@ func (o *Options) run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("unable to build landscaper cluster client from %s: %w", o.landscaperKubeconfigPath, err)
 		}
-		hostConfig, err := client.ClientConfig()
+		lsConfig, err := client.ClientConfig()
 		if err != nil {
 			return fmt.Errorf("unable to build landscaper cluster rest client from %s: %w", o.landscaperKubeconfigPath, err)
 		}
 		opts.MetricsBindAddress = "0"
-		lsMgr, err = ctrl.NewManager(hostConfig, opts)
+		lsMgr, err = ctrl.NewManager(lsConfig, opts)
 		if err != nil {
 			return fmt.Errorf("unable to setup landscaper cluster manager from %s: %w", o.landscaperKubeconfigPath, err)
 		}

--- a/cmd/landscaper-controller/app/options.go
+++ b/cmd/landscaper-controller/app/options.go
@@ -24,8 +24,9 @@ import (
 
 // Options describes the options to configure the Landscaper controller.
 type Options struct {
-	Log        logr.Logger
-	ConfigPath string
+	Log                      logr.Logger
+	ConfigPath               string
+	landscaperKubeconfigPath string
 
 	Config   *config.LandscaperConfiguration
 	Deployer deployerconfig.Options
@@ -37,6 +38,7 @@ func NewOptions() *Options {
 
 func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.ConfigPath, "config", "", "Specify the path to the configuration file")
+	fs.StringVar(&o.landscaperKubeconfigPath, "landscaper-kubeconfig", "", "Specify the path to the landscaper kubeconfig cluster")
 	o.Deployer.AddFlags(fs)
 	logger.InitFlags(fs)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR adds a new landscaper option `--landscaper-kubeconfig`.
With this option the landscaper controller can run in a hosting cluster but operate on landscaper resources in a different cluster.
This PR also adds new kubeconfig properties to the landscaper helm chart.
When this properties are set for the landscaper controller/webhooks server, they will automatically use this new feature.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add new landscaper controller command line option "--landscaper-kubeconfig".
This option allows the landscaper controller to run inside a hosting cluster, but operate on landscaper resources in a different cluster.
```
