### PR TITLE
fix landscaper deletion lifecycle

### DIFF
--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -88,6 +88,7 @@ type Controller struct {
 
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := c.Log().WithValues("installation", req.NamespacedName.String())
+	ctx = logr.NewContext(ctx, logger)
 	logger.V(5).Info("reconcile", "resource", req.NamespacedName)
 
 	inst := &lsv1alpha1.Installation{}

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -9,13 +9,14 @@ import (
 	"errors"
 	"fmt"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	lserrors "github.com/gardener/landscaper/apis/errors"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions"
 
-	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
@@ -23,81 +24,149 @@ import (
 )
 
 var (
-	SiblingImportError      = errors.New("a sibling still imports some of the exports")
-	WaitingForDeletionError = errors.New("waiting for deletion")
+	SiblingImportError = errors.New("a sibling still imports some of the exports")
 )
 
 func (c *Controller) handleDelete(ctx context.Context, inst *lsv1alpha1.Installation) error {
+	var (
+		currentOperation = "Deletion"
+		log              = logr.FromContextOrDiscard(ctx)
+	)
+
+	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
+		instOp, err := c.initPrerequisites(ctx, inst)
+		if err != nil {
+			return err
+		}
+		if err := c.Update(ctx, instOp); err != nil {
+			return err
+		}
+		if err := DeleteExecutionAndSubinstallations(ctx, instOp); err != nil {
+			return err
+		}
+
+		log.V(7).Info("remove force reconcile annotation")
+		delete(inst.Annotations, lsv1alpha1.OperationAnnotation)
+		if err := c.Client().Update(ctx, inst); err != nil {
+			return instOp.NewError(err, "RemoveOperationAnnotation", "Unable to remove operation annotation")
+		}
+		return nil
+	}
+
+	_, siblings, err := installations.GetParentAndSiblings(ctx, c.Client(), inst)
+	if err != nil {
+		return lserrors.NewWrappedError(err,
+			currentOperation, "CalculateInstallationContext", err.Error(), lsv1alpha1.ErrorInternalProblem)
+	}
+
+	// check if suitable for deletion
+	// todo: replacements and internal deletions
+	if checkIfSiblingImports(inst, installations.CreateInternalInstallationBases(siblings...)) {
+		return lserrors.NewWrappedError(SiblingImportError,
+			currentOperation, "SiblingImport", SiblingImportError.Error())
+	}
+
+	execPhase, err := executions.CombinedPhase(ctx, c.Client(), inst)
+	if err != nil {
+		return lserrors.NewWrappedError(err,
+			currentOperation, "CheckExecutionStatus", err.Error(), lsv1alpha1.ErrorInternalProblem)
+	}
+
+	subPhase, err := subinstallations.CombinedPhase(ctx, c.Client(), inst)
+	if err != nil {
+		return lserrors.NewWrappedError(err,
+			currentOperation, "CheckSubinstallationStatus", err.Error())
+	}
+
+	// if no installations nor an execution is deployed both phases are empty.
+	// Then we can simply skip the deletion.
+	if (len(execPhase) + len(subPhase)) == 0 {
+		controllerutil.RemoveFinalizer(inst, lsv1alpha1.LandscaperFinalizer)
+		return c.Client().Update(ctx, inst)
+	}
+
+	combinedState := lsv1alpha1helper.CombinedInstallationPhase(subPhase, lsv1alpha1.ComponentInstallationPhase(execPhase))
+
+	// we have to wait until all children (subinstallations and execution) are finished
+	if combinedState != "" && !lsv1alpha1helper.IsCompletedInstallationPhase(combinedState) {
+		log.V(2).Info("Waiting for all deploy items and subinstallations to be completed")
+		inst.Status.Phase = lsv1alpha1.ComponentPhaseDeleting
+		return nil
+	}
+
 	instOp, err := c.initPrerequisites(ctx, inst)
 	if err != nil {
 		return err
 	}
-	return EnsureDeletion(ctx, instOp)
+	instOp.CurrentOperation = "Deletion"
+
+	eligibleToUpdate, err := c.eligibleToUpdate(ctx, instOp)
+	if err != nil {
+		return lserrors.NewWrappedError(err,
+			currentOperation, "EligibleForUpdate", err.Error())
+	}
+	if eligibleToUpdate {
+		log.V(2).Info("installation outdated. Updating before deletion.")
+		inst.Status.Phase = lsv1alpha1.ComponentPhasePending
+		if err := c.Update(ctx, instOp); err != nil {
+			return err
+		}
+	}
+	return DeleteExecutionAndSubinstallations(ctx, instOp)
 }
 
-func EnsureDeletion(ctx context.Context, op *installations.Operation) error {
+// DeleteExecutionAndSubinstallations deletes the execution and all subinstallations of the installation.
+// The function does not wait for the successful deletion of all resources.
+// It returns nil and should be called on every reconcile until it removes the finalizer form the current installation.
+func DeleteExecutionAndSubinstallations(ctx context.Context, op *installations.Operation) error {
 	op.CurrentOperation = "Deletion"
 	op.Inst.Info.Status.Phase = lsv1alpha1.ComponentPhaseDeleting
-	// check if suitable for deletion
-	// todo: replacements and internal deletions
-	if checkIfSiblingImports(op) {
-		return SiblingImportError
-	}
 
-	execDeleted, err := deleteExecution(ctx, op)
+	execDeleted, err := deleteExecution(ctx, op.Client(), op.Inst.Info)
 	if err != nil {
 		return op.NewError(err, "DeleteExecution", err.Error())
 	}
 
-	subInstsDeleted, err := deleteSubInstallations(ctx, op)
+	subInstsDeleted, err := deleteSubInstallations(ctx, op.Client(), op.Inst.Info)
 	if err != nil {
 		return op.NewError(err, "DeleteSubinstallations", err.Error())
 	}
 
-	// remove force reconcile annotation
-	if metav1.HasAnnotation(op.Inst.Info.ObjectMeta, lsv1alpha1.OperationAnnotation) {
-		delete(op.Inst.Info.Annotations, lsv1alpha1.OperationAnnotation)
-		if err := op.Client().Update(ctx, op.Inst.Info); err != nil {
-			return op.NewError(err, "RemoveOperationAnnotation", "Unable to remove operation annotation")
-		}
-	}
-
 	if !execDeleted || !subInstsDeleted {
-		return WaitingForDeletionError
+		return nil
 	}
 
 	controllerutil.RemoveFinalizer(op.Inst.Info, lsv1alpha1.LandscaperFinalizer)
 	return op.Client().Update(ctx, op.Inst.Info)
 }
 
-func deleteExecution(ctx context.Context, op *installations.Operation) (bool, error) {
-	exec := &lsv1alpha1.Execution{}
-	if err := op.Client().Get(ctx, kutil.ObjectKeyFromObject(op.Inst.Info), exec); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
+func deleteExecution(ctx context.Context, kubeClient client.Client, inst *lsv1alpha1.Installation) (bool, error) {
+	exec, err := executions.GetExecutionForInstallation(ctx, kubeClient, inst)
+	if err != nil {
 		return false, err
+	}
+	if exec == nil {
+		return true, nil
 	}
 
 	if exec.DeletionTimestamp.IsZero() {
-		if err := op.Client().Delete(ctx, exec); err != nil {
+		if err := kubeClient.Delete(ctx, exec); err != nil {
 			return false, err
 		}
 	}
 
 	// add force reconcile annotation if present
-	if lsv1alpha1helper.HasOperation(op.Inst.Info.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
+	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
 		lsv1alpha1helper.SetOperation(&exec.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
-		if err := op.Client().Update(ctx, exec); err != nil {
+		if err := kubeClient.Update(ctx, exec); err != nil {
 			return false, fmt.Errorf("unable to add force reconcile label")
 		}
 	}
 	return false, nil
 }
 
-func deleteSubInstallations(ctx context.Context, op *installations.Operation) (bool, error) {
-	op.CurrentOperation = "DeleteSubInstallation"
-	subInsts, err := subinstallations.New(op).GetSubInstallations(ctx, op.Inst.Info)
+func deleteSubInstallations(ctx context.Context, kubeClient client.Client, inst *lsv1alpha1.Installation) (bool, error) {
+	subInsts, err := installations.ListSubinstallations(ctx, kubeClient, inst)
 	if err != nil {
 		return false, err
 	}
@@ -107,13 +176,13 @@ func deleteSubInstallations(ctx context.Context, op *installations.Operation) (b
 
 	for _, inst := range subInsts {
 		if inst.DeletionTimestamp.IsZero() {
-			if err := op.Client().Delete(ctx, inst); err != nil {
+			if err := kubeClient.Delete(ctx, inst); err != nil {
 				return false, err
 			}
 		}
-		if lsv1alpha1helper.HasOperation(op.Inst.Info.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
+		if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
 			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
-			if err := op.Client().Update(ctx, inst); err != nil {
+			if err := kubeClient.Update(ctx, inst); err != nil {
 				return false, fmt.Errorf("unable to add force reconcile annotation to subinstallation %s: %w", inst.Name, err)
 			}
 		}
@@ -122,14 +191,15 @@ func deleteSubInstallations(ctx context.Context, op *installations.Operation) (b
 	return false, nil
 }
 
-func checkIfSiblingImports(op *installations.Operation) bool {
-	for _, sibling := range op.Context().Siblings {
-		for _, dataImports := range op.Inst.Info.Spec.Exports.Data {
+// checkIfSiblingImports checks if a sibling imports any of the installations exports.
+func checkIfSiblingImports(inst *lsv1alpha1.Installation, siblings []*installations.InstallationBase) bool {
+	for _, sibling := range siblings {
+		for _, dataImports := range inst.Spec.Exports.Data {
 			if sibling.IsImportingData(dataImports.DataRef) {
 				return true
 			}
 		}
-		for _, targetImport := range op.Inst.Info.Spec.Exports.Targets {
+		for _, targetImport := range inst.Spec.Exports.Targets {
 			if sibling.IsImportingData(targetImport.Target) {
 				return true
 			}

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -6,15 +6,23 @@ package installations_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/landscaper/pkg/utils/simplelogger"
 
 	"github.com/gardener/landscaper/apis/config"
 	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
@@ -31,153 +39,234 @@ import (
 
 var _ = Describe("Delete", func() {
 
-	var (
-		op   *lsoperation.Operation
-		ctrl reconcile.Reconciler
+	Context("reconciler", func() {
+		var (
+			op   *lsoperation.Operation
+			ctrl reconcile.Reconciler
 
-		state        *envtest.State
-		fakeCompRepo ctf.ComponentResolver
-	)
+			state        *envtest.State
+			fakeCompRepo ctf.ComponentResolver
+		)
 
-	BeforeEach(func() {
-		var err error
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata")
-		Expect(err).ToNot(HaveOccurred())
+		BeforeEach(func() {
+			var err error
+			fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata")
+			Expect(err).ToNot(HaveOccurred())
 
-		op = lsoperation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
+			op = lsoperation.NewOperation(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 
-		ctrl = installationsctl.NewTestActuator(*op, &config.LandscaperConfiguration{
-			Registry: config.RegistryConfiguration{
-				Local: &config.LocalRegistryConfiguration{
-					RootPath: "./testdata",
+			ctrl = installationsctl.NewTestActuator(*op, &config.LandscaperConfiguration{
+				Registry: config.RegistryConfiguration{
+					Local: &config.LocalRegistryConfiguration{
+						RootPath: "./testdata",
+					},
 				},
-			},
+			})
+		})
+
+		AfterEach(func() {
+			if state != nil {
+				ctx := context.Background()
+				defer ctx.Done()
+				Expect(testenv.CleanupState(ctx, state)).ToNot(HaveOccurred())
+				state = nil
+			}
+		})
+
+		It("should block deletion if there are still subinstallations", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test1")
+			Expect(err).ToNot(HaveOccurred())
+
+			inInstRoot, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/root"])
+			Expect(err).ToNot(HaveOccurred())
+
+			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstRoot, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(installationsctl.DeleteExecutionAndSubinstallations(ctx, instOp)).To(Succeed())
+
+			instA := &lsv1alpha1.Installation{}
+			Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "a", Namespace: state.Namespace}, instA)).ToNot(HaveOccurred())
+			instB := &lsv1alpha1.Installation{}
+			Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "b", Namespace: state.Namespace}, instB)).ToNot(HaveOccurred())
+
+			Expect(instA.DeletionTimestamp.IsZero()).To(BeFalse())
+			Expect(instB.DeletionTimestamp.IsZero()).To(BeFalse())
+		})
+
+		It("should not block deletion if there are no subinstallations left", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test1")
+			Expect(err).ToNot(HaveOccurred())
+
+			inInstB, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/b"])
+			Expect(err).ToNot(HaveOccurred())
+
+			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = installationsctl.DeleteExecutionAndSubinstallations(ctx, instOp)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should delete subinstallations if no one imports exported values", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test2")
+			Expect(err).ToNot(HaveOccurred())
+
+			inInstB, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/a"])
+			Expect(err).ToNot(HaveOccurred())
+
+			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(installationsctl.DeleteExecutionAndSubinstallations(ctx, instOp)).To(Succeed())
+
+			instC := &lsv1alpha1.Installation{}
+			Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "c", Namespace: state.Namespace}, instC)).ToNot(HaveOccurred())
+			Expect(instC.DeletionTimestamp.IsZero()).To(BeFalse())
+		})
+
+		It("should propagate the force deletion annotation to a execution in deletion state", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test3")
+			Expect(err).ToNot(HaveOccurred())
+
+			inst := &lsv1alpha1.Installation{}
+			inst.Name = "root"
+			inst.Namespace = state.Namespace
+			testutils.ExpectNoError(testenv.Client.Delete(ctx, inst))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+
+			exec := &lsv1alpha1.Execution{}
+			exec.Name = "root"
+			exec.Namespace = state.Namespace
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+			Expect(exec.DeletionTimestamp).ToNot(BeNil())
+
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			metav1.SetMetaDataAnnotation(&inst.ObjectMeta, lsv1alpha1.OperationAnnotation, string(lsv1alpha1.ForceReconcileOperation))
+			testutils.ExpectNoError(testenv.Client.Update(ctx, inst))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+
+			// execution should have the force reconcile annotation
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+			ann, ok := exec.Annotations[lsv1alpha1.OperationAnnotation]
+			Expect(ok).To(BeTrue())
+			Expect(ann).To(Equal(string(lsv1alpha1.ForceReconcileOperation)))
 		})
 	})
 
-	AfterEach(func() {
-		if state != nil {
-			ctx := context.Background()
-			defer ctx.Done()
-			Expect(testenv.CleanupState(ctx, state)).ToNot(HaveOccurred())
-			state = nil
-		}
-	})
+	Context("Controller", func() {
 
-	It("should not delete if another installation still imports a exported value", func() {
-		ctx := context.Background()
+		var (
+			state  *envtest.State
+			mgr    manager.Manager
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
 
-		var err error
-		state, err = testenv.InitResources(ctx, "./testdata/state/test1")
-		Expect(err).ToNot(HaveOccurred())
+		BeforeEach(func() {
+			ctx, cancel = context.WithCancel(context.Background())
+			var err error
+			mgr, err = manager.New(testenv.Env.Config, manager.Options{
+				Scheme:             api.LandscaperScheme,
+				MetricsBindAddress: "0",
+			})
+			Expect(err).ToNot(HaveOccurred())
 
-		inInstA, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/a"])
-		Expect(err).ToNot(HaveOccurred())
+			state, err = testenv.InitState(ctx)
+			Expect(err).ToNot(HaveOccurred())
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstA, nil)
-		Expect(err).ToNot(HaveOccurred())
+			Expect(installationsctl.AddControllerToManager(simplelogger.NewIOLogger(GinkgoWriter), mgr, nil, &config.LandscaperConfiguration{})).To(Succeed())
+			go func() {
+				Expect(mgr.Start(ctx)).To(Succeed())
+			}()
+			Expect(mgr.GetCache().WaitForCacheSync(ctx)).To(BeTrue())
+		})
 
-		err = installationsctl.EnsureDeletion(ctx, instOp)
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(installationsctl.SiblingImportError))
+		AfterEach(func() {
+			cancel()
+		})
 
-		instC := &lsv1alpha1.Installation{}
-		Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "c", Namespace: state.Namespace}, instC)).ToNot(HaveOccurred())
-		Expect(instC.DeletionTimestamp.IsZero()).To(BeTrue())
-	})
+		It("should not delete if another installation still imports a exported value", func() {
 
-	It("should block deletion if there are still subinstallations", func() {
-		ctx := context.Background()
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test1")
+			Expect(err).ToNot(HaveOccurred())
 
-		var err error
-		state, err = testenv.InitResources(ctx, "./testdata/state/test1")
-		Expect(err).ToNot(HaveOccurred())
+			inst := state.Installations[state.Namespace+"/a"]
+			Expect(testenv.Client.Delete(ctx, inst)).To(Succeed())
 
-		inInstRoot, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/root"])
-		Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				i := &lsv1alpha1.Installation{}
+				if err := testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), i); err != nil {
+					return err
+				}
+				if i.Status.LastError == nil {
+					return errors.New("no error present")
+				}
+				if !strings.Contains(i.Status.LastError.Message, installationsctl.SiblingImportError.Error()) {
+					return fmt.Errorf("expected the reported error to be %q but got %q", installationsctl.SiblingImportError.Error(), i.Status.LastError.Message)
+				}
+				return nil
+			}, 20*time.Second, 2*time.Second).Should(Succeed(), "should error with a sibling import error")
 
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstRoot, nil)
-		Expect(err).ToNot(HaveOccurred())
+			instC := &lsv1alpha1.Installation{}
+			Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "c", Namespace: state.Namespace}, instC)).ToNot(HaveOccurred())
+			Expect(instC.DeletionTimestamp.IsZero()).To(BeTrue())
+		})
 
-		err = installationsctl.EnsureDeletion(ctx, instOp)
-		Expect(err).To(HaveOccurred())
+		It("should be able to delete a installation with an erroneous component descriptor", func() {
+			inst := &lsv1alpha1.Installation{}
+			inst.GenerateName = "test-"
+			inst.Namespace = state.Namespace
+			inst.Spec.ComponentDescriptor = &lsv1alpha1.ComponentDescriptorDefinition{
+				Reference: &lsv1alpha1.ComponentDescriptorReference{
+					RepositoryContext: testutils.ExampleRepositoryContext(),
+					ComponentName:     "not-a-component",
+					Version:           "v0.0.0",
+				},
+			}
 
-		instA := &lsv1alpha1.Installation{}
-		Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "a", Namespace: state.Namespace}, instA)).ToNot(HaveOccurred())
-		instB := &lsv1alpha1.Installation{}
-		Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "b", Namespace: state.Namespace}, instB)).ToNot(HaveOccurred())
+			Expect(state.Create(ctx, testenv.Client, inst)).To(Succeed())
+			Eventually(func() error {
+				i := &lsv1alpha1.Installation{}
+				if err := testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), i); err != nil {
+					return err
+				}
+				if len(i.Finalizers) == 0 {
+					return errors.New("no finalizers exist on the installation")
+				}
+				return nil
+			}, 20*time.Second, 2*time.Second).Should(Succeed(), "the installation should have been reconciled once")
 
-		Expect(instA.DeletionTimestamp.IsZero()).To(BeFalse())
-		Expect(instB.DeletionTimestamp.IsZero()).To(BeFalse())
-	})
+			// patch status to be failed
+			old := inst.DeepCopy()
+			inst.Status.Phase = lsv1alpha1.ComponentPhaseFailed
+			Expect(testenv.Client.Status().Patch(ctx, inst, client.MergeFrom(old)))
+			Expect(testenv.Client.Delete(ctx, inst)).To(Succeed())
 
