### PR TITLE
do not try to load chart from archive for non-success http status codes

### DIFF
--- a/pkg/deployer/helm/chartresolver/chart.go
+++ b/pkg/deployer/helm/chartresolver/chart.go
@@ -62,6 +62,9 @@ func getChartFromArchive(archiveConfig *helmv1alpha1.ArchiveAccess) (*chart.Char
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch helm chart from %q: %w", archiveConfig.Remote.URL, err)
 		}
+		if res.StatusCode < 200 || res.StatusCode > 299 {
+			return nil, fmt.Errorf("unable to fetch helm chart from %q: %s", archiveConfig.Remote.URL, res.Status)
+		}
 		ch, err := chartloader.LoadArchive(res.Body)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load chart from %q: %w", archiveConfig.Remote.URL, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind bug
/priority 3

**What this PR does / why we need it**:

When a non-success status code was received while resolving a helm chart from http access, we have ignored this error and tried to load the chart anyway.
This results in a strange error message:

`unable to load chart from \“https://myrepo/mychart.tgz\“: gzip: invalid header”`

This change introduces a handling for non-success http status codes and returns a better error message.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
