### PR TITLE
add namespace read permissions as needed by the context controller

### DIFF
--- a/charts/landscaper/charts/rbac/templates/clusterrole-controller.yaml
+++ b/charts/landscaper/charts/rbac/templates/clusterrole-controller.yaml
@@ -52,6 +52,14 @@ rules:
       - update
       - delete
   - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
       - "clusterroles"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority 3

**What this PR does / why we need it**:

The new context controller needs read access for namespaces (https://github.com/gardener/landscaper/blob/master/pkg/landscaper/controllers/context/add.go#L39).
This permission is missing from the landscaper controller clusterrole.

```
E1203 11:31:25.756253       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:255: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:ls-system:landscaper-controller" cannot list resource "namespaces" in API group "" at the cluster scope
```

This symptom seems to only affect the landscaper service use case as it is otherwise masked by the landscaper agent clusterrole which has permissions to basically all resources.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Add namespace read permissions to the landscaper controller clusterrole in the landscper rbac chart.
```
