### PR TITLE
move schema generator to new app package

### DIFF
--- a/apis/hack/generate-schemes/app/app.go
+++ b/apis/hack/generate-schemes/app/app.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gardener/landscaper/apis/hack/generate-schemes/generators"
+	"github.com/gardener/landscaper/apis/openapi"
+	lsschema "github.com/gardener/landscaper/apis/schema"
+	"github.com/go-openapi/jsonreference"
+	"github.com/go-openapi/spec"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+)
+
+// SchemaGenerator generates JSON schemas and Custom Resource Definitions
+type SchemaGenerator struct {
+	exports []string
+	CRDs []lsschema.CustomResourceDefinitions
+}
+
+// NewSchemaGenerator creates a new SchemaGenerator instance
+func NewSchemaGenerator(exports []string, CRDs []lsschema.CustomResourceDefinitions) *SchemaGenerator {
+	schemaGenerator := &SchemaGenerator{
+		exports: exports,
+		CRDs: CRDs,
+	}
+	return schemaGenerator
+}
+
+// Run runs the schema generator with the given output directories
+func (g *SchemaGenerator) Run(schemaDir, crdDir string) error {
+	if err := prepareExportDir(schemaDir); err != nil {
+		return err
+	}
+	if err := prepareExportDir(crdDir); err != nil {
+		return err
+	}
+
+	refCallback := func(path string) spec.Ref {
+		ref, _ := jsonreference.New(generators.DefinitionsRef(path))
+		return spec.Ref{Ref: ref}
+	}
+	jsonGen := &generators.JSONSchemaGenerator{
+		Definitions: openapi.GetOpenAPIDefinitions(refCallback),
+	}
+	for defName, apiDefinition := range jsonGen.Definitions {
+		if !ShouldCreateDefinition(g.exports, defName) {
+			continue
+		}
+		data, err := jsonGen.Generate(defName, apiDefinition)
+		if err != nil {
+			return fmt.Errorf("unable to generate jsonschema for %s: %w", defName, err)
+		}
+
+		// write file
+		file := filepath.Join(schemaDir, generators.ParsePackageVersionName(defName).String() + ".json")
+		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
+			return fmt.Errorf("unable to write jsonschema for %q to %q: %w", file, generators.ParsePackageVersionName(defName).String(), err)
+		}
+
+		fmt.Printf("Generated jsonschema for %q...\n", generators.ParsePackageVersionName(defName).String())
+	}
+
+	if len(crdDir) == 0 {
+		log.Println("Skip crd generation")
+		return nil
+	}
+	crdGen := generators.NewCRDGenerator(openapi.GetOpenAPIDefinitions)
+	for _, crdVersion := range g.CRDs {
+		for _, crdDef := range crdVersion.Definitions {
+			if err := crdGen.Generate(crdVersion.Group, crdVersion.Version, crdDef, crdVersion.OutputDir); err != nil {
+				return fmt.Errorf("unable to generate crd for %s %s %s: %w", crdVersion.Group, crdVersion.Version, crdDef.Names.Kind, err)
+			}
+		}
+	}
+
+	crds, err := crdGen.CRDs()
+	if err != nil {
+		return err
+	}
+	cleanedCrdDirs := sets.NewString(crdDir)
+	for _, crd := range crds {
+		jsonBytes, err := json.Marshal(crd.CRD)
+		if err != nil {
+			return fmt.Errorf("unable to marshal CRD %s: %w", crd.CRD.Name, err)
+		}
+		data, err := yaml.JSONToYAML(jsonBytes)
+		if err != nil {
+			return fmt.Errorf("unable to convert json of CRD %s to yaml: %w", crd.CRD.Name, err)
+		}
+
+		outDir := crdDir
+		if len(crd.OutputDir) != 0 {
+			outDir = crd.OutputDir
+		}
+		if !cleanedCrdDirs.Has(outDir) {
+			if err := prepareExportDir(outDir); err != nil {
+				return err
+			}
+			cleanedCrdDirs.Insert(outDir)
+		}
+
+		// write file
+		file := filepath.Join(outDir, fmt.Sprintf("%s_%s.yaml", crd.CRD.Spec.Group, crd.CRD.Spec.Names.Plural))
+		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
+			return fmt.Errorf("unable to write crd for %q to %q: %w", file, crd.CRD.Name, err)
+		}
+
+		fmt.Printf("Generated crd for %q in %s...\n", crd.CRD.Name, file)
+	}
+
+	return nil
+}
+
+// ShouldCreateDefinition checks whether the definition should be exported
+func ShouldCreateDefinition(exportNames []string, defName string) bool {
+	for _, exportName := range exportNames {
+		if strings.HasSuffix(defName, exportName) {
+			return true
+		}
+	}
+	return false
+}
+
+func prepareExportDir(exportDir string) error {
+	log.Printf("Prepate export dir %q", exportDir)
+	if err := os.MkdirAll(exportDir, os.ModePerm); err != nil {
+		return fmt.Errorf("unable to to create export directory %q: %w", exportDir, err)
+	}
+	// cleanup previous files
+	files, err := ioutil.ReadDir(exportDir)
+	if err != nil {
+		return fmt.Errorf("unable to read files from export directory: %w", err)
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		filename := filepath.Join(exportDir, file.Name())
+		if err := os.Remove(filename); err != nil {
+			return fmt.Errorf("unable to remove %s: %w", filename, err)
+		}
+	}
+	return nil
+}

