### PR TITLE
Improve integration tests

### DIFF
--- a/test/integration/installations/phase-propagation.go
+++ b/test/integration/installations/phase-propagation.go
@@ -114,8 +114,11 @@ func PhasePropagationTests(f *framework.Framework) {
 			}, timeoutTime, resyncTime).Should(BeEquivalentTo(lsv1alpha1.ComponentPhaseSucceeded), "subinstallation should be in phase %q", string(lsv1alpha1.ComponentPhaseSucceeded))
 
 			By("set execution deploy item to Failed and verify phase propagation")
-			execDi.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-			utils.ExpectNoError(f.Client.Status().Update(ctx, execDi))
+			Eventually(func() error {
+				execDi.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+				err := f.Client.Status().Update(ctx, execDi)
+				return err
+			}, timeoutTime, resyncTime).ShouldNot(HaveOccurred(), "unable to update deploy item status")
 			Eventually(func() (lsv1alpha1.ExecutionPhase, error) {
 				err := f.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)
 				if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt
/priority 3

**What this PR does / why we need it**:

This improves two integration tests:
1. One of the deployer management tests, which checks for failed installations now only observes installations which were created during the test. This prevents the test from failing if there are already failed installations in the landscaper namespace.
2. The phase propagation test now tries to update the status multiple times, in case it fails. This prevents flakeyness due to update conflicts.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
