### PR TITLE
Reuse secret in service accounts

### DIFF
--- a/charts/container-deployer/templates/_helpers.tpl
+++ b/charts/container-deployer/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Create the name of the service account to use
 */}}
 {{- define "deployer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "deployer.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "deployer.fullname" .) .Values.serviceAccount.name }}-tmp
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name }}-tmp
 {{- end }}
 {{- end }}
 

--- a/charts/helm-deployer/templates/_helpers.tpl
+++ b/charts/helm-deployer/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Create the name of the service account to use
 */}}
 {{- define "deployer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "deployer.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "deployer.fullname" .) .Values.serviceAccount.name }}-tmp
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name }}-tmp
 {{- end }}
 {{- end }}
 

--- a/charts/manifest-deployer/templates/_helpers.tpl
+++ b/charts/manifest-deployer/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Create the name of the service account to use
 */}}
 {{- define "deployer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "deployer.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "deployer.fullname" .) .Values.serviceAccount.name }}-tmp
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name }}-tmp
 {{- end }}
 {{- end }}
 

--- a/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/controller-utils/pkg/kubernetes/kubernetes.go
@@ -606,6 +606,23 @@ func SetRequiredNestedFieldsFromObj(currObj, obj *unstructured.Unstructured) err
 				return err
 			}
 		}
+	case "ServiceAccount":
+		secrets, found, err := unstructured.NestedSlice(obj.Object, "secrets")
+		if err != nil {
+			return err
+		}
+
+		if !found || len(secrets) == 0 {
+			secrets, found, err = unstructured.NestedSlice(currObj.Object, "secrets")
+			if err != nil {
+				return err
+			}
+			if found && len(secrets) > 0 {
+				if err := unstructured.SetNestedSlice(obj.Object, secrets, "secrets"); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	resourceVersion, found, err := unstructured.NestedString(currObj.Object, "metadata", "resourceVersion")

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/kubernetes.go
@@ -606,6 +606,23 @@ func SetRequiredNestedFieldsFromObj(currObj, obj *unstructured.Unstructured) err
 				return err
 			}
 		}
+	case "ServiceAccount":
+		secrets, found, err := unstructured.NestedSlice(obj.Object, "secrets")
+		if err != nil {
+			return err
+		}
+
+		if !found || len(secrets) == 0 {
+			secrets, found, err = unstructured.NestedSlice(currObj.Object, "secrets")
+			if err != nil {
+				return err
+			}
+			if found && len(secrets) > 0 {
+				if err := unstructured.SetNestedSlice(obj.Object, secrets, "secrets"); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	resourceVersion, found, err := unstructured.NestedString(currObj.Object, "metadata", "resourceVersion")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:
Over time, lots of secrets have accumulated on Landscaper clusters. The secrets belong to the service accounts of the deployers. This PR fixes this issue and cleans up the secrets that are no longer needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