--- a/apis/hack/generate-schemes/app/app.go
+++ b/apis/hack/generate-schemes/app/app.go
@@ -20,15 +20,18 @@ import (
 
 // SchemaGenerator generates JSON schemas and Custom Resource Definitions
 type SchemaGenerator struct {
-	exports []string
+	// Exports defines the types for which the schemas shall be generated
+	Exports []string
+
+	// CRDs specifies the custom resource definition which is used for generating the schemas
 	CRDs []lsschema.CustomResourceDefinitions
 }
 
 // NewSchemaGenerator creates a new SchemaGenerator instance
 func NewSchemaGenerator(exports []string, CRDs []lsschema.CustomResourceDefinitions) *SchemaGenerator {
 	schemaGenerator := &SchemaGenerator{
-		exports: exports,
-		CRDs: CRDs,
+		Exports: exports,
+		CRDs:    CRDs,
 	}
 	return schemaGenerator
 }
@@ -50,7 +53,7 @@ func (g *SchemaGenerator) Run(schemaDir, crdDir string) error {
 		Definitions: openapi.GetOpenAPIDefinitions(refCallback),
 	}
 	for defName, apiDefinition := range jsonGen.Definitions {
-		if !ShouldCreateDefinition(g.exports, defName) {
+		if !ShouldCreateDefinition(g.Exports, defName) {
 			continue
 		}
 		data, err := jsonGen.Generate(defName, apiDefinition)
@@ -59,7 +62,7 @@ func (g *SchemaGenerator) Run(schemaDir, crdDir string) error {
 		}
 
 		// write file
-		file := filepath.Join(schemaDir, generators.ParsePackageVersionName(defName).String() + ".json")
+		file := filepath.Join(schemaDir, generators.ParsePackageVersionName(defName).String()+".json")
 		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to write jsonschema for %q to %q: %w", file, generators.ParsePackageVersionName(defName).String(), err)
 		}

--- a/apis/hack/generate-schemes/main.go
+++ b/apis/hack/generate-schemes/main.go
@@ -5,26 +5,15 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	depv1alpha1 "github.com/gardener/landscaper/apis/deployer/core/v1alpha1"
-	"github.com/gardener/landscaper/apis/hack/generate-schemes/generators"
+	"github.com/gardener/landscaper/apis/hack/generate-schemes/app"
 	lsschema "github.com/gardener/landscaper/apis/schema"
-	"github.com/go-openapi/spec"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/yaml"
-
-	"github.com/go-openapi/jsonreference"
-
-	"github.com/gardener/landscaper/apis/openapi"
 )
 
 var Exports = []string{
@@ -55,124 +44,9 @@ func main() {
 	if len(schemaDir) == 0 {
 		log.Fatalln("expected --schema-dir to be set")
 	}
-	if err := run(schemaDir, crdDir); err != nil {
+	schemaGenerator := app.NewSchemaGenerator(Exports, CRDs)
+	if err := schemaGenerator.Run(schemaDir, crdDir); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-}
-
-func run(schemaDir, crdDir string) error {
-	if err := prepareExportDir(schemaDir); err != nil {
-		return err
-	}
-	if err := prepareExportDir(crdDir); err != nil {
-		return err
-	}
-
-	refCallback := func(path string) spec.Ref {
-		ref, _ := jsonreference.New(generators.DefinitionsRef(path))
-		return spec.Ref{Ref: ref}
-	}
-	jsonGen := &generators.JSONSchemaGenerator{
-		Definitions: openapi.GetOpenAPIDefinitions(refCallback),
-	}
-	for defName, apiDefinition := range jsonGen.Definitions {
-		if !ShouldCreateDefinition(Exports, defName) {
-			continue
-		}
-		data, err := jsonGen.Generate(defName, apiDefinition)
-		if err != nil {
-			return fmt.Errorf("unable to generate jsonschema for %s: %w", defName, err)
-		}
-
-		// write file
-		file := filepath.Join(schemaDir, generators.ParsePackageVersionName(defName).String() + ".json")
-		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
-			return fmt.Errorf("unable to write jsonschema for %q to %q: %w", file, generators.ParsePackageVersionName(defName).String(), err)
-		}
-
-		fmt.Printf("Generated jsonschema for %q...\n", generators.ParsePackageVersionName(defName).String())
-	}
-
-	if len(crdDir) == 0 {
-		log.Println("Skip crd generation")
-		return nil
-	}
-	crdGen := generators.NewCRDGenerator(openapi.GetOpenAPIDefinitions)
-	for _, crdVersion := range CRDs {
-		for _, crdDef := range crdVersion.Definitions {
-			if err := crdGen.Generate(crdVersion.Group, crdVersion.Version, crdDef, crdVersion.OutputDir); err != nil {
-				return fmt.Errorf("unable to generate crd for %s %s %s: %w", crdVersion.Group, crdVersion.Version, crdDef.Names.Kind, err)
-			}
-		}
-	}
-
-	crds, err := crdGen.CRDs()
-	if err != nil {
-		return err
-	}
-	cleanedCrdDirs := sets.NewString(crdDir)
-	for _, crd := range crds {
-		jsonBytes, err := json.Marshal(crd.CRD)
-		if err != nil {
-			return fmt.Errorf("unable to marshal CRD %s: %w", crd.CRD.Name, err)
-		}
-		data, err := yaml.JSONToYAML(jsonBytes)
-		if err != nil {
-			return fmt.Errorf("unable to convert json of CRD %s to yaml: %w", crd.CRD.Name, err)
-		}
-
-		outDir := crdDir
-		if len(crd.OutputDir) != 0 {
-			outDir = crd.OutputDir
-		}
-		if !cleanedCrdDirs.Has(outDir) {
-			if err := prepareExportDir(outDir); err != nil {
-				return err
-			}
-			cleanedCrdDirs.Insert(outDir)
-		}
-
-		// write file
-		file := filepath.Join(outDir, fmt.Sprintf("%s_%s.yaml", crd.CRD.Spec.Group, crd.CRD.Spec.Names.Plural))
-		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
-			return fmt.Errorf("unable to write crd for %q to %q: %w", file, crd.CRD.Name, err)
-		}
-
-		fmt.Printf("Generated crd for %q in %s...\n", crd.CRD.Name, file)
-	}
-
-	return nil
-}
-
-// ShouldCreateDefinition checks whether the definition should be exported
-func ShouldCreateDefinition(exportNames []string, defName string) bool {
-	for _, exportName := range exportNames {
-		if strings.HasSuffix(defName, exportName) {
-			return true
-		}
-	}
-	return false
-}
-
-func prepareExportDir(exportDir string) error {
-	log.Printf("Prepate export dir %q", exportDir)
-	if err := os.MkdirAll(exportDir, os.ModePerm); err != nil {
-		return fmt.Errorf("unable to to create export directory %q: %w", exportDir, err)
-	}
-	// cleanup previous files
-	files, err := ioutil.ReadDir(exportDir)
-	if err != nil {
-		return fmt.Errorf("unable to read files from export directory: %w", err)
-	}
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-		filename := filepath.Join(exportDir, file.Name())
-		if err := os.Remove(filename); err != nil {
-			return fmt.Errorf("unable to remove %s: %w", filename, err)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority 3

**What this PR does / why we need it**:
This change moves the implementation of the schema generation to a new app package so it can be re-used in other (external) modules.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
