### PR TITLE
make name and namespace in helm deployer providerconfig mandatory

### DIFF
--- a/apis/deployer/helm/v1alpha1/validation/validation.go
+++ b/apis/deployer/helm/v1alpha1/validation/validation.go
@@ -23,6 +23,13 @@ func ValidateProviderConfiguration(config *helmv1alpha1.ProviderConfiguration) e
 	allErrs = append(allErrs, health.ValidateReadinessCheckConfiguration(field.NewPath("readinessChecks"), &config.ReadinessChecks)...)
 	allErrs = append(allErrs, ValidateChart(field.NewPath("chart"), config.Chart)...)
 
+	if len(config.Name) == 0 {
+		allErrs = append(allErrs, field.Required(field.NewPath("name"), "must not be empty"))
+	}
+	if len(config.Namespace) == 0 {
+		allErrs = append(allErrs, field.Required(field.NewPath("namespace"), "must not be empty"))
+	}
+
 	expPath := field.NewPath("exportsFromManifests")
 	keys := sets.NewString()
 	for i, export := range config.ExportsFromManifests {

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -60,6 +60,8 @@ var _ = Describe("Template", func() {
 		helmConfig.Chart.Archive = &helmv1alpha1.ArchiveAccess{
 			Raw: base64.StdEncoding.EncodeToString(chartData),
 		}
+		helmConfig.Name = "foo"
+		helmConfig.Namespace = "foo"
 		providerConfig, err := helper.ProviderConfigurationToRawExtension(helmConfig)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/validation/validation.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/validation/validation.go
@@ -23,6 +23,13 @@ func ValidateProviderConfiguration(config *helmv1alpha1.ProviderConfiguration) e
 	allErrs = append(allErrs, health.ValidateReadinessCheckConfiguration(field.NewPath("readinessChecks"), &config.ReadinessChecks)...)
 	allErrs = append(allErrs, ValidateChart(field.NewPath("chart"), config.Chart)...)
 
+	if len(config.Name) == 0 {
+		allErrs = append(allErrs, field.Required(field.NewPath("name"), "must not be empty"))
+	}
+	if len(config.Namespace) == 0 {
+		allErrs = append(allErrs, field.Required(field.NewPath("namespace"), "must not be empty"))
+	}
+
 	expPath := field.NewPath("exportsFromManifests")
 	keys := sets.NewString()
 	for i, export := range config.ExportsFromManifests {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind enhancement
/priority 3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The fields `name` and `namespace` in the config of a helm deploy item are now mandatory, since one or both of them being empty can lead to weird errors.
```
