### PR TITLE
Fix helm chart templating for targetSelector

### DIFF
--- a/charts/container-deployer/templates/_helpers.tpl
+++ b/charts/container-deployer/templates/_helpers.tpl
@@ -91,7 +91,7 @@ oci:
   {{- end }}
   {{- end }}
 {{- end }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/charts/helm-deployer/templates/_helpers.tpl
+++ b/charts/helm-deployer/templates/_helpers.tpl
@@ -83,7 +83,7 @@ oci:
   {{- end }}
   {{- end }}
 {{- end }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/charts/manifest-deployer/templates/_helpers.tpl
+++ b/charts/manifest-deployer/templates/_helpers.tpl
@@ -72,7 +72,7 @@ kind: Configuration
 identity: {{ .Values.deployer.identity }}
 {{- end }}
 namespace: {{ .Values.deployer.namespace | default .Release.Namespace  }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/charts/mock-deployer/templates/_helpers.tpl
+++ b/charts/mock-deployer/templates/_helpers.tpl
@@ -71,7 +71,7 @@ kind: Configuration
 {{- if .Values.deployer.identity }}
 identity: {{ .Values.deployer.identity }}
 {{- end }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:
The targetSelectors of the deployers are configured in the helm chart values at `.deployer.targetSelector`.  This configuration gets currently lost, because the templating of the charts uses the wrong path `.Values.targetSelector` instead of the correct path `.Values.deployer.targetSelector`. The PR fixes this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
