### PR TITLE
add example for the preserveDir option

### DIFF
--- a/docs/tutorials/02-local-simple-blueprint.md
+++ b/docs/tutorials/02-local-simple-blueprint.md
@@ -85,8 +85,27 @@ version: v0.1.0
 relation: external
 input:
   type: "dir" # type dir automatically creates a tar from the given dir.
-  path: /tmp/chart # path to the downloaded helm chart
+  path: /tmp/chart # parent path to the downloaded helm chart
   compress: true # compresses the tar/blob using gzip.
+  # Media type automatically defaults to "application/gzip" for compressed=true
+  # mediaType: "application/gzip"
+...
+```
+
+:warning: In the above example, the path to the helm chart points to the parent directory of `/tmp/chart/nginx-ingress`.
+The reason is that helm enforces to have the chart resources located in a parent directory.
+If the fully qualified path to the helm chart should be used, the option `preserveDir` has to be set to `true`.
+```yaml
+---
+type: helm
+name: ingress-nginx-chart
+version: v0.1.0
+relation: external
+input:
+  type: "dir" # type dir automatically creates a tar from the given dir.
+  path: /tmp/chart/nginx-ingress # fully qualified path to the downloaded helm chart
+  compress: true # compresses the tar/blob using gzip.
+  preserveDir: true # preserves the root directory of the helm chart
   # Media type automatically defaults to "application/gzip" for compressed=true
   # mediaType: "application/gzip"
 ...


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority 4

**What this PR does / why we need it**:

Specifying the correct path for a helm resource is a common pitfall.
Improve the docuementation a bit, so that it is more clear that the parent path to the helm chart has to be specified.
Also explain the `preserveDir` option.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
NONE
```
