### PR TITLE
Provide CD-List for imported CD-List

### DIFF
--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -299,6 +299,22 @@ imports:
       config:
         kubeconfig: |
           apiVersion: ...
+  my-cdlist: # import of a component descriptor list
+    meta:
+      schemaVersion: v2
+    components:
+      - meta:
+          schemaVersion: v2
+        component: 
+          name: component-1
+          version: v1.0.1
+          ...  # same structure as for key "cd"   
+      - meta:
+          schemaVersion: v2
+        component:
+          name: component-2
+          version: v1.0.1
+          ...
 cd:
   meta:
     schemaVersion: v2
@@ -371,6 +387,9 @@ deployExecutions:
           {{ $component := getComponent .cd "name" "my-referenced-component" }} # get a component that is referenced
           {{ $resource := getResource $component "name" "ubuntu" }}
           usesImage: {{ $resource.access.imageReference }} # resolves to ubuntu:0.18.0
+          
+          imageVectorOverwrite: |
+            {{- generateImageOverwrite .cd .imports.my-cdlist | toYaml | nindent 12 }}
 ```
 
 ### ExportExecutions

--- a/pkg/landscaper/dataobjects/cdlist.go
+++ b/pkg/landscaper/dataobjects/cdlist.go
@@ -30,16 +30,23 @@ func NewComponentDescriptorListWithSize(size int) *ComponentDescriptorList {
 }
 
 // GetData returns the targets as list of internal go maps.
-func (cdl *ComponentDescriptorList) GetData() ([]interface{}, error) {
+func (cdl *ComponentDescriptorList) GetData() (interface{}, error) {
 	rawCDs := make([]cdv2.ComponentDescriptor, len(cdl.ComponentDescriptors))
 	for i := range cdl.ComponentDescriptors {
 		rawCDs[i] = *cdl.ComponentDescriptors[i].Descriptor
 	}
-	raw, err := json.Marshal(rawCDs)
+
+	compDescList := cdv2.ComponentDescriptorList{
+		Metadata: cdv2.Metadata{
+			Version: cdv2.SchemaVersion,
+		},
+		Components: rawCDs,
+	}
+	raw, err := json.Marshal(compDescList)
 	if err != nil {
 		return nil, err
 	}
-	var data []interface{}
+	var data interface{}
 	if err := json.Unmarshal(raw, &data); err != nil {
 		return nil, err
 	}

--- a/pkg/landscaper/dataobjects/cdlist.go
+++ b/pkg/landscaper/dataobjects/cdlist.go
@@ -29,7 +29,7 @@ func NewComponentDescriptorListWithSize(size int) *ComponentDescriptorList {
 	}
 }
 
-// GetData returns the targets as list of internal go maps.
+// GetData returns the component descriptor list as an internal go map.
 func (cdl *ComponentDescriptorList) GetData() (interface{}, error) {
 	rawCDs := make([]cdv2.ComponentDescriptor, len(cdl.ComponentDescriptors))
 	for i := range cdl.ComponentDescriptors {

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/gardener/component-spec/bindings-go/codec"
+
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
@@ -304,12 +306,17 @@ var _ = Describe("Constructor", func() {
 			Expect(inInstRoot.GetImports()).To(HaveKeyWithValue("cd-from-secret", BeEquivalentTo(secretCDData)))
 
 			// check component descriptor list import
-			Expect(inInstRoot.GetImports()).To(HaveKeyWithValue("cdlist", And(
-				HaveLen(3),
-				ContainElement(cdData),
-				ContainElement(configMapCDData),
-				ContainElement(secretCDData),
-			)))
+			fetchedImports := inInstRoot.GetImports()
+			Expect(fetchedImports).To(HaveKey("cdlist"))
+			Expect(fetchedImports).To(HaveLen(4))
+			Expect(fetchedImports).To(ContainElement(cdData))
+			Expect(fetchedImports).To(ContainElement(configMapCDData))
+			Expect(fetchedImports).To(ContainElement(secretCDData))
+
+			cdListImports := &cdv2.ComponentDescriptorList{}
+			cdListImportsData, err := json.Marshal(fetchedImports["cdlist"])
+			Expect(err).To(BeNil())
+			utils.ExpectNoError(codec.Decode(cdListImportsData, cdListImports))
 		})
 	})
 

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -307,15 +307,20 @@ var _ = Describe("Constructor", func() {
 			// check component descriptor list import
 			fetchedImports := inInstRoot.GetImports()
 			Expect(fetchedImports).To(HaveKey("cdlist"))
-			Expect(fetchedImports).To(HaveLen(4))
-			Expect(fetchedImports).To(ContainElement(cdData))
-			Expect(fetchedImports).To(ContainElement(configMapCDData))
-			Expect(fetchedImports).To(ContainElement(secretCDData))
+			cdListData := fetchedImports["cdlist"].(map[string]interface{})
+			Expect(cdListData).To(HaveKey("components"))
+			componentsData := cdListData["components"]
+
+			Expect(componentsData).To(HaveLen(3))
+			Expect(componentsData).To(ContainElement(cdData))
+			Expect(componentsData).To(ContainElement(configMapCDData))
+			Expect(componentsData).To(ContainElement(secretCDData))
 
 			cdListImports := &cdv2.ComponentDescriptorList{}
-			cdListImportsData, err := json.Marshal(fetchedImports["cdlist"])
+			cdListBytes, err := json.Marshal(cdListData)
 			Expect(err).To(BeNil())
-			utils.ExpectNoError(codec.Decode(cdListImportsData, cdListImports))
+			utils.ExpectNoError(codec.Decode(cdListBytes, cdListImports))
+			Expect(cdListImports.Components).To(HaveLen(3))
 		})
 	})
 

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -8,9 +8,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/gardener/component-spec/bindings-go/codec"
-
-	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/codec"
+	"github.com/gardener/component-spec/bindings-go/ctf"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

With this PR a component descriptor list is returned for the corresponding import data and not the contained components only. This also resolves problems with the template function `generateImageOverwrite`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
- Imports of component descriptor lists now provide the data of a real component descriptor list and not only the contained components
```
