### PR TITLE
fix bug which prevents 'empty' installations from getting a phase

### DIFF
--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -42,7 +42,11 @@ func (c *Controller) reconcile(ctx context.Context, inst *lsv1alpha1.Installatio
 	combinedState := lsv1alpha1helper.CombinedInstallationPhase(subState, lsv1alpha1.ComponentInstallationPhase(execState))
 
 	// we have to wait until all children (subinstallations and execution) are finished
-	if combinedState != "" && !lsv1alpha1helper.IsCompletedInstallationPhase(combinedState) {
+	if combinedState == "" {
+		// If combinedState is empty, this means there are neither subinstallations nor executions
+		// and an 'empty' installation is Succeeded by default
+		combinedState = lsv1alpha1.ComponentPhaseSucceeded
+	} else if !lsv1alpha1helper.IsCompletedInstallationPhase(combinedState) {
 		log.V(2).Info("Waiting for all deploy items and subinstallations to be completed")
 		inst.Status.Phase = lsv1alpha1.ComponentPhaseProgressing
 		return nil

--- a/pkg/landscaper/installations/helper.go
+++ b/pkg/landscaper/installations/helper.go
@@ -483,6 +483,10 @@ func HandleSubComponentPhaseChanges(
 	for _, sub := range subinsts {
 		phases = append(phases, sub.Status.Phase)
 	}
+	if len(phases) == 0 {
+		// Installation contains neither an execution nor subinstallations, so the phase can't be out of sync.
+		return nil
+	}
 	cp := lsv1alpha1helper.CombinedInstallationPhase(phases...)
 	if inst.Status.Phase != cp {
 		// Phase is completed but doesn't fit to the deploy items' phases


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**Which issue(s) this PR fixes**:
Fixes #189 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Installations which contain neither an execution nor subinstallations will now be set to `Succeeded` (if the imports are fulfilled) instead of being stuck without a phase.
```
