### PR TITLE
Blueprint index method

### DIFF
--- a/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
+++ b/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
@@ -40,6 +40,11 @@
           "type": "boolean",
           "default": false
         },
+        "indexMethod": {
+          "description": "IndexMethod describes the method that should be used to index blueprints in the store. If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod otherwise use the BlueprintDigestIndex to index by the content hash. Defaults to ComponentDescriptorIdentityMethod",
+          "type": "string",
+          "default": ""
+        },
         "path": {
           "description": "Path defines the root path where the blueprints are cached.",
           "type": "string",

--- a/apis/config/types_landscaper_config.go
+++ b/apis/config/types_landscaper_config.go
@@ -226,13 +226,32 @@ type LandscaperAgentConfiguration struct {
 	AgentConfiguration `json:",inline"`
 }
 
+// IndexMethod describes the blueprint store index method
+type IndexMethod string
+
+const (
+	// BlueprintDigestIndex describes a IndexMethod that uses the digest of the blueprint.
+	// This is useful if blueprints and component descriptors are not immutable (e.g. during development)
+	BlueprintDigestIndex IndexMethod = "BlueprintDigestIndex"
+	// ComponentDescriptorIdentityMethod describes a IndexMethod that uses the component descriptor identity.
+	// This means that the blueprint is uniquely identified using the component-descriptors repository, name and version
+	// with the blueprint resource identity.
+	ComponentDescriptorIdentityMethod IndexMethod = "ComponentDescriptorIdentityMethod"
+)
+
 // BlueprintStore contains the configuration for the blueprint store.
 type BlueprintStore struct {
 	// Path defines the root path where the blueprints are cached.
-	Path string `json:"path"`
+	Path string
 	// DisableCache disables the cache and always fetches the blob from the registry.
 	// The blueprint is still stored on the filesystem.
-	DisableCache bool `json:"disableCache"`
+	DisableCache bool
+	// IndexMethod describes the method that should be used to index blueprints in the store.
+	// If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod
+	// otherwise use the BlueprintDigestIndex to index by the content hash.
+	// Defaults to ComponentDescriptorIdentityMethod
+	// +optional
+	IndexMethod IndexMethod
 	GarbageCollectionConfiguration
 }
 

--- a/apis/config/v1alpha1/defaults.go
+++ b/apis/config/v1alpha1/defaults.go
@@ -118,7 +118,7 @@ func SetDefaults_BlueprintStore(obj *BlueprintStore) {
 	const PreservedHitsProportion = 0.5
 
 	if len(obj.IndexMethod) == 0 {
-		obj.IndexMethod = ComponentDescriptorIdentityMethod
+		obj.IndexMethod = BlueprintDigestIndex
 	}
 
 	if obj.Size == "0" {

--- a/apis/config/v1alpha1/defaults.go
+++ b/apis/config/v1alpha1/defaults.go
@@ -117,6 +117,10 @@ func SetDefaults_BlueprintStore(obj *BlueprintStore) {
 	// PreservedHitsProportion defines the default percent of hits that should be preserved.
 	const PreservedHitsProportion = 0.5
 
+	if len(obj.IndexMethod) == 0 {
+		obj.IndexMethod = ComponentDescriptorIdentityMethod
+	}
+
 	if obj.Size == "0" {
 		// no garbage collection configured ignore all other values
 		return

--- a/apis/config/v1alpha1/defaults_test.go
+++ b/apis/config/v1alpha1/defaults_test.go
@@ -30,6 +30,16 @@ var _ = Describe("Defaults", func() {
 		Expect(cfg.ForceUpdate).To(gstruct.PointTo(Equal(true)))
 	})
 
+	Context("BlueprintStore", func() {
+
+		It("should default index method", func() {
+			cfg := &v1alpha1.BlueprintStore{}
+			v1alpha1.SetDefaults_BlueprintStore(cfg)
+			Expect(cfg.IndexMethod).To(Equal(v1alpha1.ComponentDescriptorIdentityMethod))
+		})
+
+	})
+
 	Context("CommonControllerConfig", func() {
 
 		checkCommonConfig := func(cfg *v1alpha1.CommonControllerConfig) {

--- a/apis/config/v1alpha1/defaults_test.go
+++ b/apis/config/v1alpha1/defaults_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Defaults", func() {
 		It("should default index method", func() {
 			cfg := &v1alpha1.BlueprintStore{}
 			v1alpha1.SetDefaults_BlueprintStore(cfg)
-			Expect(cfg.IndexMethod).To(Equal(v1alpha1.ComponentDescriptorIdentityMethod))
+			Expect(cfg.IndexMethod).To(Equal(v1alpha1.BlueprintDigestIndex))
 		})
 
 	})

--- a/apis/config/v1alpha1/types_landscaper_config.go
+++ b/apis/config/v1alpha1/types_landscaper_config.go
@@ -226,6 +226,19 @@ type LandscaperAgentConfiguration struct {
 	AgentConfiguration `json:",inline"`
 }
 
+// IndexMethod describes the blueprint store index method
+type IndexMethod string
+
+const (
+	// BlueprintDigestIndex describes a IndexMethod that uses the digest of the blueprint.
+	// This is useful if blueprints and component descriptors are not immutable (e.g. during development)
+	BlueprintDigestIndex IndexMethod = "BlueprintDigestIndex"
+	// ComponentDescriptorIdentityMethod describes a IndexMethod that uses the component descriptor identity.
+	// This means that the blueprint is uniquely identified using the component-descriptors repository, name and version
+	// with the blueprint resource identity.
+	ComponentDescriptorIdentityMethod IndexMethod = "ComponentDescriptorIdentityMethod"
+)
+
 // BlueprintStore contains the configuration for the blueprint store.
 type BlueprintStore struct {
 	// Path defines the root path where the blueprints are cached.
@@ -233,6 +246,12 @@ type BlueprintStore struct {
 	// DisableCache disables the cache and always fetches the blob from the registry.
 	// The blueprint is still stored on the filesystem.
 	DisableCache bool `json:"disableCache"`
+	// IndexMethod describes the method that should be used to index blueprints in the store.
+	// If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod
+	// otherwise use the BlueprintDigestIndex to index by the content hash.
+	// Defaults to ComponentDescriptorIdentityMethod
+	// +optional
+	IndexMethod IndexMethod `json:"indexMethod"`
 	GarbageCollectionConfiguration
 }
 

--- a/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/apis/config/v1alpha1/zz_generated.conversion.go
@@ -282,6 +282,7 @@ func Convert_config_AgentConfiguration_To_v1alpha1_AgentConfiguration(in *config
 func autoConvert_v1alpha1_BlueprintStore_To_config_BlueprintStore(in *BlueprintStore, out *config.BlueprintStore, s conversion.Scope) error {
 	out.Path = in.Path
 	out.DisableCache = in.DisableCache
+	out.IndexMethod = config.IndexMethod(in.IndexMethod)
 	if err := Convert_v1alpha1_GarbageCollectionConfiguration_To_config_GarbageCollectionConfiguration(&in.GarbageCollectionConfiguration, &out.GarbageCollectionConfiguration, s); err != nil {
 		return err
 	}
@@ -296,6 +297,7 @@ func Convert_v1alpha1_BlueprintStore_To_config_BlueprintStore(in *BlueprintStore
 func autoConvert_config_BlueprintStore_To_v1alpha1_BlueprintStore(in *config.BlueprintStore, out *BlueprintStore, s conversion.Scope) error {
 	out.Path = in.Path
 	out.DisableCache = in.DisableCache
+	out.IndexMethod = IndexMethod(in.IndexMethod)
 	if err := Convert_config_GarbageCollectionConfiguration_To_v1alpha1_GarbageCollectionConfiguration(&in.GarbageCollectionConfiguration, &out.GarbageCollectionConfiguration, s); err != nil {
 		return err
 	}

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -1117,7 +1117,7 @@ func schema_gardener_landscaper_apis_config_BlueprintStore(ref common.ReferenceC
 				Description: "BlueprintStore contains the configuration for the blueprint store.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"path": {
+					"Path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path defines the root path where the blueprints are cached.",
 							Default:     "",
@@ -1125,11 +1125,19 @@ func schema_gardener_landscaper_apis_config_BlueprintStore(ref common.ReferenceC
 							Format:      "",
 						},
 					},
-					"disableCache": {
+					"DisableCache": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DisableCache disables the cache and always fetches the blob from the registry. The blueprint is still stored on the filesystem.",
 							Default:     false,
 							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"IndexMethod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IndexMethod describes the method that should be used to index blueprints in the store. If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod otherwise use the BlueprintDigestIndex to index by the content hash. Defaults to ComponentDescriptorIdentityMethod",
+							Default:     "",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
@@ -1140,7 +1148,7 @@ func schema_gardener_landscaper_apis_config_BlueprintStore(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"path", "disableCache", "GarbageCollectionConfiguration"},
+				Required: []string{"Path", "DisableCache", "GarbageCollectionConfiguration"},
 			},
 		},
 		Dependencies: []string{
@@ -1958,6 +1966,14 @@ func schema_landscaper_apis_config_v1alpha1_BlueprintStore(ref common.ReferenceC
 							Description: "DisableCache disables the cache and always fetches the blob from the registry. The blueprint is still stored on the filesystem.",
 							Default:     false,
 							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"indexMethod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IndexMethod describes the method that should be used to index blueprints in the store. If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod otherwise use the BlueprintDigestIndex to index by the content hash. Defaults to ComponentDescriptorIdentityMethod",
+							Default:     "",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},

--- a/examples/00-Landscaper-Configuration.yaml
+++ b/examples/00-Landscaper-Configuration.yaml
@@ -58,3 +58,8 @@ deployerManagement:
 #  pickup: "5m"
 #  abort: "5m"
 #  progressingDefault: "5m"
+
+blueprintStore:
+  path: "" # path to teh blueprint store
+  disable: false # forces the blueprint to be downloaded every time.
+  indexMethod: "BlueprintDigestIndex" # used index method that is used to cache blueprints.

--- a/pkg/landscaper/registry/components/cdutils/utils.go
+++ b/pkg/landscaper/registry/components/cdutils/utils.go
@@ -16,8 +16,8 @@ import (
 
 // BlobResolverFunc describes a helper blob resolver that implements the ctf.BlobResolver interface.
 type BlobResolverFunc struct {
-	info func(ctx context.Context, res cdv2.Resource) (*ctf.BlobInfo, error)
-	resolve func(ctx context.Context, res cdv2.Resource, writer io.Writer) (*ctf.BlobInfo, error)
+	info       func(ctx context.Context, res cdv2.Resource) (*ctf.BlobInfo, error)
+	resolve    func(ctx context.Context, res cdv2.Resource, writer io.Writer) (*ctf.BlobInfo, error)
 	canResolve func(resource cdv2.Resource) bool
 }
 
@@ -57,7 +57,6 @@ func (b BlobResolverFunc) Resolve(ctx context.Context, res cdv2.Resource, writer
 }
 
 var _ ctf.TypedBlobResolver = &BlobResolverFunc{}
-
 
 // ResolveToComponentDescriptorList transitively resolves all referenced components of a component descriptor and
 // return a list containing all resolved component descriptors.

--- a/pkg/landscaper/registry/components/cdutils/utils.go
+++ b/pkg/landscaper/registry/components/cdutils/utils.go
@@ -8,10 +8,56 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/ctf"
 )
+
+// BlobResolverFunc describes a helper blob resolver that implements the ctf.BlobResolver interface.
+type BlobResolverFunc struct {
+	info func(ctx context.Context, res cdv2.Resource) (*ctf.BlobInfo, error)
+	resolve func(ctx context.Context, res cdv2.Resource, writer io.Writer) (*ctf.BlobInfo, error)
+	canResolve func(resource cdv2.Resource) bool
+}
+
+// NewBlobResolverFunc creates a new generic blob resolver with a minimal resolve function.
+func NewBlobResolverFunc(resolve func(ctx context.Context, res cdv2.Resource, writer io.Writer) (*ctf.BlobInfo, error)) *BlobResolverFunc {
+	return &BlobResolverFunc{
+		resolve: resolve,
+	}
+}
+
+func (b *BlobResolverFunc) WithInfo(f func(ctx context.Context, res cdv2.Resource) (*ctf.BlobInfo, error)) *BlobResolverFunc {
+	b.info = f
+	return b
+}
+
+func (b *BlobResolverFunc) WithCanResolve(f func(resource cdv2.Resource) bool) *BlobResolverFunc {
+	b.canResolve = f
+	return b
+}
+
+func (b BlobResolverFunc) CanResolve(resource cdv2.Resource) bool {
+	if b.canResolve == nil {
+		return true
+	}
+	return b.canResolve(resource)
+}
+
+func (b BlobResolverFunc) Info(ctx context.Context, res cdv2.Resource) (*ctf.BlobInfo, error) {
+	if b.info == nil {
+		return b.resolve(ctx, res, nil)
+	}
+	return b.info(ctx, res)
+}
+
+func (b BlobResolverFunc) Resolve(ctx context.Context, res cdv2.Resource, writer io.Writer) (*ctf.BlobInfo, error) {
+	return b.resolve(ctx, res, writer)
+}
+
+var _ ctf.TypedBlobResolver = &BlobResolverFunc{}
+
 
 // ResolveToComponentDescriptorList transitively resolves all referenced components of a component descriptor and
 // return a list containing all resolved component descriptors.

--- a/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
@@ -226,13 +226,32 @@ type LandscaperAgentConfiguration struct {
 	AgentConfiguration `json:",inline"`
 }
 
+// IndexMethod describes the blueprint store index method
+type IndexMethod string
+
+const (
+	// BlueprintDigestIndex describes a IndexMethod that uses the digest of the blueprint.
+	// This is useful if blueprints and component descriptors are not immutable (e.g. during development)
+	BlueprintDigestIndex IndexMethod = "BlueprintDigestIndex"
+	// ComponentDescriptorIdentityMethod describes a IndexMethod that uses the component descriptor identity.
+	// This means that the blueprint is uniquely identified using the component-descriptors repository, name and version
+	// with the blueprint resource identity.
+	ComponentDescriptorIdentityMethod IndexMethod = "ComponentDescriptorIdentityMethod"
+)
+
 // BlueprintStore contains the configuration for the blueprint store.
 type BlueprintStore struct {
 	// Path defines the root path where the blueprints are cached.
-	Path string `json:"path"`
+	Path string
 	// DisableCache disables the cache and always fetches the blob from the registry.
 	// The blueprint is still stored on the filesystem.
-	DisableCache bool `json:"disableCache"`
+	DisableCache bool
+	// IndexMethod describes the method that should be used to index blueprints in the store.
+	// If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod
+	// otherwise use the BlueprintDigestIndex to index by the content hash.
+	// Defaults to ComponentDescriptorIdentityMethod
+	// +optional
+	IndexMethod IndexMethod
 	GarbageCollectionConfiguration
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
@@ -118,7 +118,7 @@ func SetDefaults_BlueprintStore(obj *BlueprintStore) {
 	const PreservedHitsProportion = 0.5
 
 	if len(obj.IndexMethod) == 0 {
-		obj.IndexMethod = ComponentDescriptorIdentityMethod
+		obj.IndexMethod = BlueprintDigestIndex
 	}
 
 	if obj.Size == "0" {

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
@@ -117,6 +117,10 @@ func SetDefaults_BlueprintStore(obj *BlueprintStore) {
 	// PreservedHitsProportion defines the default percent of hits that should be preserved.
 	const PreservedHitsProportion = 0.5
 
+	if len(obj.IndexMethod) == 0 {
+		obj.IndexMethod = ComponentDescriptorIdentityMethod
+	}
+
 	if obj.Size == "0" {
 		// no garbage collection configured ignore all other values
 		return

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_landscaper_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_landscaper_config.go
@@ -226,6 +226,19 @@ type LandscaperAgentConfiguration struct {
 	AgentConfiguration `json:",inline"`
 }
 
+// IndexMethod describes the blueprint store index method
+type IndexMethod string
+
+const (
+	// BlueprintDigestIndex describes a IndexMethod that uses the digest of the blueprint.
+	// This is useful if blueprints and component descriptors are not immutable (e.g. during development)
+	BlueprintDigestIndex IndexMethod = "BlueprintDigestIndex"
+	// ComponentDescriptorIdentityMethod describes a IndexMethod that uses the component descriptor identity.
+	// This means that the blueprint is uniquely identified using the component-descriptors repository, name and version
+	// with the blueprint resource identity.
+	ComponentDescriptorIdentityMethod IndexMethod = "ComponentDescriptorIdentityMethod"
+)
+
 // BlueprintStore contains the configuration for the blueprint store.
 type BlueprintStore struct {
 	// Path defines the root path where the blueprints are cached.
@@ -233,6 +246,12 @@ type BlueprintStore struct {
 	// DisableCache disables the cache and always fetches the blob from the registry.
 	// The blueprint is still stored on the filesystem.
 	DisableCache bool `json:"disableCache"`
+	// IndexMethod describes the method that should be used to index blueprints in the store.
+	// If component descriptors and blueprint are immutable (blueprints cannot be updated) use ComponentDescriptorIdentityMethod
+	// otherwise use the BlueprintDigestIndex to index by the content hash.
+	// Defaults to ComponentDescriptorIdentityMethod
+	// +optional
+	IndexMethod IndexMethod `json:"indexMethod"`
 	GarbageCollectionConfiguration
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/zz_generated.conversion.go
@@ -282,6 +282,7 @@ func Convert_config_AgentConfiguration_To_v1alpha1_AgentConfiguration(in *config
 func autoConvert_v1alpha1_BlueprintStore_To_config_BlueprintStore(in *BlueprintStore, out *config.BlueprintStore, s conversion.Scope) error {
 	out.Path = in.Path
 	out.DisableCache = in.DisableCache
+	out.IndexMethod = config.IndexMethod(in.IndexMethod)
 	if err := Convert_v1alpha1_GarbageCollectionConfiguration_To_config_GarbageCollectionConfiguration(&in.GarbageCollectionConfiguration, &out.GarbageCollectionConfiguration, s); err != nil {
 		return err
 	}
@@ -296,6 +297,7 @@ func Convert_v1alpha1_BlueprintStore_To_config_BlueprintStore(in *BlueprintStore
 func autoConvert_config_BlueprintStore_To_v1alpha1_BlueprintStore(in *config.BlueprintStore, out *BlueprintStore, s conversion.Scope) error {
 	out.Path = in.Path
 	out.DisableCache = in.DisableCache
+	out.IndexMethod = IndexMethod(in.IndexMethod)
 	if err := Convert_config_GarbageCollectionConfiguration_To_v1alpha1_GarbageCollectionConfiguration(&in.GarbageCollectionConfiguration, &out.GarbageCollectionConfiguration, s); err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,8 +19,6 @@ github.com/Microsoft/hcsshim/osversion
 github.com/ahmetb/gen-crd-api-reference-docs
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
-# github.com/bits-and-blooms/bitset v1.2.1
-## explicit
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/cloudfoundry-incubator/candiedyaml v0.0.0-20170901234223-a41693b7b7af
@@ -152,8 +150,6 @@ github.com/gobwas/glob/syntax/ast
 github.com/gobwas/glob/syntax/lexer
 github.com/gobwas/glob/util/runes
 github.com/gobwas/glob/util/strings
-# github.com/gogo/googleapis v1.4.1
-## explicit
 # github.com/gogo/protobuf v1.3.2
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
@@ -313,8 +309,6 @@ github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.2
 github.com/opencontainers/runc/libcontainer/user
-# github.com/opencontainers/selinux v1.8.5
-## explicit
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area landscaper
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Adds a new index method for the blueprint store that uses the digest of the blueprints has been added and made as default.
It i still possible to use the component descriptor + blueprint name as cache index.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Adds a new index method for the blueprint store that uses the digest of the blueprints has been added and made as default.
With that change blueprints are updated when the content of a blueprint changes which is useful for development.
```
