### PR TITLE
Fixes a panic for root installations and adds support for targets in the dependency check

### DIFF
--- a/.landscaper/container-deployer/resources.yaml
+++ b/.landscaper/container-deployer/resources.yaml
@@ -13,7 +13,7 @@ name: container-deployer-chart
 relation: local
 access:
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/charts/container-deployer-controller:${VERSION}
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/container-deployer:${VERSION}
 ---
 type: ociImage
 name: container-deployer-image

--- a/.landscaper/helm-deployer/resources.yaml
+++ b/.landscaper/helm-deployer/resources.yaml
@@ -13,7 +13,7 @@ name: helm-deployer-chart
 relation: local
 access:
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/charts/helm-deployer-controller:${VERSION}
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/helm-deployer:${VERSION}
 ---
 type: ociImage
 name: helm-deployer-image

--- a/.landscaper/manifest-deployer/resources.yaml
+++ b/.landscaper/manifest-deployer/resources.yaml
@@ -13,7 +13,7 @@ name: manifest-deployer-chart
 relation: local
 access:
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/charts/manifest-deployer-controller:${VERSION}
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/manifest-deployer:${VERSION}
 ---
 type: ociImage
 name: manifest-deployer-image

--- a/.landscaper/mock-deployer/resources.yaml
+++ b/.landscaper/mock-deployer/resources.yaml
@@ -13,7 +13,7 @@ name: mock-deployer-chart
 relation: local
 access:
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/charts/mock-deployer-controller:${VERSION}
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/mock-deployer:${VERSION}
 ---
 type: ociImage
 name: mock-deployer-image

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -4,7 +4,7 @@ name: landscaper-chart
 relation: local
 access:
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/charts/landscaper-controller:${VERSION}
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/landscaper:${VERSION}
 ---
 type: helm.io/chart
 name: landscaper-agent-chart

--- a/charts/landscaper/Chart.yaml
+++ b/charts/landscaper/Chart.yaml
@@ -25,3 +25,11 @@ version: v0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: v0.13.0
+
+dependencies:
+- name: landscaper-controller
+  version: v0.1.0
+  alias: landscaper
+- name: landscaper-rbac
+  version: v0.1.0
+  alias: rbac

--- a/charts/landscaper/values.yaml
+++ b/charts/landscaper/values.yaml
@@ -28,8 +28,8 @@ global:
       # If not set and create is true, the default will be "landscaper-user"
       name: ""
 
-landscaper:
+#landscaper:
   # landscaper helm chart values
 
-rbac:
+#rbac:
   # rbac helm chart values

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
 
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/spf13/cobra"
@@ -71,6 +72,12 @@ func NewLandscaperControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *Options) run(ctx context.Context) error {
 	o.Log.Info(fmt.Sprintf("Start Landscaper Controller with version %q", version.Get().String()))
+
+	configBytes, err := yaml.Marshal(o.Config)
+	if err != nil {
+		return fmt.Errorf("unable to marshal Landscaper config: %w", err)
+	}
+	_, _ = fmt.Fprintln(os.Stderr, string(configBytes))
 
 	opts := manager.Options{
 		LeaderElection:     false,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gardener/component-cli v0.29.0
 	github.com/gardener/component-spec/bindings-go v0.0.53
 	github.com/gardener/image-vector v0.5.0
-	github.com/gardener/landscaper/apis v0.13.0
+	github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
 	github.com/golang/mock v1.5.0

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -245,7 +245,7 @@ func (o *Operation) GetImportedTargets(ctx context.Context) (map[string]*dataobj
 			// It's a target list, skip it
 			continue
 		}
-		target, err := GetTargetImport(ctx, o.Client(), o.Context().Name, o.Inst, def.Target)
+		target, err := GetTargetImport(ctx, o.Client(), o.Context().Name, o.Inst.Info, def.Target)
 		if err != nil {
 			return nil, err
 		}
@@ -294,10 +294,10 @@ func (o *Operation) GetImportedTargetLists(ctx context.Context) (map[string]*dat
 		)
 		if def.Targets != nil {
 			// List of target names
-			tl, err = GetTargetListImportByNames(ctx, o.Client(), o.Context().Name, o.Inst, def.Targets)
+			tl, err = GetTargetListImportByNames(ctx, o.Client(), o.Context().Name, o.Inst.Info, def.Targets)
 		} else if len(def.TargetListReference) != 0 {
 			// TargetListReference is converted to a label selector internally
-			tl, err = GetTargetListImportBySelector(ctx, o.Client(), o.Context().Name, o.Inst, map[string]string{lsv1alpha1.DataObjectKeyLabel: def.TargetListReference}, true)
+			tl, err = GetTargetListImportBySelector(ctx, o.Client(), o.Context().Name, o.Inst.Info, map[string]string{lsv1alpha1.DataObjectKeyLabel: def.TargetListReference}, true)
 		} else {
 			// Invalid target
 			err = fmt.Errorf("invalid target definition '%s': none of target, targets and targetListRef is defined", def.Name)

--- a/pkg/utils/ociconfig.go
+++ b/pkg/utils/ociconfig.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gardener/landscaper/apis/config"
 )
 
-// WithConfiguration applies external oci configuration as internal options.
+// WithConfigurationStruct applies external oci configuration as internal options.
 type WithConfigurationStruct config.OCIConfiguration
 
 func (c *WithConfigurationStruct) ApplyOption(options *ociclient.Options) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/gardener/component-spec/bindings-go/utils/selector
 # github.com/gardener/image-vector v0.5.0
 ## explicit
 github.com/gardener/image-vector/pkg
-# github.com/gardener/landscaper/apis v0.13.0 => ./apis
+# github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000 => ./apis
 ## explicit
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/config/install


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a nil pointer in the validation that occurs for root installations (installations without a parent).
Also added support for targets in the dependency check

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug in the import validation has been fixed that caused the Landscaper to panic when a root Installation is validated.
```
```feature user
The Landscaper now also validates target imports and waits until Installations that have created that target are finished.
```
