### PR TITLE
move the subinstallations of landscaper service to seperate files

### DIFF
--- a/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
@@ -2,55 +2,68 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint
 
 imports:
+   # The "hostingCluster" specifies the target Kubernetes cluster into which the landscaper service will be installed.
   - name: hostingCluster
     required: true
     targetType: landscaper.gardener.cloud/kubernetes-cluster
 
+  # The "hostingClusterNamespace" is the namespace in the hosting cluster into which the landscaper service is getting installed.
+  # Only one landscaper server per namespace can be installed.
   - name: hostingClusterNamespace
     required: true
     type: data
     schema:
       type: string
 
+  # Specifies whether the "hostingClusterNamespace" is getting deleted before the installation.
   - name: deleteHostingClusterNamespace
     type: data
     schema:
       type: boolean
 
+  # The "virtualClusterNamespace" is the namespace in the virtual cluster into which the landscaper resources are getting installed.
   - name: virtualClusterNamespace
     required: true
     type: data
     schema:
       type: string
 
+  # The underlying infrastructure provider of the "hostingCluster" Kubernetes cluster.
+  # Currently, supported values: "gcp", "aws", "alicloud"
   - name: providerType
     type: data
     required: true
     schema:
       type: string
 
+  # The DNS domain at which the landscaper service should be accessible.
+  # Used for certificate generation.
   - name: dnsAccessDomain
     type: data
     required: true
     schema:
       type: string
 
+  # The landscaper registry configuration.
   - name: registryConfig
     type: data
     schema:
       $ref: "cd://resources/registry-config-definition"
 
+  # The landscaper deployment configuration.
   - name: landscaperConfig
     type: data
     schema:
       $ref: "cd://resources/landscaper-config-definition"
 
 exports:
+  # "landscaperClusterEndpoint" is the API server endpoint at which the landscaper is available.
   - name: landscaperClusterEndpoint
     type: data
     schema:
       type: string
 
+  # "landscaperClusterKubeconfig" is the Kubernetes kubeconfig which can be used to connect to the API server (Base64 encoded).
   - name: landscaperClusterKubeconfig
     type: data
     schema:
@@ -65,103 +78,6 @@ exportExecutions:
         landscaperClusterKubeconfig: {{ .values.dataobjects.landscaperUserKubeconfigYaml | b64enc }}
 
 subinstallations:
-  - apiVersion: landscaper.gardener.cloud/v1alpha1
-    kind: InstallationTemplate
-
-    name: virtual-garden
-
-    blueprint:
-      ref: cd://componentReferences/virtual-garden/resources/blueprint
-
-    imports:
-      targets:
-        - name: cluster
-          target: hostingCluster
-      data:
-        - name: importHostingClusterNamespace
-          dataRef: hostingClusterNamespace
-        - name: importProviderType
-          dataRef: providerType
-        - name: importDeleteNamespace
-          dataRef: deleteHostingClusterNamespace
-        - name: importDnsAccessDomain
-          dataRef: dnsAccessDomain
-
-    importDataMappings:
-      hostingCluster:
-        namespace: (( importHostingClusterNamespace ))
-        infrastructureProvider: (( importProviderType ))
-
-      virtualGarden:
-        deleteNamespace: (( importDeleteNamespace ))
-        etcd:
-          storageClassName: (( "landscaper-" importHostingClusterNamespace))
-          handleETCDPersistentVolumes: true
-        kubeAPIServer:
-          replicas: 1
-          dnsAccessDomain: (( importDnsAccessDomain ))
-          gardenerControlplane:
-            validatingWebhookEnabled: true
-            mutatingWebhookEnabled: true
-
-    exports:
-      data:
-        - name: virtualGardenEndpoint
-          dataRef: virtualGardenEndpoint
-      targets:
-        - name: virtualGardenKubeconfig
-          target: virtualGardenKubeconfig
-
-
-  - apiVersion: landscaper.gardener.cloud/v1alpha1
-    kind: InstallationTemplate
-
-    name: landscaper-rbac
-
-    blueprint:
-      ref: cd://resources/rbac-blueprint
-
-    imports:
-      targets:
-        - name: virtualCluster
-          target: virtualGardenKubeconfig
-      data:
-        - name: virtualClusterNamespace
-          dataRef: virtualClusterNamespace
-        - name: virtualClusterEndpoint
-          dataRef: virtualGardenEndpoint
-
-    exports:
-      data:
-        - name: landscaperControllerKubeconfigYaml
-          dataRef: landscaperControllerKubeconfigYaml
-        - name: landscaperWebhooksKubeconfigYaml
-          dataRef: landscaperWebhooksKubeconfigYaml
-        - name: landscaperUserKubeconfigYaml
-          dataRef: landscaperUserKubeconfigYaml
-
-  - apiVersion: landscaper.gardener.cloud/v1alpha1
-    kind: InstallationTemplate
-
-    name: landscaper-deployment
-
-    blueprint:
-      ref: cd://resources/landscaper-blueprint
-
-    imports:
-      targets:
-        - name: hostingCluster
-          target: hostingCluster
-      data:
-        - name: hostingClusterNamespace
-          dataRef: hostingClusterNamespace
-        - name: virtualClusterNamespace
-          dataRef: virtualClusterNamespace
-        - name: landscaperControllerKubeconfigYaml
-          dataRef: landscaperControllerKubeconfigYaml
-        - name: landscaperWebhooksKubeconfigYaml
-          dataRef: landscaperWebhooksKubeconfigYaml
-        - name: registryConfig
-          dataRef: registryConfig
-        - name: landscaperConfig
-          dataRef: landscaperConfig
+  - file: /virtual-garden-subinst.yaml
+  - file: /landscaper-rbac-subinst.yaml
+  - file: /landscaper-deployment-subinst.yaml

