### PR TITLE
Update helm chart versions before uploading the chart

### DIFF
--- a/.ci/publish-helm-charts
+++ b/.ci/publish-helm-charts
@@ -11,6 +11,8 @@ set -o pipefail
 SOURCE_PATH="$(dirname $0)/.."
 CHART_REPO="eu.gcr.io/gardener-project/landscaper/charts/"
 
+${SOURCE_PATH}/hack/update-helm-chart-version.sh
+
 $SOURCE_PATH/hack/create-helm-chart.sh ${CHART_REPO} charts/landscaper
 $SOURCE_PATH/hack/create-helm-chart.sh ${CHART_REPO} charts/landscaper/charts/rbac
 $SOURCE_PATH/hack/create-helm-chart.sh ${CHART_REPO} charts/landscaper/charts/landscaper

--- a/.ci/release
+++ b/.ci/release
@@ -25,5 +25,3 @@ sed -i -e "0,/)/{s@github.com/gardener/landscaper/apis .*@github.com/gardener/la
 
 cd $SOURCE_DIR
 make revendor
-
-${SOURCE_DIR}/hack/update-helm-chart-version.sh


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

The versions of the helm charts need to be updated before they are uploaded to the OCI registry.
This change moves the version update from step "release" to step "publish-helm-charts".

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
