### PR TITLE
Fix agent

### DIFF
--- a/apis/core/v1alpha1/constants.go
+++ b/apis/core/v1alpha1/constants.go
@@ -52,6 +52,9 @@ const (
 	// DeployerEnvironmentTargetAnnotationName is the default name for the target selector of specific environments.
 	DeployerEnvironmentTargetAnnotationName = "landscaper.gardener.cloud/environment"
 
+	// DeployerOnlyTargetAnnotationName marks a target to be used to deploy only deployers
+	DeployerOnlyTargetAnnotationName = "landscaper.gardener.cloud/deployer-only"
+
 	// NotUseDefaultDeployerAnnotation is the installation annotation that refuses the internal deployer to reconcile
 	// the installation.
 	NotUseDefaultDeployerAnnotation = "landscaper.gardener.cloud/not-internal"

--- a/charts/container-deployer/templates/_helpers.tpl
+++ b/charts/container-deployer/templates/_helpers.tpl
@@ -91,7 +91,7 @@ oci:
   {{- end }}
   {{- end }}
 {{- end }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/charts/container-deployer/values.yaml
+++ b/charts/container-deployer/values.yaml
@@ -34,11 +34,11 @@ deployer:
 #     <name>: <docker config json>
 #  verbosityLevel: 9
 
-# targetSelector:
-# - annotations:
-#   - key:
-#     operator:
-#     value:
+#  targetSelector:
+#  - annotations:
+#    - key:
+#      operator:
+#      value:
 
 replicaCount: 1
 

--- a/charts/helm-deployer/templates/_helpers.tpl
+++ b/charts/helm-deployer/templates/_helpers.tpl
@@ -83,7 +83,7 @@ oci:
   {{- end }}
   {{- end }}
 {{- end }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/charts/helm-deployer/values.yaml
+++ b/charts/helm-deployer/values.yaml
@@ -25,11 +25,11 @@ deployer:
 #      <name>: <docker config json>
 #  verbosityLevel: 9
 
-# targetSelector:
-# - annotations:
-#   - key:
-#     operator:
-#     value:
+#  targetSelector:
+#  - annotations:
+#    - key:
+#      operator:
+#      value:
 
 replicaCount: 1
 

--- a/charts/manifest-deployer/templates/_helpers.tpl
+++ b/charts/manifest-deployer/templates/_helpers.tpl
@@ -72,7 +72,7 @@ kind: Configuration
 identity: {{ .Values.deployer.identity }}
 {{- end }}
 namespace: {{ .Values.deployer.namespace | default .Release.Namespace  }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/charts/manifest-deployer/values.yaml
+++ b/charts/manifest-deployer/values.yaml
@@ -20,11 +20,11 @@ deployer:
   namespace: ""
 #  verbosityLevel: 9
 
-# targetSelector:
-# - annotations:
-#   - key:
-#     operator:
-#     value:
+#  targetSelector:
+#  - annotations:
+#    - key:
+#      operator:
+#      value:
 
 replicaCount: 1
 

--- a/charts/mock-deployer/templates/_helpers.tpl
+++ b/charts/mock-deployer/templates/_helpers.tpl
@@ -71,7 +71,7 @@ kind: Configuration
 {{- if .Values.deployer.identity }}
 identity: {{ .Values.deployer.identity }}
 {{- end }}
-{{- with .Values.targetSelector }}
+{{- with .Values.deployer.targetSelector }}
 targetSelector:
 {{ toYaml . }}
 {{- end }}

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -179,10 +179,6 @@ func (o *Options) run(ctx context.Context) error {
 							Key:      lsv1alpha1.DeployerEnvironmentTargetAnnotationName,
 							Operator: selection.DoesNotExist,
 						},
-						{
-							Key:      lsv1alpha1.NotUseDefaultDeployerAnnotation,
-							Operator: selection.Exists,
-						},
 					},
 				},
 			)

--- a/cmd/landscaper-controller/app/app_test.go
+++ b/cmd/landscaper-controller/app/app_test.go
@@ -6,7 +6,6 @@ package app_test
 
 import (
 	"context"
-	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -122,12 +121,6 @@ var _ = Describe("Landscaper Controller", func() {
 			Expect(reg.Spec.DeployItemTypes).To(ConsistOf(lsv1alpha1.DeployItemType(deployerconfig.HelmDeployerType)))
 			Expect(reg.Spec.InstallationTemplate.ComponentDescriptor.Reference.ComponentName).To(Equal("github.com/gardener/landscaper/helm-deployer"))
 			Expect(reg.Spec.InstallationTemplate.Blueprint.Reference.ResourceName).To(Equal("helm-deployer-blueprint"))
-			Expect(reg.Spec.InstallationTemplate.ImportDataMappings).To(HaveKey("targetSelectors"))
-
-			targetSelectorBytes := reg.Spec.InstallationTemplate.ImportDataMappings["targetSelectors"]
-			var targetSelector []lsv1alpha1.TargetSelector
-			Expect(json.Unmarshal(targetSelectorBytes.RawMessage, &targetSelector)).To(Succeed())
-			Expect(targetSelector).To(HaveLen(1))
 		})
 
 		It("should deploy a mock Deployer registration with custom values", func() {

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -52,6 +52,9 @@ const (
 	// DeployerEnvironmentTargetAnnotationName is the default name for the target selector of specific environments.
 	DeployerEnvironmentTargetAnnotationName = "landscaper.gardener.cloud/environment"
 
+	// DeployerOnlyTargetAnnotationName marks a target to be used to deploy only deployers
+	DeployerOnlyTargetAnnotationName = "landscaper.gardener.cloud/deployer-only"
+
 	// NotUseDefaultDeployerAnnotation is the installation annotation that refuses the internal deployer to reconcile
 	// the installation.
 	NotUseDefaultDeployerAnnotation = "landscaper.gardener.cloud/not-internal"

--- a/pkg/agent/add.go
+++ b/pkg/agent/add.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/selection"
+
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,7 +69,17 @@ func AddToManager(ctx context.Context, logger logr.Logger, lsMgr manager.Manager
 	helmConfig.OCI = config.OCI
 	helmConfig.TargetSelector = []lsv1alpha1.TargetSelector{
 		{
-			Targets: []lsv1alpha1.ObjectReference{{Name: config.Name}},
+			Annotations: []lsv1alpha1.Requirement{
+				{
+					Key:      lsv1alpha1.DeployerEnvironmentTargetAnnotationName,
+					Operator: selection.Equals,
+					Values:   []string{config.Name},
+				},
+				{
+					Key:      lsv1alpha1.DeployerOnlyTargetAnnotationName,
+					Operator: selection.Exists,
+				},
+			},
 		},
 	}
 	if err := helmctlr.AddDeployerToManager(log, lsMgr, hostMgr, helmConfig); err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -100,6 +100,7 @@ func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostCli
 
 		env.Spec.HostTarget.Annotations = map[string]string{
 			lsv1alpha1.DeployerEnvironmentTargetAnnotationName: env.Name,
+			lsv1alpha1.DeployerOnlyTargetAnnotationName:        "true",
 		}
 		env.Spec.HostTarget.TargetSpec = target.Spec
 	}
@@ -249,14 +250,15 @@ func (a Agent) TargetSecretName() string {
 func DefaultTargetSelector(envName string) []lsv1alpha1.TargetSelector {
 	return []lsv1alpha1.TargetSelector{
 		{
-			Targets: []lsv1alpha1.ObjectReference{{Name: envName}},
-		},
-		{
 			Annotations: []lsv1alpha1.Requirement{
 				{
 					Key:      lsv1alpha1.DeployerEnvironmentTargetAnnotationName,
 					Operator: selection.Equals,
 					Values:   []string{envName},
+				},
+				{
+					Key:      lsv1alpha1.DeployerOnlyTargetAnnotationName,
+					Operator: selection.DoesNotExist,
 				},
 			},
 		},

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -93,9 +93,11 @@ func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostCli
 		controllerutil.AddFinalizer(env, lsv1alpha1.LandscaperAgentFinalizer)
 		env.Spec.Namespace = a.config.Namespace
 		env.Spec.LandscaperClusterRestConfig = clusterRestConfig
-		env.Spec.TargetSelectors = a.config.TargetSelectors
-		if env.Spec.TargetSelectors == nil {
+
+		if len(a.config.TargetSelectors) == 0 {
 			env.Spec.TargetSelectors = DefaultTargetSelector(env.Name)
+		} else {
+			env.Spec.TargetSelectors = a.config.TargetSelectors
 		}
 
 		env.Spec.HostTarget.Annotations = map[string]string{
@@ -255,10 +257,6 @@ func DefaultTargetSelector(envName string) []lsv1alpha1.TargetSelector {
 					Key:      lsv1alpha1.DeployerEnvironmentTargetAnnotationName,
 					Operator: selection.Equals,
 					Values:   []string{envName},
-				},
-				{
-					Key:      lsv1alpha1.DeployerOnlyTargetAnnotationName,
-					Operator: selection.DoesNotExist,
 				},
 			},
 		},

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -58,11 +58,9 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 		return err
 	}
 
-	envTargetSelectors := env.Spec.TargetSelectors
-
-	if registration.Name == "helm" {
-		for i := range envTargetSelectors {
-			nextSelector := &envTargetSelectors[i]
+	envTargetSelectors := []lsv1alpha1.TargetSelector{}
+	for _, nextSelector := range env.Spec.TargetSelectors {
+		if registration.Name == "helm" {
 			nextSelector.Annotations = append(
 				nextSelector.Annotations,
 				lsv1alpha1.Requirement{
@@ -71,6 +69,8 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 				},
 			)
 		}
+
+		envTargetSelectors = append(envTargetSelectors, nextSelector)
 	}
 
 	targetSelectorsBytes, err := json.Marshal(envTargetSelectors)

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -61,7 +61,7 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 	envTargetSelectors := env.Spec.TargetSelectors
 
 	if registration.Name == "helm" {
-		for i, _ := range envTargetSelectors {
+		for i := range envTargetSelectors {
 			nextSelector := &envTargetSelectors[i]
 			nextSelector.Annotations = append(
 				nextSelector.Annotations,

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -62,10 +62,10 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 	}
 
 	envTargetSelectors := []lsv1alpha1.TargetSelector{}
-	for _, nextSelector := range env.Spec.TargetSelectors {
+	for _, selector := range env.Spec.TargetSelectors {
 		if registration.Name == "helm" {
-			nextSelector.Annotations = append(
-				nextSelector.Annotations,
+			selector.Annotations = append(
+				selector.Annotations,
 				lsv1alpha1.Requirement{
 					Key:      lsv1alpha1.DeployerOnlyTargetAnnotationName,
 					Operator: selection.DoesNotExist,
@@ -73,7 +73,7 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 			)
 		}
 
-		envTargetSelectors = append(envTargetSelectors, nextSelector)
+		envTargetSelectors = append(envTargetSelectors, selector)
 	}
 
 	targetSelectorsBytes, err := json.Marshal(envTargetSelectors)

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -63,11 +63,13 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 	if registration.Name == "helm" {
 		for i, _ := range envTargetSelectors {
 			nextSelector := &envTargetSelectors[i]
-			nextSelector.Annotations = append(nextSelector.Annotations,
+			nextSelector.Annotations = append(
+				nextSelector.Annotations,
 				lsv1alpha1.Requirement{
 					Key:      lsv1alpha1.DeployerOnlyTargetAnnotationName,
 					Operator: selection.DoesNotExist,
-				})
+				},
+			)
 		}
 	}
 

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -53,6 +53,9 @@ func NewDeployerManagement(log logr.Logger, client client.Client, scheme *runtim
 
 // Reconcile reconciles a deployer installation given a deployer registration and a environment.
 func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1alpha1.DeployerRegistration, env *lsv1alpha1.Environment) error {
+	registration = registration.DeepCopy()
+	env = env.DeepCopy()
+
 	inst, err := dm.getInstallation(ctx, registration, env)
 	if err != nil {
 		return err

--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -166,9 +166,7 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 		inst := &lsv1alpha1.Installation{}
 		inst.Name = "deployer"
 		inst.Namespace = state.Namespace
-		inst.Annotations = map[string]string{
-			lsv1alpha1.NotUseDefaultDeployerAnnotation: "true",
-		}
+		inst.Annotations = map[string]string{}
 		inst.Spec.ComponentDescriptor = &lsv1alpha1.ComponentDescriptorDefinition{
 			Reference: &lsv1alpha1.ComponentDescriptorReference{
 				RepositoryContext: &repoCtx,

--- a/test/utils/charts.go
+++ b/test/utils/charts.go
@@ -51,7 +51,7 @@ func InjectTargetSelectorIntoValues(values *json.RawMessage, targetSelector []ls
 	v := make(map[string]interface{})
 	err := json.Unmarshal(*values, &v)
 	Expect(err).ToNot(HaveOccurred())
-	v["targetSelector"] = targetSelector
+	v["deployer"].(map[string]interface{})["targetSelector"] = targetSelector
 	*values, err = json.Marshal(v)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -52,6 +52,9 @@ const (
 	// DeployerEnvironmentTargetAnnotationName is the default name for the target selector of specific environments.
 	DeployerEnvironmentTargetAnnotationName = "landscaper.gardener.cloud/environment"
 
+	// DeployerOnlyTargetAnnotationName marks a target to be used to deploy only deployers
+	DeployerOnlyTargetAnnotationName = "landscaper.gardener.cloud/deployer-only"
+
 	// NotUseDefaultDeployerAnnotation is the installation annotation that refuses the internal deployer to reconcile
 	// the installation.
 	NotUseDefaultDeployerAnnotation = "landscaper.gardener.cloud/not-internal"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 2

**What this PR does / why we need it**:

This PR fixes the responsibility settings of the deployer in a multi environment setup of the landscaper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix responsibility settings of the deployer in a multi environment setup of the landscaper
```
