### PR TITLE
download component-cli via curl instead of go get

### DIFF
--- a/hack/generate-cd.sh
+++ b/hack/generate-cd.sh
@@ -19,7 +19,8 @@ fi
 if ! which component-cli 1>/dev/null; then
   echo -n "component-cli is required to generate the component descriptors"
   echo -n "Trying to installing it..."
-  go get github.com/gardener/component-cli/cmd/component-cli
+  curl -L https://github.com/gardener/component-cli/releases/download/$(curl -s https://api.github.com/repos/gardener/component-cli/releases/latest | jq -r '.tag_name')/componentcli-$(go env GOOS)-$(go env GOARCH).gz | gzip -d > $(go env GOPATH)/bin/component-cli
+  chmod +x $(go env GOPATH)/bin/component-cli
 
   if ! which component-cli 1>/dev/null; then
     echo -n "component-cli was successfully installed but the binary cannot be found"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

Trying to download `component-cli` via ´go get` will fail with

```
go get github.com/gardener/component-cli/cmd/component-cli: create zip: pkg/commands/componentarchive/testdata/01-ca-blob/blobs/sha256:ab894987c426bf8d660826c6fa52a1f351a4c4c094f913862be9c76386bcc32f: malformed file path "pkg/commands/componentarchive/testdata/01-ca-blob/blobs/sha256:ab894987c426bf8d660826c6fa52a1f351a4c4c094f913862be9c76386bcc32f": invalid char ':'
make: *** [cnudie] Error 1
```

It seems that `go get` cant handle certain paths containing the char `:`.
With this PR the script will use curl to download the latest component-cli binary directly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