-	It("should not block deletion if there are no subinstallations left", func() {
-		ctx := context.Background()
-
-		var err error
-		state, err = testenv.InitResources(ctx, "./testdata/state/test1")
-		Expect(err).ToNot(HaveOccurred())
-
-		inInstB, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/b"])
-		Expect(err).ToNot(HaveOccurred())
-
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = installationsctl.EnsureDeletion(ctx, instOp)
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should delete subinstallations if no one imports exported values", func() {
-		ctx := context.Background()
-
-		var err error
-		state, err = testenv.InitResources(ctx, "./testdata/state/test2")
-		Expect(err).ToNot(HaveOccurred())
-
-		inInstB, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), state.Installations[state.Namespace+"/a"])
-		Expect(err).ToNot(HaveOccurred())
-
-		instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = installationsctl.EnsureDeletion(ctx, instOp)
-		Expect(err).To(HaveOccurred())
-
-		instC := &lsv1alpha1.Installation{}
-		Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "c", Namespace: state.Namespace}, instC)).ToNot(HaveOccurred())
-		Expect(instC.DeletionTimestamp.IsZero()).To(BeFalse())
-	})
-
-	It("should propagate the force deletion annotation to a execution in deletion state", func() {
-		ctx := context.Background()
-
-		var err error
-		state, err = testenv.InitResources(ctx, "./testdata/state/test3")
-		Expect(err).ToNot(HaveOccurred())
-
-		inst := &lsv1alpha1.Installation{}
-		inst.Name = "root"
-		inst.Namespace = state.Namespace
-		testutils.ExpectNoError(testenv.Client.Delete(ctx, inst))
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(inst)) // returns a still waiting error
-
-		exec := &lsv1alpha1.Execution{}
-		exec.Name = "root"
-		exec.Namespace = state.Namespace
-		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
-		Expect(exec.DeletionTimestamp).ToNot(BeNil())
-
-		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
-		metav1.SetMetaDataAnnotation(&inst.ObjectMeta, lsv1alpha1.OperationAnnotation, string(lsv1alpha1.ForceReconcileOperation))
-		testutils.ExpectNoError(testenv.Client.Update(ctx, inst))
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(inst)) // returns a still waiting error
-
-		// execution should have the force reconcile annotation
-		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
-		ann, ok := exec.Annotations[lsv1alpha1.OperationAnnotation]
-		Expect(ok).To(BeTrue())
-		Expect(ann).To(Equal(string(lsv1alpha1.ForceReconcileOperation)))
+			Eventually(func() error {
+				i := &lsv1alpha1.Installation{}
+				if err := testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), i); err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil
+					}
+					return err
+				}
+				return errors.New("installation still exist")
+			}, 20*time.Second, 2*time.Second).Should(Succeed(), "the installation should be deleted")
+		})
 	})
 
 })

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/root-no-imports/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/root-no-imports/blueprint.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+annotations:
+  local/name: root
+  local/version: 1.0.0

