### PR TITLE
fix uuid handling in the object applier

### DIFF
--- a/pkg/deployer/lib/resourcemanager/objectapplier.go
+++ b/pkg/deployer/lib/resourcemanager/objectapplier.go
@@ -222,7 +222,7 @@ func (a *ManifestApplier) applyObject(ctx context.Context, manifest *Manifest) (
 
 	mr := &managedresource.ManagedResourceStatus{
 		Policy:   manifest.Policy,
-		Resource: *kutil.CoreObjectReferenceFromUnstructuredObject(obj),
+		Resource: *kutil.CoreObjectReferenceFromUnstructuredObject(&currObj),
 	}
 
 	// if fallback policy is set and the resource is already managed by another deployer
@@ -388,7 +388,6 @@ func containsObjectRef(obj corev1.ObjectReference, objects []managedresource.Man
 			if obj.UID == found.UID {
 				return true
 			}
-			continue
 		}
 		// todo: check for conversions .e.g. networking.k8s.io -> apps.k8s.io
 		if found.GetObjectKind().GroupVersionKind().GroupKind() != obj.GetObjectKind().GroupVersionKind().GroupKind() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a bug in the object applier that is used in the helm and manifest deployer.
Now uuids and the cleanup logic correctly handles a reconcile of a manually deleted resource.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the UUID handling of resources in the Manifest and Helm Deployer has been fixed.
```
