### PR TITLE
fix landscaper version in integration test

### DIFF
--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -13,6 +13,8 @@ cd "$(dirname $0)/.."
 mkdir -p /tm
 /cc/utils/cli.py config attribute --cfg-type kubernetes --cfg-name testmachinery --key kubeconfig > /tm/kubeconfig
 
+VERSION="./hacks/get-version.sh)"
+
 # inject the release image tag (content of the VERSION file) as well as the current HEAD commit sha, so that
 # 1) TM can retrieve the needed TestDefinitions (from current HEAD)
 # 2) we will test the actual release docker image instead of a dev image
@@ -22,5 +24,6 @@ mkdir -p /tm
     --testrun-prefix landscaper-e2e- \
     --timeout=3700 \
     --testruns-chart-path=.ci/testruns/integration-test \
-    --set imageTag="$(cat ./VERSION)" \
+    --set imageTag="${VERSION}" \
+    --set version="${VERSION}" \
     --set revision="$(git rev-parse HEAD)"

--- a/.ci/testruns/integration-test/templates/testrun.yaml
+++ b/.ci/testruns/integration-test/templates/testrun.yaml
@@ -22,6 +22,11 @@ spec:
   - name: HOST_CLUSTER_CONFIG
     type: env
     value: testmachinery.config
+  {{- if .Values.version }}
+  - name: EFFECTIVE_VERSION
+    type: env
+    value: {{ .Values.version }}
+  {{- end }}
 
   testflow:
   - name: create-cluster

--- a/hack/install-landscaper-for-integration-test.sh
+++ b/hack/install-landscaper-for-integration-test.sh
@@ -43,6 +43,7 @@ if ! which helm 1>/dev/null; then
   curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 fi
 
+# in the testmachinery the version should be set by the EFFECTIVE_VERSION
 VERSION="$(${CURRENT_DIR}/get-version.sh)"
 
 if [[ -z "VERSION" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes a bug in the integration test to now use the real version that is created in the pipeline.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