--- a/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
@@ -27,6 +27,14 @@ component:
       type: localFilesystemBlob
       mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root
+  - name: root-no-imports
+    type: blueprint
+    version: 1.0.0
+    relation: local
+    access:
+      type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
+      filename: root-no-imports
   - name: res-a
     type: blueprint
     version: 1.0.0

--- a/pkg/landscaper/controllers/installations/testdata/state/test3/00-root.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test3/00-root.yaml
@@ -21,26 +21,15 @@ spec:
 
   blueprint:
     ref:
-      resourceName: root
-
-  imports:
-    data:
-    - name: root.a
-      dataRef: ext.a
-
-  exports:
-    data:
-    - name: root.y
-      dataRef: root.y
-    - name: root.z
-      dataRef: root.z
+      resourceName: root-no-imports
 
 status:
-  phase: Progressing
+  phase: Failed
   configGeneration: ""
+
 
   imports:
   - name: root.a
     configGeneration: ""
 
-  observedGeneration: 0
+  observedGeneration: 2

--- a/pkg/landscaper/controllers/installations/testdata/state/test3/10-exec.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test3/10-exec.yaml
@@ -25,7 +25,7 @@ spec:
       my-val: val1
 
 status:
-  phase: Init
+  phase: Failed
 
-  observedGeneration: 0
+  observedGeneration: 1
 

