### PR TITLE
add support for namespace creation in the helm deployer

### DIFF
--- a/apis/.schemes/helm-v1alpha1-ProviderConfiguration.json
+++ b/apis/.schemes/helm-v1alpha1-ProviderConfiguration.json
@@ -668,6 +668,11 @@
       "$ref": "#/definitions/utils-continuousreconcile-ContinuousReconcileSpec",
       "description": "ContinuousReconcile contains the schedule for continuous reconciliation."
     },
+    "createNamespace": {
+      "default": false,
+      "description": "CreateNamespace configures the deployer to create the release namespace if not present. The behavior is similar to the \"helm install --create-namespace\"",
+      "type": "boolean"
+    },
     "deleteTimeout": {
       "$ref": "#/definitions/core-v1alpha1-Duration",
       "description": "DeleteTimeout is the time to wait before giving up on a resource to be deleted. Defaults to 180s."
@@ -721,7 +726,8 @@
   "required": [
     "chart",
     "name",
-    "namespace"
+    "namespace",
+    "createNamespace"
   ],
   "title": "helm-v1alpha1-ProviderConfiguration",
   "type": "object"

--- a/apis/deployer/helm/types_provider.go
+++ b/apis/deployer/helm/types_provider.go
@@ -52,6 +52,10 @@ type ProviderConfiguration struct {
 	// Namespace is the release namespace of the chart
 	Namespace string `json:"namespace"`
 
+	// CreateNamespace configures the deployer to create the release namespace if not present.
+	// The behavior is similar to the "helm install --create-namespace"
+	CreateNamespace bool `json:"createNamespace"`
+
 	// Values are the values that are used for templating.
 	Values json.RawMessage `json:"values,omitempty"`
 

--- a/apis/deployer/helm/v1alpha1/types_provider.go
+++ b/apis/deployer/helm/v1alpha1/types_provider.go
@@ -50,6 +50,10 @@ type ProviderConfiguration struct {
 	// Namespace is the release namespace of the chart
 	Namespace string `json:"namespace"`
 
+	// CreateNamespace configures the deployer to create the release namespace if not present.
+	// The behavior is similar to the "helm install --create-namespace"
+	CreateNamespace bool `json:"createNamespace"`
+
 	// Values are the values that are used for templating.
 	Values json.RawMessage `json:"values,omitempty"`
 

--- a/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -221,6 +221,7 @@ func autoConvert_v1alpha1_ProviderConfiguration_To_helm_ProviderConfiguration(in
 	}
 	out.Name = in.Name
 	out.Namespace = in.Namespace
+	out.CreateNamespace = in.CreateNamespace
 	out.Values = *(*json.RawMessage)(unsafe.Pointer(&in.Values))
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))
@@ -243,6 +244,7 @@ func autoConvert_helm_ProviderConfiguration_To_v1alpha1_ProviderConfiguration(in
 	}
 	out.Name = in.Name
 	out.Namespace = in.Namespace
+	out.CreateNamespace = in.CreateNamespace
 	out.Values = *(*json.RawMessage)(unsafe.Pointer(&in.Values))
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -7473,6 +7473,14 @@ func schema_apis_deployer_helm_v1alpha1_ProviderConfiguration(ref common.Referen
 							Format:      "",
 						},
 					},
+					"createNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreateNamespace configures the deployer to create the release namespace if not present. The behavior is similar to the \"helm install --create-namespace\"",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Values are the values that are used for templating.",
@@ -7507,7 +7515,7 @@ func schema_apis_deployer_helm_v1alpha1_ProviderConfiguration(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"chart", "name", "namespace"},
+				Required: []string{"chart", "name", "namespace", "createNamespace"},
 			},
 		},
 		Dependencies: []string{

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -117,6 +117,9 @@ spec:
     name: my-release
     # Namespace of the release: helm --namespace
     namespace: default
+    # configure the landscaper to automatically create the release namespace.
+    # Works similar to "helm install --create-namespace"
+    createNamespace: true
     # Values to template the chart
     # optional
     values: {}

--- a/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
+++ b/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
@@ -118,7 +118,6 @@ var _ = Describe("GetChart", func() {
 
 	It("should resolve a chart as base64 encoded file", func() {
 		ctx := context.Background()
-		defer ctx.Done()
 		ociClient, err := ociclient.NewClient(logr.Discard())
 		Expect(err).ToNot(HaveOccurred())
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/types_provider.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/types_provider.go
@@ -52,6 +52,10 @@ type ProviderConfiguration struct {
 	// Namespace is the release namespace of the chart
 	Namespace string `json:"namespace"`
 
+	// CreateNamespace configures the deployer to create the release namespace if not present.
+	// The behavior is similar to the "helm install --create-namespace"
+	CreateNamespace bool `json:"createNamespace"`
+
 	// Values are the values that are used for templating.
 	Values json.RawMessage `json:"values,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/types_provider.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/types_provider.go
@@ -50,6 +50,10 @@ type ProviderConfiguration struct {
 	// Namespace is the release namespace of the chart
 	Namespace string `json:"namespace"`
 
+	// CreateNamespace configures the deployer to create the release namespace if not present.
+	// The behavior is similar to the "helm install --create-namespace"
+	CreateNamespace bool `json:"createNamespace"`
+
 	// Values are the values that are used for templating.
 	Values json.RawMessage `json:"values,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -221,6 +221,7 @@ func autoConvert_v1alpha1_ProviderConfiguration_To_helm_ProviderConfiguration(in
 	}
 	out.Name = in.Name
 	out.Namespace = in.Namespace
+	out.CreateNamespace = in.CreateNamespace
 	out.Values = *(*json.RawMessage)(unsafe.Pointer(&in.Values))
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))
@@ -243,6 +244,7 @@ func autoConvert_helm_ProviderConfiguration_To_v1alpha1_ProviderConfiguration(in
 	}
 	out.Name = in.Name
 	out.Namespace = in.Namespace
+	out.CreateNamespace = in.CreateNamespace
 	out.Values = *(*json.RawMessage)(unsafe.Pointer(&in.Values))
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))

--- a/vendor/github.com/gardener/landscaper/crdmanager/pkg/crdmanager/crdmanager.go
+++ b/vendor/github.com/gardener/landscaper/crdmanager/pkg/crdmanager/crdmanager.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	parserReadAheadSize = 1024
+	readerBufferSize = 1024
 )
 
 // CRDManager contains everything required to initialize or update CRDs
@@ -158,7 +158,7 @@ func (crdmgr *CRDManager) crdsFromDir() ([]v1.CustomResourceDefinition, error) {
 			return nil, fmt.Errorf("failed to read CRD file %q: %w", file.Name(), err)
 		}
 
-		decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), parserReadAheadSize)
+		decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), readerBufferSize)
 		crd := &v1.CustomResourceDefinition{}
 		err = decoder.Decode(crd)
 		if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind enhancement
/priority 3

**What this PR does / why we need it**:

It is now possible to configure the helm deployer to automatically create the release namespace.
The behaviour is similar to helm's `--create-namespace` flag.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/landscaper/issues/350

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to configure a helm deploy item to automatically create the release namespace.
This behaviour is similar to Helm's `--create-namespace` flag.

The namespace creation can be configured by setting `createNamespace: true`.
For more details see the Helm deployer documentation.
```
