### PR TITLE
Make helm deployer deploy CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	google.golang.org/grpc v1.41.0 // indirect
 	helm.sh/helm/v3 v3.7.0
 	k8s.io/api v0.22.1
+	k8s.io/apiextensions-apiserver v0.22.1
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.1
 	k8s.io/utils v0.0.0-20210802155522-efc7438f0176

--- a/pkg/deployer/helm/deployer.go
+++ b/pkg/deployer/helm/deployer.go
@@ -71,7 +71,7 @@ func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, tar
 	}
 	di.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
 
-	files, values, err := helm.Template(ctx)
+	files, crds, values, err := helm.Template(ctx)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, tar
 			"ConstructExportFromValues", "", err.Error())
 		return err
 	}
-	return helm.ApplyFiles(ctx, files, exports)
+	return helm.ApplyFiles(ctx, files, crds, exports)
 }
 
 func (d *deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -75,8 +75,9 @@ var _ = Describe("Template", func() {
 
 		h, err := helm.New(logr.Discard(), helmv1alpha1.Configuration{}, testenv.Client, testenv.Client, item, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
-		files, _, _, err := h.Template(ctx)
+		files, crds, _, err := h.Template(ctx)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(crds).To(HaveKey("testchart/crds/crontabs.yaml"))
 		Expect(files).To(HaveKey("testchart/templates/secret.yaml"))
 		Expect(files).To(HaveKey("testchart/templates/note.txt"))
 

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Template", func() {
 
 		h, err := helm.New(logr.Discard(), helmv1alpha1.Configuration{}, testenv.Client, testenv.Client, item, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
-		files, _, err := h.Template(ctx)
+		files, _, _, err := h.Template(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(files).To(HaveKey("testchart/templates/secret.yaml"))
 		Expect(files).To(HaveKey("testchart/templates/note.txt"))

--- a/pkg/deployer/helm/testdata/testchart/crds/crontabs.yaml
+++ b/pkg/deployer/helm/testdata/testchart/crds/crontabs.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+    - ct

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -581,6 +581,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.22.1
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind bug
/priority 3

**What this PR does / why we need it**:
With helm 3, it is possible to have CRDs in a folder named `crds` next to the `templates` folder of a helm chart. While `helm install` will deploy these CRDs, the helm deployer ignored the folder.
With this PR, the helm deployer will now deploy CRDs in this folder. Also, the logic for CRDs has been improved, so that the helm deployer can handle simultaneous deployments of a CRD and a CR of that type.

**Which issue(s) this PR fixes**:
Fixes #385 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The helm deployer will now deploy CRDs in the `crds` folder of a chart (see [here](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you)) instead of ignoring them.
```
```bugfix user
Fixed a bug in the helm deployer which prevented it from deploying charts that contain CRDs together with corresponding resources.
```