--- a/pkg/landscaper/installations/helper.go
+++ b/pkg/landscaper/installations/helper.go
@@ -64,13 +64,16 @@ func CreateInternalInstallations(ctx context.Context, compResolver ctf.Component
 }
 
 // CreateInternalInstallationBases creates internal installation bases for a list of ComponentInstallations
-func CreateInternalInstallationBases(installations ...*lsv1alpha1.Installation) ([]*InstallationBase, error) {
+func CreateInternalInstallationBases(installations ...*lsv1alpha1.Installation) []*InstallationBase {
+	if len(installations) == 0 {
+		return nil
+	}
 	internalInstallations := make([]*InstallationBase, len(installations))
 	for i, inst := range installations {
 		inInst := CreateInternalInstallationBase(inst)
 		internalInstallations[i] = inInst
 	}
-	return internalInstallations, nil
+	return internalInstallations
 }
 
 // ResolveComponentDescriptor resolves the component descriptor of a installation.
@@ -98,6 +101,9 @@ func ResolveComponentDescriptor(ctx context.Context, compRepo ctf.ComponentResol
 
 // CreateInternalInstallation creates an internal installation for an Installation
 func CreateInternalInstallation(ctx context.Context, compResolver ctf.ComponentResolver, inst *lsv1alpha1.Installation) (*Installation, error) {
+	if inst == nil {
+		return nil, nil
+	}
 	cdRef := GetReferenceFromComponentDescriptorDefinition(inst.Spec.ComponentDescriptor)
 	blue, err := blueprints.Resolve(ctx, compResolver, cdRef, inst.Spec.Blueprint)
 	if err != nil {
@@ -470,7 +476,7 @@ func HandleSubComponentPhaseChanges(
 		}
 		phases = append(phases, lsv1alpha1.ComponentInstallationPhase(exec.Status.Phase))
 	}
-	subinsts, err := listSubinstallations(ctx, kubeClient, inst)
+	subinsts, err := ListSubinstallations(ctx, kubeClient, inst)
 	if err != nil {
 		return fmt.Errorf("error fetching subinstallations for installation %s/%s: %w", inst.Namespace, inst.Name, err)
 	}

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -341,7 +341,7 @@ func (v *Validator) checkStateForParentImport(fldPath *field.Path, importName st
 		return installations.NewImportNotFoundErrorf(err, "%s: import in parent not found", fldPath.String())
 	}
 	// parent has to be progressing
-	if v.parent.Info.Status.Phase != lsv1alpha1.ComponentPhaseProgressing {
+	if !lsv1alpha1helper.IsProgressingInstallationPhase(v.parent.Info.Status.Phase) {
 		return installations.NewImportNotSatisfiedErrorf(nil, "%s: Parent has to be progressing to get imports", fldPath.String())
 	}
 	return nil

--- a/pkg/landscaper/installations/installation.go
+++ b/pkg/landscaper/installations/installation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 )
 
-// Installation is the internal representation of an installation without resolved blueprint.
+// InstallationBase is the internal representation of an installation without resolved blueprint.
 type InstallationBase struct {
 	Imports map[string]interface{}
 	Info    *lsv1alpha1.Installation

--- a/pkg/landscaper/installations/installations_suite_test.go
+++ b/pkg/landscaper/installations/installations_suite_test.go
@@ -5,13 +5,34 @@
 package installations_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Installations Test Suite")
 }
+
+var (
+	testenv *envtest.Environment
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	projectRoot := filepath.Join("../../../")
+	testenv, err = envtest.New(projectRoot)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = testenv.Start()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).ToNot(HaveOccurred())
+})

--- a/pkg/utils/simplelogger/logger.go
+++ b/pkg/utils/simplelogger/logger.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Logger provides a simplified, plain logging interface in constrast to
+// Logger provides a simplified, plain logging interface in contrast to
 // logr.Logger
 type Logger interface {
 	Log(message string)

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -275,6 +275,9 @@ func (d *Dumper) DumpLandscaperResources(ctx context.Context) error {
 	if err := d.DumpInstallationsInNamespace(ctx, d.lsNamespace); err != nil {
 		return err
 	}
+	if err := d.DumpExecutionInNamespace(ctx, d.lsNamespace); err != nil {
+		return err
+	}
 	if err := d.DumpDeployItemsInNamespace(ctx, d.lsNamespace); err != nil {
 		return err
 	}

--- a/test/landscaper/e2e/inlinecd_test.go
+++ b/test/landscaper/e2e/inlinecd_test.go
@@ -139,8 +139,7 @@ var _ = Describe("Inline Component Descriptor", func() {
 
 		// the installation controller should propagate the deletion to its subcharts
 		_, err = instActuator.Reconcile(ctx, instReq)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("waiting for deletion"))
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
 		Expect(exec.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -139,8 +139,7 @@ var _ = Describe("Simple", func() {
 
 		// the installation controller should propagate the deletion to its subcharts
 		_, err = instActuator.Reconcile(ctx, instReq)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("waiting for deletion"))
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
 		Expect(exec.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")

--- a/test/utils/controller.go
+++ b/test/utils/controller.go
@@ -65,8 +65,7 @@ func DeleteInstallation(ctx context.Context, client client.Client, execActuator,
 	gomega.Expect(client.Get(ctx, execReq.NamespacedName, exec)).ToNot(gomega.HaveOccurred())
 
 	// the installation controller should propagate the deletion to its subcharts
-	err := ShouldNotReconcile(ctx, instActuator, instReq)
-	gomega.Expect(err.Error()).To(gomega.ContainSubstring("waiting for deletion"))
+	ShouldReconcile(ctx, instActuator, instReq)
 
 	gomega.Expect(client.Get(ctx, execReq.NamespacedName, exec)).ToNot(gomega.HaveOccurred())
 	gomega.Expect(exec.DeletionTimestamp.IsZero()).To(gomega.BeFalse(), "deletion timestamp should be set")
@@ -85,14 +84,14 @@ func DeleteInstallation(ctx context.Context, client client.Client, execActuator,
 		gomega.Expect(di.DeletionTimestamp.IsZero()).To(gomega.BeFalse(), "deletion timestamp should be set")
 
 		ShouldReconcile(ctx, mockActuator, diReq)
-		err = client.Get(ctx, diReq.NamespacedName, di)
+		err := client.Get(ctx, diReq.NamespacedName, di)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue(), "deploy item should be deleted")
 	}
 
 	// execution controller should remove the finalizer
 	ShouldReconcile(ctx, execActuator, execReq)
-	err = client.Get(ctx, execReq.NamespacedName, exec)
+	err := client.Get(ctx, execReq.NamespacedName, exec)
 	gomega.Expect(err).To(gomega.HaveOccurred())
 	gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue(), "execution should be deleted")
 

--- a/test/utils/envtest/fake_client.go
+++ b/test/utils/envtest/fake_client.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,7 +18,6 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
-	mock_client "github.com/gardener/landscaper/pkg/utils/kubernetes/mock"
 )
 
 // NewFakeClientFromPath reads all landscaper related files from the given path adds them to the controller runtime's fake client.
@@ -71,14 +69,4 @@ func NewFakeClientFromPath(path string) (client.Client, *State, error) {
 	}
 
 	return fake.NewClientBuilder().WithScheme(api.LandscaperScheme).WithObjects(objects...).Build(), state, nil
-}
-
-// RegisterFakeClientToMock adds fake client calls to a mockclient
-func RegisterFakeClientToMock(mockClient *mock_client.MockClient, fakeClient client.Client) error {
-	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Get)
-	mockClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Create)
-	mockClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Update)
-	mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Patch)
-	mockClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Delete)
-	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind cleanup
/priority 3

**What this PR does / why we need it**:

- Fixes an issue that installations that never had any subinstallations nor blueprint can be deleted even if some configuration is erroneous.

- The deletion flow has been enhanced so that now changes in the installation are propagated to the execution and subinstallations.
Before this was not possible so one was unable to fix anything after deletion was triggered.

- The check if a installation is ready to be executed is now done before all external resources are fetched. This should decrease the network and increase the performace for most of the reconcile loops.

**Which issue(s) this PR fixes**:
Fixes #230 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed that caused the installation to stuck in deletion if the installation is erroneous.
Updated configuration is now correctly propagated during deletion and it is possible to set the `force-reconcile` annotation.

Installations that never had a successful execution (never have deployed an execution nor an installation) are now directly deleted.
```
