### PR TITLE
pass openapi callback as a parameter to the schema generator api

### DIFF
--- a/apis/hack/generate-schemes/main.go
+++ b/apis/hack/generate-schemes/main.go
@@ -13,6 +13,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	depv1alpha1 "github.com/gardener/landscaper/apis/deployer/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/hack/generate-schemes/app"
+	"github.com/gardener/landscaper/apis/openapi"
 	lsschema "github.com/gardener/landscaper/apis/schema"
 )
 
@@ -44,7 +45,7 @@ func main() {
 	if len(schemaDir) == 0 {
 		log.Fatalln("expected --schema-dir to be set")
 	}
-	schemaGenerator := app.NewSchemaGenerator(Exports, CRDs)
+	schemaGenerator := app.NewSchemaGenerator(Exports, CRDs, openapi.GetOpenAPIDefinitions)
 	if err := schemaGenerator.Run(schemaDir, crdDir); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:
The open api callback `GetOpenAPIDefinitions` must be passed to the schema generator by the caller.
Otherwise it can't be used by external modules to generate schemas of the own type definitions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
