### PR TITLE
Fix rendering of blueprints

### DIFF
--- a/pkg/utils/landscaper/blueprint.go
+++ b/pkg/utils/landscaper/blueprint.go
@@ -394,13 +394,13 @@ func validateComponentDescriptorImport(value interface{}, fldPath *field.Path) f
 func validateComponentDescriptorListImport(value interface{}, fldPath *field.Path) field.ErrorList {
 	allErr := field.ErrorList{}
 
-	targetList, ok := value.([]interface{})
+	cdList, ok := value.([]interface{})
 	if !ok {
 		allErr = append(allErr, field.Invalid(fldPath, value, "a component descriptor list is expected to be a list"))
 	}
 
-	for i, targetObj := range targetList {
-		allErr = append(allErr, validateComponentDescriptorImport(targetObj, fldPath.Index(i))...)
+	for i, cdObj := range cdList {
+		allErr = append(allErr, validateComponentDescriptorImport(cdObj, fldPath.Index(i))...)
 	}
 
 	return allErr

--- a/pkg/utils/landscaper/blueprint.go
+++ b/pkg/utils/landscaper/blueprint.go
@@ -319,33 +319,91 @@ func ValidateImports(bp *blueprints.Blueprint,
 					fmt.Sprintf("invalid imported value: %s", err.Error())))
 			}
 		case lsv1alpha1.ImportTypeTarget:
-			// import is a target import
-			targetObj, ok := value.(map[string]interface{})
-			if !ok {
-				allErr = append(allErr, field.Invalid(fldPath, value, "a target is expected to be an object"))
-				continue
-			}
-			targetType, _, err := unstructured.NestedString(targetObj, "spec", "type")
-			if err != nil {
-				allErr = append(allErr, field.Invalid(
-					fldPath,
-					value,
-					fmt.Sprintf("unable to get type of target: %s", err.Error())))
-				continue
-			}
-			if targetType != importDef.TargetType {
-				allErr = append(allErr, field.Invalid(
-					fldPath,
-					targetType,
-					fmt.Sprintf("expected target type to be %q but got %q", importDef.TargetType, targetType)))
-				continue
-			}
+			allErr = append(allErr, validateTargetImport(value, importDef.TargetType, fldPath)...)
+
+		case lsv1alpha1.ImportTypeTargetList:
+			allErr = append(allErr, validateTargetListImport(value, importDef.TargetType, fldPath)...)
+
+		case lsv1alpha1.ImportTypeComponentDescriptor:
+			allErr = append(allErr, validateComponentDescriptorImport(value, fldPath)...)
+
+		case lsv1alpha1.ImportTypeComponentDescriptorList:
+			allErr = append(allErr, validateComponentDescriptorListImport(value, fldPath)...)
+
 		default:
 			allErr = append(allErr, field.Invalid(fldPath, string(importDef.Type), "unknown import type"))
 		}
 	}
 
 	return allErr.ToAggregate()
+}
+
+func validateTargetImport(value interface{}, expectedTargetType string, fldPath *field.Path) field.ErrorList {
+	allErr := field.ErrorList{}
+
+	targetObj, ok := value.(map[string]interface{})
+	if !ok {
+		allErr = append(allErr, field.Invalid(fldPath, value, "a target is expected to be an object"))
+		return allErr
+	}
+	targetType, _, err := unstructured.NestedString(targetObj, "spec", "type")
+	if err != nil {
+		allErr = append(allErr, field.Invalid(
+			fldPath,
+			value,
+			fmt.Sprintf("unable to get type of target: %s", err.Error())))
+		return allErr
+	}
+	if targetType != expectedTargetType {
+		allErr = append(allErr, field.Invalid(
+			fldPath,
+			targetType,
+			fmt.Sprintf("expected target type to be %q but got %q", expectedTargetType, targetType)))
+		return allErr
+	}
+
+	return allErr
+}
+
+func validateTargetListImport(value interface{}, expectedTargetType string, fldPath *field.Path) field.ErrorList {
+	allErr := field.ErrorList{}
+
+	targetList, ok := value.([]interface{})
+	if !ok {
+		allErr = append(allErr, field.Invalid(fldPath, value, "a target list is expected to be a list"))
+	}
+
+	for i, targetObj := range targetList {
+		allErr = append(allErr, validateTargetImport(targetObj, expectedTargetType, fldPath.Index(i))...)
+	}
+
+	return allErr
+}
+
+func validateComponentDescriptorImport(value interface{}, fldPath *field.Path) field.ErrorList {
+	allErr := field.ErrorList{}
+	_, ok := value.(map[string]interface{})
+	if !ok {
+		allErr = append(allErr, field.Invalid(fldPath, value, "a component descriptor is expected to be an object"))
+		return allErr
+	}
+
+	return allErr
+}
+
+func validateComponentDescriptorListImport(value interface{}, fldPath *field.Path) field.ErrorList {
+	allErr := field.ErrorList{}
+
+	targetList, ok := value.([]interface{})
+	if !ok {
+		allErr = append(allErr, field.Invalid(fldPath, value, "a component descriptor list is expected to be a list"))
+	}
+
+	for i, targetObj := range targetList {
+		allErr = append(allErr, validateComponentDescriptorImport(targetObj, fldPath.Index(i))...)
+	}
+
+	return allErr
 }
 
 // MergeImports merges all imports of b into a.

