### PR TITLE
simplfied the usage of the teststate helper struct

### DIFF
--- a/cmd/landscaper-controller/app/app_test.go
+++ b/cmd/landscaper-controller/app/app_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Landscaper Controller", func() {
 
 		AfterEach(func() {
 			ctx := context.Background()
-			Expect(state.CleanupState(ctx, testenv.Client, nil)).To(Succeed())
+			Expect(state.CleanupState(ctx)).To(Succeed())
 			// remove all Deployer registrations
 			deployerRegistrations := &lsv1alpha1.DeployerRegistrationList{}
 			Expect(testenv.Client.List(ctx, deployerRegistrations)).To(Succeed())

--- a/pkg/deployer/container/container_suite_test.go
+++ b/pkg/deployer/container/container_suite_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Template", func() {
 		item.Name = "container-test"
 		item.Namespace = state.Namespace
 
-		Expect(state.Create(ctx, testenv.Client, item)).To(Succeed())
+		Expect(state.Create(ctx, item)).To(Succeed())
 
 		di := &lsv1alpha1.DeployItem{}
 		Eventually(func() error {

--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Helm Deployer", func() {
 		di.Spec.Configuration, err = helper.ProviderConfigurationToRawExtension(providerConfig)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(state.Create(ctx, testenv.Client, di, envtest.UpdateStatus(true))).To(Succeed())
+		Expect(state.Create(ctx, di, envtest.UpdateStatus(true))).To(Succeed())
 
 		// At this stage, resources are not yet ready
 		err = testutil.ShouldNotReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))

--- a/pkg/deployer/lib/readinesscheck/readiness_suite_test.go
+++ b/pkg/deployer/lib/readinesscheck/readiness_suite_test.go
@@ -75,7 +75,7 @@ func loadObjectsIntoTestEnv(dirname string, c client.Client, s *envtest.State) (
 		}
 
 		u.SetNamespace(s.Namespace)
-		err = s.Create(ctx, c, u)
+		err = s.Create(ctx, u)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/deployer/lib/resourcemanager/exporter_test.go
+++ b/pkg/deployer/lib/resourcemanager/exporter_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Exporter", func() {
 
 	AfterEach(func() {
 		cancel()
-		Expect(state.CleanupState(context.TODO(), testenv.Client, nil))
+		Expect(state.CleanupState(context.TODO()))
 	})
 
 	It("should export from a existing configmap", func() {
@@ -49,7 +49,7 @@ var _ = Describe("Exporter", func() {
 		cm.Data = map[string]string{
 			"somekey": "abc",
 		}
-		Expect(state.Create(ctx, testenv.Client, cm)).To(Succeed())
+		Expect(state.Create(ctx, cm)).To(Succeed())
 
 		exports := &managedresource.Exports{
 			Exports: []managedresource.Export{
@@ -100,7 +100,7 @@ var _ = Describe("Exporter", func() {
 			case <-ctx.Done():
 				return
 			case <-time.After(10 * time.Second):
-				Expect(state.Create(ctx, testenv.Client, cm)).To(Succeed())
+				Expect(state.Create(ctx, cm)).To(Succeed())
 			}
 		}()
 
@@ -144,7 +144,7 @@ var _ = Describe("Exporter", func() {
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-data"
 		cm.Namespace = state.Namespace
-		Expect(state.Create(ctx, testenv.Client, cm)).To(Succeed())
+		Expect(state.Create(ctx, cm)).To(Succeed())
 
 		go func() {
 			select {
@@ -203,7 +203,7 @@ var _ = Describe("Exporter", func() {
 		cm.Data = map[string]string{
 			"somekey": "abc",
 		}
-		Expect(state.Create(ctx, testenv.Client, cm)).To(Succeed())
+		Expect(state.Create(ctx, cm)).To(Succeed())
 
 		exports := &managedresource.Exports{
 			Exports: []managedresource.Export{
@@ -239,14 +239,14 @@ var _ = Describe("Exporter", func() {
 				"name":      "my-ref-data",
 				"namespace": cm.Namespace,
 			}
-			Expect(state.Create(ctx, testenv.Client, cm)).To(Succeed())
+			Expect(state.Create(ctx, cm)).To(Succeed())
 			refCm := &corev1.ConfigMap{}
 			refCm.Name = "my-ref-data"
 			refCm.Namespace = state.Namespace
 			refCm.Data = map[string]string{
 				"somekey": "abc",
 			}
-			Expect(state.Create(ctx, testenv.Client, refCm)).To(Succeed())
+			Expect(state.Create(ctx, refCm)).To(Succeed())
 
 			exports := &managedresource.Exports{
 				Exports: []managedresource.Export{
@@ -300,7 +300,7 @@ var _ = Describe("Exporter", func() {
 					Name: "sa-token",
 				},
 			}
-			Expect(state.Create(ctx, testenv.Client, sa)).To(Succeed())
+			Expect(state.Create(ctx, sa)).To(Succeed())
 
 			secret := &corev1.Secret{}
 			secret.Name = "sa-token"
@@ -308,7 +308,7 @@ var _ = Describe("Exporter", func() {
 			secret.Data = map[string][]byte{
 				"somekey": []byte("abc"),
 			}
-			Expect(state.Create(ctx, testenv.Client, secret)).To(Succeed())
+			Expect(state.Create(ctx, secret)).To(Succeed())
 
 			exports := &managedresource.Exports{
 				Exports: []managedresource.Export{

--- a/pkg/deployer/lib/resourcemanager/objectapplier_test.go
+++ b/pkg/deployer/lib/resourcemanager/objectapplier_test.go
@@ -37,7 +37,7 @@ var _ = Describe("ObjectApplier", func() {
 	})
 
 	AfterEach(func() {
-		Expect(state.CleanupState(context.TODO(), testenv.Client, nil))
+		Expect(state.CleanupState(context.TODO()))
 	})
 
 	It("should apply and update a configmap", func() {

--- a/pkg/deployer/lib/targetselector/e2e_suite_test.go
+++ b/pkg/deployer/lib/targetselector/e2e_suite_test.go
@@ -68,7 +68,7 @@ var _ = Describe("E2E", func() {
 			AddAnnotation(AnnotationKey, AnnotationValue).
 			Build()
 		testutils.ExpectNoError(err)
-		testutils.ExpectNoError(state.Create(ctx, testenv.Client, tgt))
+		testutils.ExpectNoError(state.Create(ctx, tgt))
 
 		mockConfig := &mockv1alpha1.ProviderConfiguration{}
 		phase := lsv1alpha1.ExecutionPhaseSucceeded
@@ -79,7 +79,7 @@ var _ = Describe("E2E", func() {
 			TargetFromObjectKey(kutil.ObjectKeyFromObject(tgt)).
 			Build()
 		testutils.ExpectNoError(err)
-		testutils.ExpectNoError(state.Create(ctx, testenv.Client, di))
+		testutils.ExpectNoError(state.Create(ctx, di))
 
 		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{
 			TargetSelector: []lsv1alpha1.TargetSelector{
@@ -117,7 +117,7 @@ var _ = Describe("E2E", func() {
 			AddAnnotation(AnnotationKey, AnnotationValue).
 			Build()
 		testutils.ExpectNoError(err)
-		testutils.ExpectNoError(state.Create(ctx, testenv.Client, tgt))
+		testutils.ExpectNoError(state.Create(ctx, tgt))
 
 		mockConfig := &mockv1alpha1.ProviderConfiguration{}
 		phase := lsv1alpha1.ExecutionPhaseSucceeded
@@ -128,7 +128,7 @@ var _ = Describe("E2E", func() {
 			TargetFromObjectKey(kutil.ObjectKeyFromObject(tgt)).
 			Build()
 		testutils.ExpectNoError(err)
-		testutils.ExpectNoError(state.Create(ctx, testenv.Client, di))
+		testutils.ExpectNoError(state.Create(ctx, di))
 
 		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{
 			TargetSelector: []lsv1alpha1.TargetSelector{

--- a/pkg/deployer/manifest/manifest_suite_test.go
+++ b/pkg/deployer/manifest/manifest_suite_test.go
@@ -67,13 +67,13 @@ var _ = Describe("Reconcile", func() {
 
 	AfterEach(func() {
 		defer ctx.Done()
-		Expect(state.CleanupState(ctx, testenv.Client, nil)).To(Succeed())
+		Expect(state.CleanupState(ctx)).To(Succeed())
 	})
 
 	It("should create a configured configmap", func() {
 		target, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state.Create(ctx, testenv.Client, target)).To(Succeed())
+		Expect(state.Create(ctx, target)).To(Succeed())
 
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
@@ -94,7 +94,7 @@ var _ = Describe("Reconcile", func() {
 			Target(target.Namespace, target.Name).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state.Create(ctx, testenv.Client, item)).To(Succeed())
+		Expect(state.Create(ctx, item)).To(Succeed())
 
 		m, err := manifest.New(logr.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
@@ -115,11 +115,11 @@ var _ = Describe("Reconcile", func() {
 		kSecret.Data = map[string][]byte{
 			lsv1alpha1.DefaultKubeconfigKey: kubeconfigBytes,
 		}
-		Expect(state.Create(ctx, testenv.Client, kSecret)).To(Succeed())
+		Expect(state.Create(ctx, kSecret)).To(Succeed())
 
 		target, err := utils.CreateKubernetesTargetFromSecret(state.Namespace, "my-target", kSecret)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state.Create(ctx, testenv.Client, target)).To(Succeed())
+		Expect(state.Create(ctx, target)).To(Succeed())
 
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
@@ -140,7 +140,7 @@ var _ = Describe("Reconcile", func() {
 			Target(target.Namespace, target.Name).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state.Create(ctx, testenv.Client, item)).To(Succeed())
+		Expect(state.Create(ctx, item)).To(Succeed())
 
 		m, err := manifest.New(logr.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
@@ -155,7 +155,7 @@ var _ = Describe("Reconcile", func() {
 	It("should delete a created configmap", func() {
 		target, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state.Create(ctx, testenv.Client, target)).To(Succeed())
+		Expect(state.Create(ctx, target)).To(Succeed())
 
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
@@ -176,7 +176,7 @@ var _ = Describe("Reconcile", func() {
 			Target(target.Namespace, target.Name).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(state.Create(ctx, testenv.Client, item)).To(Succeed())
+		Expect(state.Create(ctx, item)).To(Succeed())
 
 		m, err := manifest.New(logr.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -230,7 +230,7 @@ func ReadAndCreateOrUpdateDeployItem(ctx context.Context, testenv *envtest.Envir
 	old := &lsv1alpha1.DeployItem{}
 	if err := testenv.Client.Get(ctx, kutil.ObjectKey(di.Name, di.Namespace), old); err != nil {
 		if apierrors.IsNotFound(err) {
-			Expect(state.Create(ctx, testenv.Client, di, envtest.UpdateStatus(true))).To(Succeed())
+			Expect(state.Create(ctx, di, envtest.UpdateStatus(true))).To(Succeed())
 			return di
 		}
 		testutil.ExpectNoError(err)

--- a/pkg/deployermanagement/controller/controller_reconcile_test.go
+++ b/pkg/deployermanagement/controller/controller_reconcile_test.go
@@ -75,7 +75,7 @@ var _ = Describe("EnvironmentController Reconcile Test", func() {
 			"test": "val",
 		}
 		env.Spec.HostTarget.Type = "mytype"
-		Expect(state.Create(ctx, testenv.Client, env)).To(Succeed())
+		Expect(state.Create(ctx, env)).To(Succeed())
 
 		envReq := testutils.Request(env.Name, state.Namespace)
 		testutils.ShouldReconcile(ctx, envController, envReq)
@@ -100,7 +100,7 @@ var _ = Describe("EnvironmentController Reconcile Test", func() {
 			env.GenerateName = "test"
 			env.Spec.TargetSelectors = make([]lsv1alpha1.TargetSelector, 0)
 			env.Spec.HostTarget.Type = "mytype"
-			Expect(state.Create(ctx, testenv.Client, env)).To(Succeed())
+			Expect(state.Create(ctx, env)).To(Succeed())
 			envKey := kutil.ObjectKeyFromObject(env)
 
 			envReq := testutils.Request(env.Name, state.Namespace)
@@ -120,7 +120,7 @@ var _ = Describe("EnvironmentController Reconcile Test", func() {
 			reg := &lsv1alpha1.DeployerRegistration{}
 			reg.GenerateName = "test-"
 			reg.Spec.DeployItemTypes = []lsv1alpha1.DeployItemType{"test"}
-			Expect(state.Create(ctx, testenv.Client, reg)).To(Succeed())
+			Expect(state.Create(ctx, reg)).To(Succeed())
 			regKey := kutil.ObjectKeyFromObject(reg)
 			regReq := testutils.Request(reg.Name, state.Namespace)
 
@@ -141,7 +141,7 @@ var _ = Describe("EnvironmentController Reconcile Test", func() {
 			controllerutil.AddFinalizer(env, lsv1alpha1.LandscaperDMFinalizer)
 			env.Spec.TargetSelectors = make([]lsv1alpha1.TargetSelector, 0)
 			env.Spec.HostTarget.Type = "mytype"
-			testutils.ExpectNoError(state.Create(ctx, testenv.Client, env))
+			testutils.ExpectNoError(state.Create(ctx, env))
 			testutils.ExpectNoError(testenv.Client.Delete(ctx, env))
 			envKey := kutil.ObjectKeyFromObject(env)
 			envReq := testutils.Request(env.Name, state.Namespace)
@@ -168,7 +168,7 @@ var _ = Describe("EnvironmentController Reconcile Test", func() {
 			reg.GenerateName = "test-"
 			controllerutil.AddFinalizer(reg, lsv1alpha1.LandscaperDMFinalizer)
 			reg.Spec.DeployItemTypes = []lsv1alpha1.DeployItemType{"test"}
-			testutils.ExpectNoError(state.Create(ctx, testenv.Client, reg))
+			testutils.ExpectNoError(state.Create(ctx, reg))
 			testutils.ExpectNoError(testenv.Client.Delete(ctx, reg))
 			regKey := kutil.ObjectKeyFromObject(reg)
 			regReq := testutils.Request(reg.Name, state.Namespace)

--- a/pkg/deployermanagement/controller/deployer_management_test.go
+++ b/pkg/deployermanagement/controller/deployer_management_test.go
@@ -59,13 +59,13 @@ var _ = Describe("Deployer Management Test", func() {
 			env.GenerateName = "test-"
 			env.Spec.TargetSelectors = make([]lsv1alpha1.TargetSelector, 0)
 			env.Spec.HostTarget.Type = "mytype"
-			Expect(state.Create(ctx, testenv.Client, env)).To(Succeed())
+			Expect(state.Create(ctx, env)).To(Succeed())
 
 			reg := &lsv1alpha1.DeployerRegistration{}
 			reg.GenerateName = "test-"
 			controllerutil.AddFinalizer(reg, lsv1alpha1.LandscaperDMFinalizer)
 			reg.Spec.DeployItemTypes = []lsv1alpha1.DeployItemType{"test"}
-			testutils.ExpectNoError(state.Create(ctx, testenv.Client, reg))
+			testutils.ExpectNoError(state.Create(ctx, reg))
 
 			inst := &lsv1alpha1.Installation{}
 			inst.GenerateName = "test-"
@@ -74,7 +74,7 @@ var _ = Describe("Deployer Management Test", func() {
 				lsv1alpha1.DeployerEnvironmentLabelName:  env.Name,
 				lsv1alpha1.DeployerRegistrationLabelName: reg.Name,
 			}
-			testutils.ExpectNoError(state.Create(ctx, testenv.Client, inst))
+			testutils.ExpectNoError(state.Create(ctx, inst))
 			instKey := kutil.ObjectKeyFromObject(inst)
 
 			testutils.ExpectNoError(dm.Delete(ctx, reg, env))
@@ -92,13 +92,13 @@ var _ = Describe("Deployer Management Test", func() {
 			env.Spec.TargetSelectors = make([]lsv1alpha1.TargetSelector, 0)
 			env.Spec.HostTarget.Type = "mytype"
 			env.Spec.Namespace = state.Namespace
-			Expect(state.Create(ctx, testenv.Client, env)).To(Succeed())
+			Expect(state.Create(ctx, env)).To(Succeed())
 
 			reg := &lsv1alpha1.DeployerRegistration{}
 			reg.GenerateName = "test-"
 			controllerutil.AddFinalizer(reg, lsv1alpha1.LandscaperDMFinalizer)
 			reg.Spec.DeployItemTypes = []lsv1alpha1.DeployItemType{"test"}
-			testutils.ExpectNoError(state.Create(ctx, testenv.Client, reg))
+			testutils.ExpectNoError(state.Create(ctx, reg))
 
 			testutils.MimicKCMServiceAccount(ctx, testenv.Client, testutils.MimicKCMServiceAccountArgs{
 				Name:      deployers.FQName(reg, env),

--- a/pkg/landscaper/controllers/componentoverwrites/componentoverwrites_controller_suite_test.go
+++ b/pkg/landscaper/controllers/componentoverwrites/componentoverwrites_controller_suite_test.go
@@ -58,14 +58,16 @@ var _ = Describe("Reconcile", func() {
 	AfterEach(func() {
 		defer ctx.Done()
 		if state != nil {
-			Expect(state.CleanupState(ctx, testenv.Client, nil))
+			Expect(state.CleanupState(ctx))
 		}
 	})
 
 	It("should add a component overwrite to the manager", func() {
 		mgr := componentoverwrites.New()
 		c := coctrl.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, mgr)
-		state = envtest.NewState()
+		var err error
+		state, err = testenv.InitState(context.TODO())
+		Expect(err).ToNot(HaveOccurred())
 
 		co := &lsv1alpha1.ComponentOverwrites{}
 		co.Name = "my-co"
@@ -79,7 +81,7 @@ var _ = Describe("Reconcile", func() {
 				},
 			},
 		}
-		Expect(state.Create(ctx, testenv.Client, co)).To(Succeed())
+		Expect(state.Create(ctx, co)).To(Succeed())
 
 		testutil.ShouldReconcile(ctx, c, testutil.Request("my-co", ""))
 

--- a/pkg/landscaper/controllers/execution/reconcile_test.go
+++ b/pkg/landscaper/controllers/execution/reconcile_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Reconcile", func() {
 				},
 			},
 		}
-		testutils.ExpectNoError(state.Create(ctx, testenv.Client, exec))
+		testutils.ExpectNoError(state.Create(ctx, exec))
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
 
 		// expect a deploy item
@@ -102,7 +102,7 @@ var _ = Describe("Reconcile", func() {
 				},
 			},
 		}
-		testutils.ExpectNoError(state.Create(ctx, testenv.Client, exec))
+		testutils.ExpectNoError(state.Create(ctx, exec))
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
 
 		// expect a deploy item

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Delete", func() {
 				},
 			}
 
-			Expect(state.Create(ctx, testenv.Client, inst)).To(Succeed())
+			Expect(state.Create(ctx, inst)).To(Succeed())
 			Eventually(func() error {
 				i := &lsv1alpha1.Installation{}
 				if err := testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), i); err != nil {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -250,8 +250,7 @@ func (f *Framework) NewState(ctx context.Context) (*envtest.State, CleanupFunc, 
 		}
 		f.Log().Logln("Start state cleanup...")
 		f.Cleanup.Remove(handle)
-		t := time.Minute
-		return state.CleanupState(ctx, f.Client, &t)
+		return state.CleanupState(ctx, envtest.WithCleanupTimeout(time.Minute))
 	}
 	if !f.DisableCleanup {
 		handle = f.Cleanup.Add(func() {

--- a/test/integration/core/registry.go
+++ b/test/integration/core/registry.go
@@ -74,14 +74,14 @@ func RegistryTest(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, false)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			ginkgo.By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			cm.SetNamespace(state.Namespace)
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.Data["namespace"] = state.Namespace
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 
 			ginkgo.By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
@@ -96,7 +96,7 @@ func RegistryTest(f *framework.Framework) {
 			}
 			inst.Spec.Blueprint.Reference.ResourceName = "my-blueprint"
 
-			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+			utils.ExpectNoError(state.Create(ctx, inst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))

--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -142,7 +142,7 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 		target.Namespace = state.Namespace
 		target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 		utils.ExpectNoError(err)
-		utils.ExpectNoError(state.Create(ctx, f.Client, target))
+		utils.ExpectNoError(state.Create(ctx, target))
 
 		ginkgo.By("Create Configuration for the installation")
 		cm := &corev1.ConfigMap{}
@@ -154,7 +154,7 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 			// todo: add own target selector to not interfere with other tests
 			"values": "{}",
 		}
-		utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+		utils.ExpectNoError(state.Create(ctx, cm))
 		cmRef := lsv1alpha1.ObjectReference{
 			Name:      cm.Name,
 			Namespace: cm.Namespace,
@@ -209,7 +209,7 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 			},
 		}
 
-		utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+		utils.ExpectNoError(state.Create(ctx, inst))
 		utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
 
 		ginkgo.By("Testing the deployer with a simple deployitem")
@@ -226,7 +226,7 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 			utils.ExpectNoError(err)
 		}
 		g.Expect(di).ToNot(g.BeNil())
-		utils.ExpectNoError(state.Create(ctx, f.Client, di))
+		utils.ExpectNoError(state.Create(ctx, di))
 
 		utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
 

--- a/test/integration/deployers/container_tests.go
+++ b/test/integration/deployers/container_tests.go
@@ -46,7 +46,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target.Namespace = state.Namespace
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			di := &lsv1alpha1.DeployItem{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "30-DeployItem-Container-sleep.yaml")))
@@ -59,7 +59,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			}
 
 			ginkgo.By("Create container deploy item")
-			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			ginkgo.By("Delete container deploy item")
@@ -73,7 +73,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target.Namespace = state.Namespace
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			di := utils.BuildContainerDeployItem(&containerv1alpha1.ProviderConfiguration{
 				Image: "example.com/some-invalid/image:v0.0.1",
@@ -87,7 +87,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			}
 
 			ginkgo.By("Create erroneous container deploy item")
-			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseFailed, 2*time.Minute))
 
 			ginkgo.By("update the DeployItem and set a valid image")
@@ -111,7 +111,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target.Namespace = state.Namespace
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			di := &lsv1alpha1.DeployItem{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "31-DeployItem-Container-export.yaml")))
@@ -124,7 +124,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			}
 
 			ginkgo.By("Create container deploy item")
-			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			// expect that the export contains a valid json with { "my-val": true }
@@ -144,7 +144,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			target.Namespace = state.Namespace
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			di := &lsv1alpha1.DeployItem{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "32-DeployItem-Container-state.yaml")))
@@ -157,7 +157,7 @@ func ContainerDeployerTests(f *framework.Framework) {
 			}
 
 			ginkgo.By("Create container deploy item")
-			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			// expect that the export contains a valid json with { "counter": 1 }

--- a/test/integration/deployers/helmcharts/chartstests.go
+++ b/test/integration/deployers/helmcharts/chartstests.go
@@ -116,11 +116,11 @@ func deployDeployItemAndWaitForSuccess(
 
 	target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, deployerName, f.RestConfig, true)
 	utils.ExpectNoError(err)
-	utils.ExpectNoError(state.Create(ctx, f.Client, target))
+	utils.ExpectNoError(state.Create(ctx, target))
 
 	By("Creating the DeployItem")
 	di := forgeHelmDeployItem(chartDir, valuesFile, deployerName, target, f.LsVersion)
-	utils.ExpectNoError(state.Create(ctx, f.Client, di))
+	utils.ExpectNoError(state.Create(ctx, di))
 	By("Waiting for the DeployItem to succeed")
 	utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
 	By("Waiting for the corresponding Deployment to become ready")

--- a/test/integration/deployers/management/dm_tests.go
+++ b/test/integration/deployers/management/dm_tests.go
@@ -231,7 +231,7 @@ func DeployerManagementTests(f *framework.Framework) {
 				"values": lsv1alpha1.NewAnyJSON([]byte("{}")),
 			}
 
-			testutil.ExpectNoError(state.Create(ctx, f.Client, reg))
+			testutil.ExpectNoError(state.Create(ctx, reg))
 
 			g.Eventually(func() error {
 				instList = &lsv1alpha1.InstallationList{}

--- a/test/integration/deployers/manifest_tests.go
+++ b/test/integration/deployers/manifest_tests.go
@@ -56,7 +56,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 			target.Namespace = state.Namespace
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			di := &lsv1alpha1.DeployItem{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "40-DeployItem-Manifest-secret.yaml")))
@@ -69,7 +69,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 			}
 
 			ginkgo.By("Create Manifest (v1alpha2) deploy item")
-			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
 
 			ginkgo.By("Check presence of Kubernetes Objects")
@@ -116,7 +116,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 			target.Namespace = state.Namespace
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			di := &lsv1alpha1.DeployItem{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(testDataDir, "00-DeployItem-Manifest-v1alpha1.yaml")))
@@ -129,7 +129,7 @@ func ManifestDeployerTests(f *framework.Framework) {
 			}
 
 			ginkgo.By("Create Manifest (v1alpha1) deploy item")
-			utils.ExpectNoError(state.Create(ctx, f.Client, di))
+			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, timeout))
 
 			ginkgo.By("Check presence of Kubernetes objects")

--- a/test/integration/deployitems/timeouts.go
+++ b/test/integration/deployitems/timeouts.go
@@ -82,8 +82,8 @@ func TimeoutTests(f *framework.Framework) {
 			dummy_inst.SetNamespace(state.Namespace)
 			mock_inst.SetNamespace(state.Namespace)
 			mock_di_prog.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, dummy_inst))
-			utils.ExpectNoError(state.Create(ctx, f.Client, mock_inst))
+			utils.ExpectNoError(state.Create(ctx, dummy_inst))
+			utils.ExpectNoError(state.Create(ctx, mock_inst))
 
 			By("verify that deploy items have been created")
 			dummy_inst_di := &lsv1alpha1.DeployItem{}
@@ -121,7 +121,7 @@ func TimeoutTests(f *framework.Framework) {
 				// return true if both deploy items could be fetched
 				return true, err
 			}, waitingForDeployItems, resyncTime).Should(BeTrue(), "unable to fetch deploy items")
-			utils.ExpectNoError(state.Create(ctx, f.Client, mock_di_prog))
+			utils.ExpectNoError(state.Create(ctx, mock_di_prog))
 
 			By("check for reconcile timestamp annotation")
 			// checking whether the set timestamp is up-to-date is difficult due to potential differences between the

--- a/test/integration/installations/import-export.go
+++ b/test/integration/installations/import-export.go
@@ -53,19 +53,19 @@ func ImportExportTests(f *framework.Framework) {
 			secret := &k8sv1.Secret{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(secret, path.Join(testdataDir, "10-dummy-secret.yaml")))
 			secret.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, secret))
+			utils.ExpectNoError(state.Create(ctx, secret))
 			expectedDataExport := string(secret.Data["value"])
 			// dummy target
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, path.Join(testdataDir, "10-dummy-target.yaml")))
 			target.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 			expectedTargetExport := target.Spec
 			// component descriptor secret
 			secret2 := &k8sv1.Secret{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(secret2, path.Join(testdataDir, "10-cdimport-secret.yaml")))
 			secret2.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, secret2))
+			utils.ExpectNoError(state.Create(ctx, secret2))
 			tmpData := secret2.Data["componentDescriptor"]
 			tmpDataJSON, err := yaml.ToJSON(tmpData)
 			utils.ExpectNoError(err)
@@ -75,7 +75,7 @@ func ImportExportTests(f *framework.Framework) {
 			cm := &k8sv1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, path.Join(testdataDir, "10-cdimport-configmap.yaml")))
 			cm.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 			tmpDataString := cm.Data["componentDescriptor"]
 			tmpDataJSON, err = yaml.ToJSON([]byte(tmpDataString))
 			utils.ExpectNoError(err)
@@ -86,7 +86,7 @@ func ImportExportTests(f *framework.Framework) {
 			root := &lsv1alpha1.Installation{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(root, path.Join(testdataDir, "00-root-installation.yaml")))
 			root.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, root))
+			utils.ExpectNoError(state.Create(ctx, root))
 
 			By("verify that subinstallation has been created")
 			subinst := &lsv1alpha1.Installation{}

--- a/test/integration/installations/phase-propagation.go
+++ b/test/integration/installations/phase-propagation.go
@@ -43,7 +43,7 @@ func PhasePropagationTests(f *framework.Framework) {
 			root := &lsv1alpha1.Installation{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(root, path.Join(testdataDir, "00-root-installation.yaml")))
 			root.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, root))
+			utils.ExpectNoError(state.Create(ctx, root))
 
 			By("verify that execution has been created and fetch deploy item")
 			exec := &lsv1alpha1.Execution{}

--- a/test/integration/tutorial/aggregated-blueprint.go
+++ b/test/integration/tutorial/aggregated-blueprint.go
@@ -40,20 +40,20 @@ func AggregatedBlueprint(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			ginkgo.By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			cm.Data["namespace"] = state.Namespace
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 
 			ginkgo.By("Create Aggregated Installation")
 			aggInst := &lsv1alpha1.Installation{}
 			g.Expect(utils.ReadResourceFromFile(aggInst, nginxInstResource)).To(g.Succeed())
 			aggInst.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, aggInst))
+			utils.ExpectNoError(state.Create(ctx, aggInst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, aggInst, 4*time.Minute))

--- a/test/integration/tutorial/external-jsonschema.go
+++ b/test/integration/tutorial/external-jsonschema.go
@@ -42,19 +42,19 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			ginkgo.By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 
 			ginkgo.By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
 			g.Expect(utils.ReadResourceFromFile(inst, instResource)).To(g.Succeed())
 			inst.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+			utils.ExpectNoError(state.Create(ctx, inst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -41,20 +41,20 @@ func NginxIngressTest(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			ginkgo.By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			cm.Data["namespace"] = state.Namespace
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 
 			ginkgo.By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
 			gomega.Expect(utils.ReadResourceFromFile(inst, instResource)).To(gomega.Succeed())
 			inst.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+			utils.ExpectNoError(state.Create(ctx, inst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
@@ -102,20 +102,20 @@ func NginxIngressTest(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			ginkgo.By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			cm.Data["namespace"] = state.Namespace
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 
 			ginkgo.By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
 			gomega.Expect(utils.ReadResourceFromFile(inst, instResource)).To(gomega.Succeed())
 			inst.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+			utils.ExpectNoError(state.Create(ctx, inst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))

--- a/test/integration/tutorial/simple-import.go
+++ b/test/integration/tutorial/simple-import.go
@@ -43,20 +43,20 @@ func SimpleImport(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
-			utils.ExpectNoError(state.Create(ctx, f.Client, target))
+			utils.ExpectNoError(state.Create(ctx, target))
 
 			ginkgo.By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			cm.SetNamespace(state.Namespace)
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.Data["namespace"] = state.Namespace
-			utils.ExpectNoError(state.Create(ctx, f.Client, cm))
+			utils.ExpectNoError(state.Create(ctx, cm))
 
 			ginkgo.By("Create Nginx Ingress Installation")
 			nginxInst := &lsv1alpha1.Installation{}
 			g.Expect(utils.ReadResourceFromFile(nginxInst, nginxInstResource)).To(g.Succeed())
 			nginxInst.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, nginxInst))
+			utils.ExpectNoError(state.Create(ctx, nginxInst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, nginxInst, 2*time.Minute))
@@ -65,7 +65,7 @@ func SimpleImport(f *framework.Framework) {
 			inst := &lsv1alpha1.Installation{}
 			g.Expect(utils.ReadResourceFromFile(inst, echoServerInstResource)).To(g.Succeed())
 			inst.SetNamespace(state.Namespace)
-			utils.ExpectNoError(state.Create(ctx, f.Client, inst))
+			utils.ExpectNoError(state.Create(ctx, inst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))

--- a/test/integration/webhook/webhook.go
+++ b/test/integration/webhook/webhook.go
@@ -58,7 +58,7 @@ func WebhookTest(f *framework.Framework) {
 
 			// make installation invalid by duplicating the first export
 			inst.Spec.Exports.Data = append(inst.Spec.Exports.Data, inst.Spec.Exports.Data[0])
-			err := state.Create(ctx, f.Client, inst)
+			err := state.Create(ctx, inst)
 			gomega.Expect(err).To(gomega.HaveOccurred()) // validation webhook should have denied this
 			gomega.Expect(err.Error()).To(gomega.HavePrefix("admission webhook \"installations.validation.landscaper.gardener.cloud\" denied the request"))
 		})
@@ -102,7 +102,7 @@ func WebhookTest(f *framework.Framework) {
 				},
 			}
 
-			err := state.Create(ctx, f.Client, exec)
+			err := state.Create(ctx, exec)
 			gomega.Expect(err).To(gomega.HaveOccurred()) // validation webhook should have denied this
 			gomega.Expect(err.Error()).To(gomega.HavePrefix("admission webhook \"executions.validation.landscaper.gardener.cloud\" denied the request"))
 		})
@@ -137,7 +137,7 @@ func WebhookTest(f *framework.Framework) {
 				},
 			}
 
-			err := state.Create(ctx, f.Client, di)
+			err := state.Create(ctx, di)
 			gomega.Expect(err).To(gomega.HaveOccurred()) // validation webhook should have denied this
 			gomega.Expect(err.Error()).To(gomega.HavePrefix("admission webhook \"deployitems.validation.landscaper.gardener.cloud\" denied the request"))
 		})
@@ -153,7 +153,7 @@ func WebhookTest(f *framework.Framework) {
 				},
 			}
 
-			err := state.Create(ctx, f.Client, di)
+			err := state.Create(ctx, di)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			updated := di.DeepCopy()

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -93,7 +93,7 @@ func (e *Environment) InitState(ctx context.Context) (*State, error) {
 
 // InitStateWithNamespace creates a new isolated environment with its own namespace.
 func InitStateWithNamespace(ctx context.Context, c client.Client) (*State, error) {
-	state := NewState()
+	state := NewStateWithClient(c)
 	// create a new testing namespace
 	ns := &corev1.Namespace{}
 	ns.GenerateName = "tests-"
@@ -112,7 +112,7 @@ func (e *Environment) InitResources(ctx context.Context, resourcesPath string) (
 		return nil, err
 	}
 
-	if err := state.InitResources(ctx, e.Client, resourcesPath); err != nil {
+	if err := state.InitResourcesWithClient(ctx, e.Client, resourcesPath); err != nil {
 		return nil, err
 	}
 	return state, err
@@ -120,8 +120,7 @@ func (e *Environment) InitResources(ctx context.Context, resourcesPath string) (
 
 // CleanupState cleans up a test environment.
 func (e *Environment) CleanupState(ctx context.Context, state *State) error {
-	t := 5 * time.Second
-	return state.CleanupState(ctx, e.Client, &t)
+	return state.CleanupStateWithClient(ctx, e.Client, WithCleanupTimeout(5*time.Second))
 }
 
 func parseResources(path string, state *State) ([]client.Object, error) {

--- a/test/utils/envtest/fake_client.go
+++ b/test/utils/envtest/fake_client.go
@@ -11,27 +11,19 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
+	mock_client "github.com/gardener/landscaper/pkg/utils/kubernetes/mock"
 )
 
 // NewFakeClientFromPath reads all landscaper related files from the given path adds them to the controller runtime's fake client.
 func NewFakeClientFromPath(path string) (client.Client, *State, error) {
 	objects := make([]client.Object, 0)
-	state := &State{
-		Installations: make(map[string]*lsv1alpha1.Installation),
-		Executions:    make(map[string]*lsv1alpha1.Execution),
-		DeployItems:   make(map[string]*lsv1alpha1.DeployItem),
-		DataObjects:   make(map[string]*lsv1alpha1.DataObject),
-		Targets:       make(map[string]*lsv1alpha1.Target),
-		Secrets:       make(map[string]*corev1.Secret),
-		ConfigMaps:    make(map[string]*corev1.ConfigMap),
-	}
+	state := NewState()
 	if len(path) != 0 {
 		err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -68,5 +60,17 @@ func NewFakeClientFromPath(path string) (client.Client, *State, error) {
 		}
 	}
 
-	return fake.NewClientBuilder().WithScheme(api.LandscaperScheme).WithObjects(objects...).Build(), state, nil
+	kubeclient := fake.NewClientBuilder().WithScheme(api.LandscaperScheme).WithObjects(objects...).Build()
+	state.Client = kubeclient
+	return kubeclient, state, nil
+}
+
+// RegisterFakeClientToMock adds fake client calls to a mockclient
+func RegisterFakeClientToMock(mockClient *mock_client.MockClient, fakeClient client.Client) error {
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Get)
+	mockClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Create)
+	mockClient.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Update)
+	mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Patch)
+	mockClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(fakeClient.Delete)
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority 3

**What this PR does / why we need it**:

The state interface of the test helper has been refactored to now store the client.
With that the interface has been simplified as the client does not have to passed in every call.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
