### PR TITLE
add unrecoverable reconcile test

### DIFF
--- a/apis/deployer/container/v1alpha1/validation/validation.go
+++ b/apis/deployer/container/v1alpha1/validation/validation.go
@@ -5,10 +5,24 @@
 package validation
 
 import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/landscaper/apis/core"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/apis/core/validation"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 )
 
-// ValidateProviderConfiguration validates a helm deployer configuration
+// ValidateProviderConfiguration validates a container deployer configuration
 func ValidateProviderConfiguration(config *containerv1alpha1.ProviderConfiguration) error {
-	return nil
+	var allErrs field.ErrorList
+	for i, secretRef := range config.RegistryPullSecrets {
+		coreSecretRef := core.ObjectReference{}
+		if err := lsv1alpha1.Convert_v1alpha1_ObjectReference_To_core_ObjectReference(&secretRef, &coreSecretRef, nil); err != nil {
+			return err
+		}
+		allErrs = append(allErrs, validation.ValidateObjectReference(coreSecretRef, field.NewPath("registryPullSecrets").Index(i))...)
+	}
+
+	return allErrs.ToAggregate()
 }

--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -29,6 +29,11 @@ func (e Error) Error() string {
 	return fmt.Sprintf("Op: %q - Reason: %q - Message: %q", e.lsErr.Operation, e.lsErr.Reason, e.lsErr.Message)
 }
 
+// LandscaperError returns the wrapped landscaper error.
+func (e Error) LandscaperError() *lsv1alpha1.Error {
+	return e.lsErr.DeepCopy()
+}
+
 // Unwrap implements the unwrap interface
 func (e Error) Unwrap() error {
 	return e.err

--- a/apis/errors/error_test.go
+++ b/apis/errors/error_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errors_test
+
+import (
+	"testing"
+	"time"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/apis/errors"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "errors Test Suite")
+}
+
+var _ = Describe("errors", func() {
+
+	Context("GetPhaseForLastError", func() {
+		DescribeTable("GetPhaseForLastError",
+			func(phase lsv1alpha1.ComponentInstallationPhase, lastError *lsv1alpha1.Error, d time.Duration, expected lsv1alpha1.ComponentInstallationPhase) {
+				res := errors.GetPhaseForLastError(phase, lastError, d)
+				Expect(res).To(Equal(expected))
+			},
+			Entry("return the given phase if no error is defined",
+				lsv1alpha1.ComponentPhaseInit,
+				nil,
+				10*time.Second,
+				lsv1alpha1.ComponentPhaseInit),
+			Entry("return the given phase if an error is defined",
+				lsv1alpha1.ComponentPhaseInit,
+				errors.NewError("", "", "").LandscaperError(),
+				10*time.Second,
+				lsv1alpha1.ComponentPhaseInit),
+			Entry("return failed phase for unrecoverable errors",
+				lsv1alpha1.ComponentPhaseInit,
+				errors.NewError("", "", "", lsv1alpha1.ErrorConfigurationProblem).LandscaperError(),
+				10*time.Second,
+				lsv1alpha1.ComponentPhaseFailed))
+	})
+
+})

--- a/pkg/deployer/container/container_suite_test.go
+++ b/pkg/deployer/container/container_suite_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
+	"github.com/gardener/landscaper/pkg/api"
+	containerctlr "github.com/gardener/landscaper/pkg/deployer/container"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	"github.com/gardener/landscaper/test/utils/envtest"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "container deployer Test Suite")
+}
+
+var (
+	testenv     *envtest.Environment
+	projectRoot = filepath.Join("../../../")
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	testenv, err = envtest.New(projectRoot)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = testenv.Start()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).ToNot(HaveOccurred())
+})
+
+var _ = Describe("Template", func() {
+
+	var (
+		state  *envtest.State
+		mgr    manager.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+		var err error
+		mgr, err = manager.New(testenv.Env.Config, manager.Options{Scheme: api.LandscaperScheme})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(containerctlr.AddControllerToManager(logr.Discard(), mgr, mgr, containerv1alpha1.Configuration{})).To(Succeed())
+
+		state, err = testenv.InitState(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		go func() {
+			Expect(mgr.Start(ctx)).To(Succeed())
+		}()
+		Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	It("should set phase to failed if the provider configuration is invalid", func() {
+		item, err := containerctlr.NewDeployItemBuilder().ProviderConfig(&containerv1alpha1.ProviderConfiguration{
+			RegistryPullSecrets: []lsv1alpha1.ObjectReference{
+				{},
+			},
+		}).Build()
+		Expect(err).ToNot(HaveOccurred())
+		item.Name = "container-test"
+		item.Namespace = state.Namespace
+
+		Expect(state.Create(ctx, testenv.Client, item)).To(Succeed())
+
+		di := &lsv1alpha1.DeployItem{}
+		Eventually(func() error {
+			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(item), di)).To(Succeed())
+			if di.Status.Phase == lsv1alpha1.ExecutionPhaseFailed {
+				return nil
+			}
+			return fmt.Errorf("phase is %s but expected it to be failed", di.Status.Phase)
+		}, 10*time.Second, 2*time.Second).Should(Succeed())
+		Expect(di.Status.LastError).ToNot(BeNil())
+		Expect(di.Status.LastError.Codes).To(ContainElement(lsv1alpha1.ErrorConfigurationProblem))
+	})
+})

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -91,7 +91,7 @@ func (e *Environment) InitState(ctx context.Context) (*State, error) {
 	return InitStateWithNamespace(ctx, e.Client)
 }
 
-// InitState creates a new isolated environment with its own namespace.
+// InitStateWithNamespace creates a new isolated environment with its own namespace.
 func InitStateWithNamespace(ctx context.Context, c client.Client) (*State, error) {
 	state := NewState()
 	// create a new testing namespace

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/validation/validation.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/validation/validation.go
@@ -5,10 +5,23 @@
 package validation
 
 import (
+	"github.com/gardener/landscaper/apis/core"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/apis/core/validation"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ValidateProviderConfiguration validates a helm deployer configuration
+// ValidateProviderConfiguration validates a container deployer configuration
 func ValidateProviderConfiguration(config *containerv1alpha1.ProviderConfiguration) error {
-	return nil
+	var allErrs field.ErrorList
+	for i, secretRef := range config.RegistryPullSecrets {
+		coreSecretRef := core.ObjectReference{}
+		if err := lsv1alpha1.Convert_v1alpha1_ObjectReference_To_core_ObjectReference(&secretRef, &coreSecretRef, nil); err != nil {
+			return err
+		}
+		allErrs = append(allErrs, validation.ValidateObjectReference(coreSecretRef, field.NewPath("registryPullSecrets").Index(i))...)
+	}
+
+	return allErrs.ToAggregate()
 }

--- a/vendor/github.com/gardener/landscaper/apis/errors/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/errors/error.go
@@ -29,6 +29,11 @@ func (e Error) Error() string {
 	return fmt.Sprintf("Op: %q - Reason: %q - Message: %q", e.lsErr.Operation, e.lsErr.Reason, e.lsErr.Message)
 }
 
+// LandscaperError returns the wrapped landscaper error.
+func (e Error) LandscaperError() *lsv1alpha1.Error {
+	return e.lsErr.DeepCopy()
+}
+
 // Unwrap implements the unwrap interface
 func (e Error) Unwrap() error {
 	return e.err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind test
/priority 3

**What this PR does / why we need it**:

Adds a test for unrecoverable error that are not retried

**Which issue(s) this PR fixes**:
Fixes #310 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