--- a/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
@@ -7,66 +7,75 @@ imports:
     required: true
     targetType: landscaper.gardener.cloud/kubernetes-cluster
 
-  # The "hostingClusterNamespace" is the namespace in the hosting cluster into which the landscaper service is getting installed.
-  # Only one landscaper server per namespace can be installed.
   - name: hostingClusterNamespace
     required: true
     type: data
     schema:
+      description: |
+        The "hostingClusterNamespace" is the namespace in the hosting cluster into which the landscaper service is getting installed.
+        Only one landscaper server per namespace can be installed.
       type: string
 
-  # Specifies whether the "hostingClusterNamespace" is getting deleted before the installation.
   - name: deleteHostingClusterNamespace
     type: data
     schema:
+      description: |
+        Specifies whether the "hostingClusterNamespace" is getting deleted before the installation.
       type: boolean
 
-  # The "virtualClusterNamespace" is the namespace in the virtual cluster into which the landscaper resources are getting installed.
   - name: virtualClusterNamespace
     required: true
     type: data
     schema:
+      description: |
+        The "virtualClusterNamespace" is the namespace in the virtual cluster into which the landscaper resources are getting installed.
       type: string
 
-  # The underlying infrastructure provider of the "hostingCluster" Kubernetes cluster.
-  # Currently, supported values: "gcp", "aws", "alicloud"
   - name: providerType
     type: data
     required: true
     schema:
+      description: |
+        The underlying infrastructure provider of the "hostingCluster" Kubernetes cluster.
+        Currently, supported values: "gcp", "aws", "alicloud"
       type: string
 
-  # The DNS domain at which the landscaper service should be accessible.
-  # Used for certificate generation.
   - name: dnsAccessDomain
     type: data
     required: true
     schema:
+      description: |
+        The DNS domain at which the landscaper service should be accessible.
+        Used for certificate generation.
       type: string
 
-  # The landscaper registry configuration.
   - name: registryConfig
     type: data
     schema:
+      description: |
+        The landscaper registry configuration.
       $ref: "cd://resources/registry-config-definition"
 
-  # The landscaper deployment configuration.
   - name: landscaperConfig
     type: data
     schema:
+      description: |
+        The landscaper deployment configuration.
       $ref: "cd://resources/landscaper-config-definition"
 
 exports:
-  # "landscaperClusterEndpoint" is the API server endpoint at which the landscaper is available.
   - name: landscaperClusterEndpoint
     type: data
     schema:
