### PR TITLE
Improve help and error message

### DIFF
--- a/pkg/deployermanagement/config/options.go
+++ b/pkg/deployermanagement/config/options.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -25,10 +26,16 @@ type Options struct {
 
 // AddFlags adds the flags for the deployer management.
 func (o *Options) AddFlags(fs *flag.FlagSet) {
+	defaultDeployers := make([]string, len(DefaultDeployerConfiguration))
+	i := 0
+	for k := range DefaultDeployerConfiguration {
+		defaultDeployers[i] = k
+		i++
+	}
 	fs.StringVar(&o.Deployers, "deployers", "",
-		`Specify additional Deployers that should be enabled.
+		fmt.Sprintf(`Specify additional Deployers that should be enabled.
 Controllers are specified as a comma separated list of controller names.
-Available Deployers are mock,helm,container.`)
+Available Deployers are %s.`, strings.Join(defaultDeployers, ",")))
 	fs.StringVar(&o.Version, "deployer-version", version.Get().String(),
 		"set the version for the automatically deployed Deployers.")
 	fs.StringVar(&o.DeployersConfigPath, "deployers-config", "", "Specify the path to the deployers-configuration file")
@@ -48,7 +55,7 @@ func (o *Options) Complete() error {
 }
 
 // GetDeployerConfigForDeployer returns the optional configuration for a deployer.
-// If not config is defined a NoConfigError is returned
+// If no config is defined a NoConfigError is returned
 func (o *Options) GetDeployerConfigForDeployer(deployerName string) (DeployerConfiguration, error) {
 	data, ok := o.DeployersConfig.Deployers[deployerName]
 	if !ok {

--- a/pkg/deployermanagement/config/options.go
+++ b/pkg/deployermanagement/config/options.go
@@ -26,11 +26,9 @@ type Options struct {
 
 // AddFlags adds the flags for the deployer management.
 func (o *Options) AddFlags(fs *flag.FlagSet) {
-	defaultDeployers := make([]string, len(DefaultDeployerConfiguration))
-	i := 0
+	defaultDeployers := make([]string, 0)
 	for k := range DefaultDeployerConfiguration {
-		defaultDeployers[i] = k
-		i++
+		defaultDeployers = append(defaultDeployers, k)
 	}
 	fs.StringVar(&o.Deployers, "deployers", "",
 		fmt.Sprintf(`Specify additional Deployers that should be enabled.

--- a/pkg/landscaper/installations/imports/constructor.go
+++ b/pkg/landscaper/installations/imports/constructor.go
@@ -98,7 +98,7 @@ func (c *Constructor) constructImports(
 				if def.Required != nil && !*def.Required {
 					continue // don't throw an error if the import is not required
 				}
-				return nil, installations.NewImportNotFoundErrorf(nil, "no import for %s exists", def.Name)
+				return nil, installations.NewImportNotFoundErrorf(nil, "blueprint defines import %q of type %s, which is not satisfied", def.Name, lsv1alpha1.ImportTypeData)
 			}
 			if err := c.JSONSchemaValidator().ValidateGoStruct(def.Schema.RawMessage, imports[def.Name]); err != nil {
 				return imports, installations.NewErrorf(installations.SchemaValidationFailed, err, "%s: imported datatype does not have the expected schema", defPath.String())
@@ -126,7 +126,7 @@ func (c *Constructor) constructImports(
 				if def.Required != nil && !*def.Required {
 					continue // don't throw an error if the import is not required
 				}
-				return nil, installations.NewImportNotFoundErrorf(nil, "no import for %s exists", def.Name)
+				return nil, installations.NewImportNotFoundErrorf(nil, "blueprint defines import %q of type %s, which is not satisfied", def.Name, lsv1alpha1.ImportTypeTarget)
 			}
 
 			var targetType string
@@ -149,7 +149,7 @@ func (c *Constructor) constructImports(
 				if def.Required != nil && !*def.Required {
 					continue // don't throw an error if the import is not required
 				}
-				return nil, installations.NewImportNotFoundErrorf(nil, "no import for %s exists", def.Name)
+				return nil, installations.NewImportNotFoundErrorf(nil, "blueprint defines import %q of type %s, which is not satisfied", def.Name, lsv1alpha1.ImportTypeTargetList)
 			}
 
 			var targetType string
@@ -178,7 +178,7 @@ func (c *Constructor) constructImports(
 				if def.Required != nil && !*def.Required {
 					continue // don't throw an error if the import is not required
 				}
-				return nil, installations.NewImportNotFoundErrorf(nil, "no import for %s exists", def.Name)
+				return nil, installations.NewImportNotFoundErrorf(nil, "blueprint defines import %q of type %s, which is not satisfied", def.Name, lsv1alpha1.ImportTypeComponentDescriptor)
 			}
 			continue
 		case lsv1alpha1.ImportTypeComponentDescriptorList:
@@ -193,7 +193,7 @@ func (c *Constructor) constructImports(
 				if def.Required != nil && !*def.Required {
 					continue // don't throw an error if the import is not required
 				}
-				return nil, installations.NewImportNotFoundErrorf(nil, "no import for %s exists", def.Name)
+				return nil, installations.NewImportNotFoundErrorf(nil, "blueprint defines import %q of type %s, which is not satisfied", def.Name, lsv1alpha1.ImportTypeComponentDescriptorList)
 			}
 			continue
 		default:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**What this PR does / why we need it**:
- The error message for imports which were defined in a blueprint but not satisfied in the installation has been improved to better show what the actual problem is.
- The help information on the landscaper-controller command displayed a wrong list of supported deployers (`manifest` was missing). This information is now computed based on the default deployer configurations, so it should always be in sync with the actually supported deployers. Disadvantage of this solution is that the order in which the deployers are listed varies, as they are pulled from a map.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