--- a/pkg/utils/landscaper/blueprint_test.go
+++ b/pkg/utils/landscaper/blueprint_test.go
@@ -17,11 +17,22 @@ var _ = Describe("Landscaper", func() {
 
 	Context("Render blueprint", func() {
 
-		It("should render a blueprint with a target list import", func() {
+		It("should render a blueprint that imports a target list", func() {
 			blueprintRenderArgs := BlueprintRenderArgs{
 				Fs:                   osfs.New(),
 				ImportValuesFilepath: "./testdata/00-blueprint-with-targetlist/values.yaml",
 				RootDir:              "./testdata/00-blueprint-with-targetlist",
+			}
+
+			_, err := RenderBlueprint(blueprintRenderArgs)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should render a blueprint that imports a component descriptor and a component descriptor list", func() {
+			blueprintRenderArgs := BlueprintRenderArgs{
+				Fs:                   osfs.New(),
+				ImportValuesFilepath: "./testdata/01-blueprint-with-cdlist/values.yaml",
+				RootDir:              "./testdata/01-blueprint-with-cdlist",
 			}
 
 			_, err := RenderBlueprint(blueprintRenderArgs)

--- a/pkg/utils/landscaper/blueprint_test.go
+++ b/pkg/utils/landscaper/blueprint_test.go
@@ -1,0 +1,33 @@
+package landscaper
+
+import (
+	"testing"
+
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Landscaper utils Test Suite")
+}
+
+var _ = Describe("Landscaper", func() {
+
+	Context("Render blueprint", func() {
+
+		It("should render a blueprint with a target list import", func() {
+			blueprintRenderArgs := BlueprintRenderArgs{
+				Fs:                   osfs.New(),
+				ImportValuesFilepath: "./testdata/00-blueprint-with-targetlist/values.yaml",
+				RootDir:              "./testdata/00-blueprint-with-targetlist",
+			}
+
+			_, err := RenderBlueprint(blueprintRenderArgs)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+	})
+
+})

--- a/pkg/utils/landscaper/testdata/00-blueprint-with-targetlist/blueprint/blueprint.yaml
+++ b/pkg/utils/landscaper/testdata/00-blueprint-with-targetlist/blueprint/blueprint.yaml
@@ -1,0 +1,14 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+jsonSchema: "https://json-schema.org/draft/2019-09/schema" # required
+
+imports:
+- name: testClusters
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+- name: testComponent
+  type: componentDescriptor
+
+- name: testComponents
+  type: componentDescriptorList

--- a/pkg/utils/landscaper/testdata/00-blueprint-with-targetlist/values.yaml
+++ b/pkg/utils/landscaper/testdata/00-blueprint-with-targetlist/values.yaml
@@ -1,0 +1,16 @@
+imports:
+  testClusters:
+  - metadata:
+      name: "test-cluster-1"
+      namespace: "test"
+    spec:
+      type: "landscaper.gardener.cloud/kubernetes-cluster"
+  - metadata:
+      name: "test-cluster-2"
+      namespace: "test"
+    spec:
+      type: "landscaper.gardener.cloud/kubernetes-cluster"
+
+  testComponent: {}
+
+  testComponents: []

--- a/pkg/utils/landscaper/testdata/01-blueprint-with-cdlist/blueprint/blueprint.yaml
+++ b/pkg/utils/landscaper/testdata/01-blueprint-with-cdlist/blueprint/blueprint.yaml
@@ -1,0 +1,10 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+jsonSchema: "https://json-schema.org/draft/2019-09/schema" # required
+
+imports:
+- name: testComponent
+  type: componentDescriptor
+
+- name: testComponents
+  type: componentDescriptorList

--- a/pkg/utils/landscaper/testdata/01-blueprint-with-cdlist/values.yaml
+++ b/pkg/utils/landscaper/testdata/01-blueprint-with-cdlist/values.yaml
@@ -1,0 +1,46 @@
+imports:
+  testComponent:
+    component:
+      name: "test-component"
+      provider: internal
+      repositoryContexts:
+        - baseUrl: test
+          type: ociRegistry
+      resources:
+        - access:
+            imageReference: test-blueprint:v0.1.0
+            type: ociRegistry
+          name: test-blueprint
+          relation: local
+          type: blueprint
+          version: v0.1.0
+
+  testComponents:
+    - component:
+        name: "test-component-1"
+        provider: internal
+        repositoryContexts:
+          - baseUrl: test
+            type: ociRegistry
+        resources:
+          - access:
+              imageReference: test-chart-1:v0.1.0
+              type: ociRegistry
+            name: test-chart-1
+            relation: local
+            type: helm
+            version: v0.1.0
+    - component:
+        name: "test-component-2"
+        provider: internal
+        repositoryContexts:
+          - baseUrl: test
+            type: ociRegistry
+        resources:
+          - access:
+              imageReference: test-chart-2:v0.1.0
+              type: ociRegistry
+            name: test-chart-2
+            relation: local
+            type: helm
+            version: v0.1.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

Currently the rendering of a blueprint fails if the blueprint contains imports of type targetList, componentDescriptor, or componentDescriptorList. This pull request fixes this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```