+      description: |
+        The API server endpoint at which the landscaper is available.
       type: string
 
-  # "landscaperClusterKubeconfig" is the Kubernetes kubeconfig which can be used to connect to the API server (Base64 encoded).
   - name: landscaperClusterKubeconfig
     type: data
     schema:
+      description: |
+        The Kubernetes kubeconfig which can be used to connect to the API server (Base64 encoded).
       type: string
 
 exportExecutions:

--- a/.landscaper/landscaper-service/blueprint/installation/landscaper-deployment-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/landscaper-deployment-subinst.yaml
@@ -1,0 +1,25 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: InstallationTemplate
+
+name: landscaper-deployment
+
+blueprint:
+  ref: cd://resources/landscaper-blueprint
+
+imports:
+  targets:
+    - name: hostingCluster
+      target: hostingCluster
+  data:
+    - name: hostingClusterNamespace
+      dataRef: hostingClusterNamespace
+    - name: virtualClusterNamespace
+      dataRef: virtualClusterNamespace
+    - name: landscaperControllerKubeconfigYaml
+      dataRef: landscaperControllerKubeconfigYaml
+    - name: landscaperWebhooksKubeconfigYaml
+      dataRef: landscaperWebhooksKubeconfigYaml
+    - name: registryConfig
+      dataRef: registryConfig
+    - name: landscaperConfig
+      dataRef: landscaperConfig

--- a/.landscaper/landscaper-service/blueprint/installation/landscaper-rbac-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/landscaper-rbac-subinst.yaml
@@ -1,0 +1,26 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: InstallationTemplate
+
+name: landscaper-rbac
+
+blueprint:
+  ref: cd://resources/rbac-blueprint
+
+imports:
+  targets:
+    - name: virtualCluster
+      target: virtualGardenKubeconfig
+  data:
+    - name: virtualClusterNamespace
+      dataRef: virtualClusterNamespace
+    - name: virtualClusterEndpoint
+      dataRef: virtualGardenEndpoint
+
+exports:
+  data:
+    - name: landscaperControllerKubeconfigYaml
+      dataRef: landscaperControllerKubeconfigYaml
+    - name: landscaperWebhooksKubeconfigYaml
+      dataRef: landscaperWebhooksKubeconfigYaml
+    - name: landscaperUserKubeconfigYaml
+      dataRef: landscaperUserKubeconfigYaml

--- a/.landscaper/landscaper-service/blueprint/installation/virtual-garden-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/virtual-garden-subinst.yaml
@@ -1,0 +1,46 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: InstallationTemplate
+
+name: virtual-garden
+
+blueprint:
+  ref: cd://componentReferences/virtual-garden/resources/blueprint
+
+imports:
+  targets:
+    - name: cluster
+      target: hostingCluster
+  data:
+    - name: importHostingClusterNamespace
+      dataRef: hostingClusterNamespace
+    - name: importProviderType
+      dataRef: providerType
+    - name: importDeleteNamespace
+      dataRef: deleteHostingClusterNamespace
+    - name: importDnsAccessDomain
+      dataRef: dnsAccessDomain
+
+importDataMappings:
+  hostingCluster:
+    namespace: (( importHostingClusterNamespace ))
+    infrastructureProvider: (( importProviderType ))
+
+  virtualGarden:
+    deleteNamespace: (( importDeleteNamespace ))
+    etcd:
+      storageClassName: (( "landscaper-" importHostingClusterNamespace))
+      handleETCDPersistentVolumes: true
+    kubeAPIServer:
+      replicas: 1
+      dnsAccessDomain: (( importDnsAccessDomain ))
+      gardenerControlplane:
+        validatingWebhookEnabled: true
+        mutatingWebhookEnabled: true
+
+exports:
+  data:
+    - name: virtualGardenEndpoint
+      dataRef: virtualGardenEndpoint
+  targets:
+    - name: virtualGardenKubeconfig
+      target: virtualGardenKubeconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 4

**What this PR does / why we need it**:

This PR moves the subinstallations to individual files, which should increase readability and maintainability.
Added some documentation for blueprint imports and exports.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
