### PR TITLE
Pass context 2

### DIFF
--- a/apis/core/types_deployitem.go
+++ b/apis/core/types_deployitem.go
@@ -46,6 +46,9 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/apis/core/types_deployitem.go
+++ b/apis/core/types_deployitem.go
@@ -46,7 +46,7 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
-	// Context defines the current context of the installation.
+	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -49,7 +49,7 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
-	// Context defines the current context of the installation.
+	// Context defines the current context of the execution.
 	// +optional
 	Context string `json:"context,omitempty"`
 	// DeployItems defines all execution items that need to be scheduled.

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -49,6 +49,9 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/apis/core/v1alpha1/defaults.go
+++ b/apis/core/v1alpha1/defaults.go
@@ -138,3 +138,19 @@ func SetDefaults_Installation(obj *Installation) {
 		}
 	}
 }
+
+// SetDefaults_Execution sets default values for Execution objects
+func SetDefaults_Execution(obj *Execution) {
+	// default the repository context to "default"
+	if len(obj.Spec.Context) == 0 {
+		obj.Spec.Context = DefaultContextName
+	}
+}
+
+// SetDefaults_DeployItem sets default values for DeployItem objects
+func SetDefaults_DeployItem(obj *DeployItem) {
+	// default the repository context to "default"
+	if len(obj.Spec.Context) == 0 {
+		obj.Spec.Context = DefaultContextName
+	}
+}

--- a/apis/core/v1alpha1/types_deployitem.go
+++ b/apis/core/v1alpha1/types_deployitem.go
@@ -88,7 +88,7 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
-	// Context defines the current context of the installation.
+	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.

--- a/apis/core/v1alpha1/types_deployitem.go
+++ b/apis/core/v1alpha1/types_deployitem.go
@@ -88,6 +88,9 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -103,7 +103,7 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
-	// Context defines the current context of the installation.
+	// Context defines the current context of the execution.
 	// +optional
 	Context string `json:"context,omitempty"`
 

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -103,6 +103,10 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1516,6 +1516,7 @@ func Convert_core_DeployItemList_To_v1alpha1_DeployItemList(in *core.DeployItemL
 func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSpec, out *core.DeployItemSpec, s conversion.Scope) error {
 	out.Type = core.DeployItemType(in.Type)
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
+	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
@@ -1530,6 +1531,7 @@ func Convert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSpec, 
 func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployItemSpec, out *DeployItemSpec, s conversion.Scope) error {
 	out.Type = DeployItemType(in.Type)
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
+	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
@@ -1948,12 +1950,14 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 }
 
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
+	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
+	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil

--- a/apis/core/v1alpha1/zz_generated.defaults.go
+++ b/apis/core/v1alpha1/zz_generated.defaults.go
@@ -19,6 +19,10 @@ import (
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&Blueprint{}, func(obj interface{}) { SetObjectDefaults_Blueprint(obj.(*Blueprint)) })
+	scheme.AddTypeDefaultingFunc(&DeployItem{}, func(obj interface{}) { SetObjectDefaults_DeployItem(obj.(*DeployItem)) })
+	scheme.AddTypeDefaultingFunc(&DeployItemList{}, func(obj interface{}) { SetObjectDefaults_DeployItemList(obj.(*DeployItemList)) })
+	scheme.AddTypeDefaultingFunc(&Execution{}, func(obj interface{}) { SetObjectDefaults_Execution(obj.(*Execution)) })
+	scheme.AddTypeDefaultingFunc(&ExecutionList{}, func(obj interface{}) { SetObjectDefaults_ExecutionList(obj.(*ExecutionList)) })
 	scheme.AddTypeDefaultingFunc(&Installation{}, func(obj interface{}) { SetObjectDefaults_Installation(obj.(*Installation)) })
 	scheme.AddTypeDefaultingFunc(&InstallationList{}, func(obj interface{}) { SetObjectDefaults_InstallationList(obj.(*InstallationList)) })
 	return nil
@@ -26,6 +30,28 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_Blueprint(in *Blueprint) {
 	SetDefaults_Blueprint(in)
+}
+
+func SetObjectDefaults_DeployItem(in *DeployItem) {
+	SetDefaults_DeployItem(in)
+}
+
+func SetObjectDefaults_DeployItemList(in *DeployItemList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_DeployItem(a)
+	}
+}
+
+func SetObjectDefaults_Execution(in *Execution) {
+	SetDefaults_Execution(in)
+}
+
+func SetObjectDefaults_ExecutionList(in *ExecutionList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Execution(a)
+	}
 }
 
 func SetObjectDefaults_Installation(in *Installation) {

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -3943,6 +3943,13 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
 						},
 					},
+					"context": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Context defines the current context of the installation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configuration contains the deployer type specific configuration.",
@@ -4678,6 +4685,13 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 				Description: "ExecutionSpec defines a execution plan.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"context": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Context defines the current context of the installation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"deployItems": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DeployItems defines all execution items that need to be scheduled.",

--- a/charts/container-deployer/templates/rbac.yaml
+++ b/charts/container-deployer/templates/rbac.yaml
@@ -15,7 +15,6 @@ rules:
   resources:
   - deployitems
   - deployitems/status
-  - contexts
   verbs:
   - get
   - watch
@@ -26,6 +25,7 @@ rules:
   - landscaper.gardener.cloud
   resources:
   - targets
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/container-deployer/templates/rbac.yaml
+++ b/charts/container-deployer/templates/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - deployitems
   - deployitems/status
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/helm-deployer/templates/clusterrole.yaml
+++ b/charts/helm-deployer/templates/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - deployitems
   - deployitems/status
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/helm-deployer/templates/clusterrole.yaml
+++ b/charts/helm-deployer/templates/clusterrole.yaml
@@ -15,7 +15,6 @@ rules:
   resources:
   - deployitems
   - deployitems/status
-  - contexts
   verbs:
   - get
   - watch
@@ -25,6 +24,7 @@ rules:
   - landscaper.gardener.cloud
   resources:
   - targets
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/manifest-deployer/templates/clusterrole.yaml
+++ b/charts/manifest-deployer/templates/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - deployitems
   - deployitems/status
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/manifest-deployer/templates/clusterrole.yaml
+++ b/charts/manifest-deployer/templates/clusterrole.yaml
@@ -15,7 +15,6 @@ rules:
   resources:
   - deployitems
   - deployitems/status
-  - contexts
   verbs:
   - get
   - watch
@@ -25,6 +24,7 @@ rules:
   - landscaper.gardener.cloud
   resources:
   - targets
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/mock-deployer/templates/clusterrole.yaml
+++ b/charts/mock-deployer/templates/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - deployitems
   - deployitems/status
+  - contexts
   verbs:
   - get
   - watch

--- a/charts/mock-deployer/templates/clusterrole.yaml
+++ b/charts/mock-deployer/templates/clusterrole.yaml
@@ -15,7 +15,6 @@ rules:
   resources:
   - deployitems
   - deployitems/status
-  - contexts
   verbs:
   - get
   - watch
@@ -25,6 +24,7 @@ rules:
   - landscaper.gardener.cloud
   resources:
   - targets
+  - contexts
   verbs:
   - get
   - watch

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -46,6 +46,9 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -49,6 +49,9 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -138,3 +138,19 @@ func SetDefaults_Installation(obj *Installation) {
 		}
 	}
 }
+
+// SetDefaults_Execution sets default values for Execution objects
+func SetDefaults_Execution(obj *Execution) {
+	// default the repository context to "default"
+	if len(obj.Spec.Context) == 0 {
+		obj.Spec.Context = DefaultContextName
+	}
+}
+
+// SetDefaults_DeployItem sets default values for DeployItem objects
+func SetDefaults_DeployItem(obj *DeployItem) {
+	// default the repository context to "default"
+	if len(obj.Spec.Context) == 0 {
+		obj.Spec.Context = DefaultContextName
+	}
+}

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -88,6 +88,9 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -103,6 +103,10 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1516,6 +1516,7 @@ func Convert_core_DeployItemList_To_v1alpha1_DeployItemList(in *core.DeployItemL
 func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSpec, out *core.DeployItemSpec, s conversion.Scope) error {
 	out.Type = core.DeployItemType(in.Type)
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
+	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
@@ -1530,6 +1531,7 @@ func Convert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSpec, 
 func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployItemSpec, out *DeployItemSpec, s conversion.Scope) error {
 	out.Type = DeployItemType(in.Type)
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
+	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
@@ -1948,12 +1950,14 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 }
 
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
+	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
+	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.defaults.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.defaults.go
@@ -19,6 +19,10 @@ import (
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&Blueprint{}, func(obj interface{}) { SetObjectDefaults_Blueprint(obj.(*Blueprint)) })
+	scheme.AddTypeDefaultingFunc(&DeployItem{}, func(obj interface{}) { SetObjectDefaults_DeployItem(obj.(*DeployItem)) })
+	scheme.AddTypeDefaultingFunc(&DeployItemList{}, func(obj interface{}) { SetObjectDefaults_DeployItemList(obj.(*DeployItemList)) })
+	scheme.AddTypeDefaultingFunc(&Execution{}, func(obj interface{}) { SetObjectDefaults_Execution(obj.(*Execution)) })
+	scheme.AddTypeDefaultingFunc(&ExecutionList{}, func(obj interface{}) { SetObjectDefaults_ExecutionList(obj.(*ExecutionList)) })
 	scheme.AddTypeDefaultingFunc(&Installation{}, func(obj interface{}) { SetObjectDefaults_Installation(obj.(*Installation)) })
 	scheme.AddTypeDefaultingFunc(&InstallationList{}, func(obj interface{}) { SetObjectDefaults_InstallationList(obj.(*InstallationList)) })
 	return nil
@@ -26,6 +30,28 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_Blueprint(in *Blueprint) {
 	SetDefaults_Blueprint(in)
+}
+
+func SetObjectDefaults_DeployItem(in *DeployItem) {
+	SetDefaults_DeployItem(in)
+}
+
+func SetObjectDefaults_DeployItemList(in *DeployItemList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_DeployItem(a)
+	}
+}
+
+func SetObjectDefaults_Execution(in *Execution) {
+	SetDefaults_Execution(in)
+}
+
+func SetObjectDefaults_ExecutionList(in *ExecutionList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Execution(a)
+	}
 }
 
 func SetObjectDefaults_Installation(in *Installation) {

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -483,7 +483,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Context defines the current context of the installation.</p>
+<p>Context defines the current context of the deployitem.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3071,7 +3071,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Context defines the current context of the installation.</p>
+<p>Context defines the current context of the execution.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -824,7 +824,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Context defines the current context of the installation.</p>
+<p>Context defines the current context of the execution.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -476,6 +476,18 @@ It is also used by the deployers to determine the ownernship.</p>
 </tr>
 <tr>
 <td>
+<code>context</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Context defines the current context of the installation.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>config</code></br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
@@ -803,6 +815,18 @@ ExecutionSpec
 <br/>
 <br/>
 <table>
+<tr>
+<td>
+<code>context</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Context defines the current context of the installation.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>deployItems</code></br>
@@ -2340,6 +2364,18 @@ It is also used by the deployers to determine the ownernship.</p>
 </tr>
 <tr>
 <td>
+<code>context</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Context defines the current context of the installation.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>config</code></br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
@@ -3026,6 +3062,18 @@ string
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>context</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Context defines the current context of the installation.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>deployItems</code></br>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2371,7 +2371,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Context defines the current context of the installation.</p>
+<p>Context defines the current context of the deployitem.</p>
 </td>
 </tr>
 <tr>

--- a/docs/technical/deployer_contract.md
+++ b/docs/technical/deployer_contract.md
@@ -31,7 +31,7 @@ spec:
   type: landscaper.gardener.cloud/kubernetes-manifest
   target:
     name: my-target
-    namespace: default
+  context: "default" # reference to the Context object in the same namespace.
   config:
     apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
     kind: ProviderConfiguration

--- a/examples/40-Example-DeployItem.yaml
+++ b/examples/40-Example-DeployItem.yaml
@@ -10,6 +10,11 @@ spec:
 
   type: container | helm | manifest
 
+  target: # optional
+    name: abc
+
+  context: "default"
+
   config:
     apiVersion: mydeplyoer/v1
     kind: ProviderConfiguration

--- a/pkg/deployer/container/container.go
+++ b/pkg/deployer/container/container.go
@@ -54,6 +54,7 @@ type Container struct {
 	Configuration    containerv1alpha1.Configuration
 
 	DeployItem            *lsv1alpha1.DeployItem
+	Context               *lsv1alpha1.Context
 	ProviderStatus        *containerv1alpha1.ProviderStatus
 	ProviderConfiguration *containerv1alpha1.ProviderConfiguration
 
@@ -70,6 +71,7 @@ func New(log logr.Logger,
 	directHostClient client.Client,
 	config containerv1alpha1.Configuration,
 	item *lsv1alpha1.DeployItem,
+	lsCtx *lsv1alpha1.Context,
 	sharedCache cache.Cache) (*Container, error) {
 	providerConfig := &containerv1alpha1.ProviderConfiguration{}
 	decoder := api.NewDecoder(Scheme)
@@ -98,6 +100,7 @@ func New(log logr.Logger,
 		directHostClient:      directHostClient,
 		Configuration:         config,
 		DeployItem:            item,
+		Context:               lsCtx,
 		ProviderStatus:        status,
 		ProviderConfiguration: providerConfig,
 		sharedCache:           sharedCache,

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/gardener/landscaper/pkg/deployer/lib"
+
 	lserrors "github.com/gardener/landscaper/apis/errors"
 
 	dockerconfig "github.com/docker/cli/cli/config"
@@ -481,7 +483,8 @@ func (c *Container) parseAndSyncSecrets(ctx context.Context, defaultLabels map[s
 		}
 	}
 
-	for _, secretRef := range c.ProviderConfiguration.RegistryPullSecrets {
+	secretRefs := append(lib.GetRegistryPullSecretsFromContext(c.Context), c.ProviderConfiguration.RegistryPullSecrets...)
+	for _, secretRef := range secretRefs {
 		secret := &corev1.Secret{}
 
 		err := c.lsClient.Get(ctx, secretRef.NamespacedName(), secret)

--- a/pkg/deployer/container/container_suite_test.go
+++ b/pkg/deployer/container/container_suite_test.go
@@ -16,6 +16,8 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/gardener/landscaper/test/utils"
+
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	containerctlr "github.com/gardener/landscaper/pkg/deployer/container"
@@ -78,6 +80,7 @@ var _ = Describe("Template", func() {
 
 		state, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
 
 		go func() {
 			Expect(mgr.Start(ctx)).To(Succeed())

--- a/pkg/deployer/container/garbage_collector_test.go
+++ b/pkg/deployer/container/garbage_collector_test.go
@@ -24,7 +24,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/utils/simplelogger"
-	"github.com/gardener/landscaper/test/utils"
+	testutils "github.com/gardener/landscaper/test/utils"
 
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
@@ -69,12 +69,14 @@ var _ = Describe("GarbageCollector", func() {
 		lsState, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, lsState.Namespace)).To(Succeed())
+
 		gc = containerctlr.NewGarbageCollector(logger, testenv.Client, hostTestEnv.Client, "test", hostState.Namespace, containerv1alpha1.GarbageCollection{
 			Worker: 1,
 		})
 		Expect(gc.Add(hostMgr, false)).To(Succeed())
 
-		Expect(utils.AddMimicKCMServiceAccountControllerToManager(hostMgr)).To(Succeed())
+		Expect(testutils.AddMimicKCMServiceAccountControllerToManager(hostMgr)).To(Succeed())
 
 		go func() {
 			Expect(lsMgr.Start(ctx)).To(Succeed())

--- a/pkg/deployer/container/helper.go
+++ b/pkg/deployer/container/helper.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"

--- a/pkg/deployer/container/reconciler_deployitem.go
+++ b/pkg/deployer/container/reconciler_deployitem.go
@@ -69,29 +69,29 @@ type deployer struct {
 	hooks            extension.ReconcileExtensionHooks
 }
 
-func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, _ *lsv1alpha1.Target) error {
+func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, _ *lsv1alpha1.Target) error {
 	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace})
-	containerOp, err := New(logger, d.lsClient, d.hostClient, d.directHostClient, d.config, di, d.sharedCache)
+	containerOp, err := New(logger, d.lsClient, d.hostClient, d.directHostClient, d.config, di, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
 	return containerOp.Reconcile(ctx, container.OperationReconcile)
 }
 
-func (d deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace})
-	containerOp, err := New(logger, d.lsClient, d.hostClient, d.directHostClient, d.config, di, d.sharedCache)
+	containerOp, err := New(logger, d.lsClient, d.hostClient, d.directHostClient, d.config, di, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
 	return containerOp.Delete(ctx)
 }
 
-func (d *deployer) ForceReconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	return d.Reconcile(ctx, di, target)
+func (d *deployer) ForceReconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	return d.Reconcile(ctx, lsCtx, di, target)
 }
 
-func (d *deployer) Abort(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Abort(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	d.log.Info("abort is not yet implemented")
 	return nil
 }
@@ -101,7 +101,8 @@ func (d *deployer) ExtensionHooks() extension.ReconcileExtensionHooks {
 }
 
 func (d *deployer) NextReconcile(ctx context.Context, last time.Time, di *lsv1alpha1.DeployItem) (*time.Time, error) {
-	containerOp, err := New(d.log, d.lsClient, d.hostClient, d.directHostClient, d.config, di, d.sharedCache)
+	// TODO: parse provider configuration directly and do not init the container helper struct
+	containerOp, err := New(d.log, d.lsClient, d.hostClient, d.directHostClient, d.config, di, nil, d.sharedCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/container/reconciler_pod.go
+++ b/pkg/deployer/container/reconciler_pod.go
@@ -52,7 +52,7 @@ func NewPodReconciler(
 }
 
 func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	deployItem, err := GetAndCheckReconcile(r.log, r.lsClient, r.config)(ctx, req)
+	deployItem, lsCtx, err := GetAndCheckReconcile(r.log, r.lsClient, r.config)(ctx, req)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -60,7 +60,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, nil
 	}
 	errHdl := deployerlib.HandleErrorFunc(r.log, r.lsClient, r.lsEventRecorder, deployItem)
-	if err := errHdl(ctx, r.diRec.Reconcile(ctx, deployItem, nil)); err != nil {
+	if err := errHdl(ctx, r.diRec.Reconcile(ctx, lsCtx, deployItem, nil)); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil

--- a/pkg/deployer/container/test/e2e_test.go
+++ b/pkg/deployer/container/test/e2e_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Container Deployer", func() {
 		var err error
 		state, err = testenv.InitState(context.TODO())
 		Expect(err).ToNot(HaveOccurred())
+		Expect(testutil.CreateExampleDefaultContext(context.TODO(), testenv.Client, state.Namespace)).To(Succeed())
 
 		deployer, err := containerctlr.NewDeployer(
 			logr.Discard(),

--- a/pkg/deployer/helm/deployer.go
+++ b/pkg/deployer/helm/deployer.go
@@ -64,8 +64,8 @@ type deployer struct {
 	hooks       extension.ReconcileExtensionHooks
 }
 
-func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, target, d.sharedCache)
+func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, target, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
@@ -85,8 +85,8 @@ func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, tar
 	return helm.ApplyFiles(ctx, files, crds, exports)
 }
 
-func (d *deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, target, d.sharedCache)
+func (d *deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, target, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
@@ -94,15 +94,15 @@ func (d *deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target
 	return helm.DeleteFiles(ctx)
 }
 
-func (d *deployer) ForceReconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	if err := d.Reconcile(ctx, di, target); err != nil {
+func (d *deployer) ForceReconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	if err := d.Reconcile(ctx, lsCtx, di, target); err != nil {
 		return err
 	}
 	delete(di.Annotations, lsv1alpha1.OperationAnnotation)
 	return nil
 }
 
-func (d *deployer) Abort(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Abort(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	d.log.Info("abort is not yet implemented")
 	return nil
 }
@@ -112,7 +112,8 @@ func (d *deployer) ExtensionHooks() extension.ReconcileExtensionHooks {
 }
 
 func (d *deployer) NextReconcile(ctx context.Context, last time.Time, di *lsv1alpha1.DeployItem) (*time.Time, error) {
-	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, nil, d.sharedCache)
+	// todo: directly parse deploy items
+	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, nil, nil, d.sharedCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/component-cli/ociclient/cache"
 	"github.com/gardener/component-cli/ociclient/credentials"
 	"github.com/go-logr/logr"
+	"github.com/mandelsoft/vfs/pkg/osfs"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/engine"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,6 +65,7 @@ type Helm struct {
 
 	DeployItem            *lsv1alpha1.DeployItem
 	Target                *lsv1alpha1.Target
+	Context               *lsv1alpha1.Context
 	ProviderConfiguration *helmv1alpha1.ProviderConfiguration
 	ProviderStatus        *helmv1alpha1.ProviderStatus
 	SharedCache           cache.Cache
@@ -80,6 +82,7 @@ func New(log logr.Logger,
 	hostKubeClient client.Client,
 	item *lsv1alpha1.DeployItem,
 	target *lsv1alpha1.Target,
+	lsCtx *lsv1alpha1.Context,
 	sharedCache cache.Cache) (*Helm, error) {
 
 	currOp := "InitHelmOperation"
@@ -111,6 +114,7 @@ func New(log logr.Logger,
 		Configuration:         helmconfig,
 		DeployItem:            item,
 		Target:                target,
+		Context:               lsCtx,
 		ProviderConfiguration: config,
 		ProviderStatus:        status,
 		SharedCache:           sharedCache,
@@ -130,7 +134,13 @@ func (h *Helm) Template(ctx context.Context) (map[string]string, map[string]stri
 
 	// download chart
 	// todo: do caching of charts
-	ociClient, err := createOCIClient(ctx, h.log, h.lsKubeClient, h.DeployItem, h.Configuration, h.SharedCache)
+
+	ociClient, err := createOCIClient(ctx,
+		h.log,
+		h.lsKubeClient,
+		append(lib.GetRegistryPullSecretsFromContext(h.Context), h.DeployItem.Spec.RegistryPullSecrets...),
+		h.Configuration,
+		h.SharedCache)
 	if err != nil {
 		return nil, nil, nil, lserrors.NewWrappedError(err,
 			currOp, "BuildOCIClient", err.Error())
@@ -244,9 +254,9 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 	return nil, nil, nil, errors.New("neither a target nor kubeconfig are defined")
 }
 
-func createOCIClient(ctx context.Context, log logr.Logger, client client.Client, item *lsv1alpha1.DeployItem, config helmv1alpha1.Configuration, sharedCache cache.Cache) (ociclient.Client, error) {
+func createOCIClient(ctx context.Context, log logr.Logger, client client.Client, registryPullSecrets []lsv1alpha1.ObjectReference, config helmv1alpha1.Configuration, sharedCache cache.Cache) (ociclient.Client, error) {
 	// resolve all pull secrets
-	secrets, err := kutil.ResolveSecrets(ctx, client, item.Spec.RegistryPullSecrets)
+	secrets, err := kutil.ResolveSecrets(ctx, client, registryPullSecrets)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +266,11 @@ func createOCIClient(ctx context.Context, log logr.Logger, client client.Client,
 	if config.OCI != nil {
 		ociConfigFiles = config.OCI.ConfigFiles
 	}
-	ociKeyring, err := credentials.CreateOCIRegistryKeyring(secrets, ociConfigFiles)
+	ociKeyring, err := credentials.NewBuilder(log.WithName("ociKeyring")).
+		WithFS(osfs.New()).
+		FromConfigFiles(ociConfigFiles...).
+		FromPullSecrets(secrets...).
+		Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -73,7 +73,10 @@ var _ = Describe("Template", func() {
 		item := &lsv1alpha1.DeployItem{}
 		item.Spec.Configuration = providerConfig
 
-		h, err := helm.New(logr.Discard(), helmv1alpha1.Configuration{}, testenv.Client, testenv.Client, item, nil, nil)
+		lsCtx := &lsv1alpha1.Context{}
+		lsCtx.Name = lsv1alpha1.DefaultContextName
+		lsCtx.Namespace = item.Namespace
+		h, err := helm.New(logr.Discard(), helmv1alpha1.Configuration{}, testenv.Client, testenv.Client, item, nil, lsCtx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		files, crds, _, err := h.Template(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -119,6 +122,7 @@ var _ = Describe("Template", func() {
 		})
 
 		It("should create the release namespace if configured", func() {
+			Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
 			target, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(state.Create(ctx, target)).To(Succeed())

--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Helm Deployer", func() {
 		var err error
 		state, err = testenv.InitState(context.TODO())
 		Expect(err).ToNot(HaveOccurred())
+		Expect(testutil.CreateExampleDefaultContext(context.TODO(), testenv.Client, state.Namespace)).To(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 
 	"github.com/gardener/landscaper/pkg/version"
 

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	kutil "github.com/gardener/landscaper/pkg/utils/kubernetes"
+
 	"github.com/gardener/landscaper/pkg/version"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -34,14 +36,14 @@ import (
 // Deployer defines a controller that acts upon deploy items.
 type Deployer interface {
 	// Reconcile the deploy item.
-	Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
+	Reconcile(ctx context.Context, lsContext *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
 	// Delete the deploy item.
-	Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
+	Delete(ctx context.Context, lsContext *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
 	// ForceReconcile the deploy item.
 	// Keep in mind that the force deletion annotation must be removed by the Deployer.
-	ForceReconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
+	ForceReconcile(ctx context.Context, lsContext *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
 	// Abort the deploy item progress.
-	Abort(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
+	Abort(ctx context.Context, lsContext *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error
 	// ExtensionHooks returns all registered extension hooks.
 	ExtensionHooks() extension.ReconcileExtensionHooks
 }
@@ -169,6 +171,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		return reconcile.Result{}, err
 	}
+	c.lsScheme.Default(di)
 
 	errHdl := HandleErrorFunc(logger, c.lsClient, c.lsEventRecorder, di)
 
@@ -195,6 +198,12 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	hookRes = extension.AggregateHookResults(hookRes, tmpHookRes)
 	if hookRes.AbortReconcile {
 		return returnAndLogReconcileResult(logger, *hookRes), nil
+	}
+
+	lsCtx := &lsv1alpha1.Context{}
+	// todo: check for real repository context. Maybe overwritten by installation.
+	if err := c.lsClient.Get(ctx, kutil.ObjectKey(di.Spec.Context, di.Namespace), lsCtx); err != nil {
+		return reconcile.Result{}, fmt.Errorf("unable to get landscaper context: %w", err)
 	}
 
 	logger.V(3).Info("check deploy item reconciliation")
@@ -246,7 +255,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if hookRes.AbortReconcile {
 			return returnAndLogReconcileResult(logger, *hookRes), nil
 		}
-		if err := errHdl(ctx, c.deployer.Abort(ctx, di, target)); err != nil {
+		if err := errHdl(ctx, c.deployer.Abort(ctx, lsCtx, di, target)); err != nil {
 			return reconcile.Result{}, err
 		}
 	case lsv1alpha1.ForceReconcileOperation:
@@ -259,7 +268,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if hookRes.AbortReconcile {
 			return returnAndLogReconcileResult(logger, *hookRes), nil
 		}
-		if err := errHdl(ctx, c.deployer.ForceReconcile(ctx, di, target)); err != nil {
+		if err := errHdl(ctx, c.deployer.ForceReconcile(ctx, lsCtx, di, target)); err != nil {
 			return reconcile.Result{}, err
 		}
 	default:
@@ -274,7 +283,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if hookRes.AbortReconcile {
 				return returnAndLogReconcileResult(logger, *hookRes), nil
 			}
-			if err := errHdl(ctx, c.delete(ctx, di, target)); err != nil {
+			if err := errHdl(ctx, c.delete(ctx, lsCtx, di, target)); err != nil {
 				return reconcile.Result{}, err
 			}
 		} else {
@@ -288,7 +297,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			if hookRes.AbortReconcile {
 				return returnAndLogReconcileResult(logger, *hookRes), nil
 			}
-			if err := errHdl(ctx, c.reconcile(ctx, di, target)); err != nil {
+			if err := errHdl(ctx, c.reconcile(ctx, lsCtx, di, target)); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -310,6 +319,7 @@ func (c *controller) checkTargetResponsibility(ctx context.Context, log logr.Log
 	}
 	log.V(7).Info("Found target. Checking responsibility")
 	target := &lsv1alpha1.Target{}
+	deployItem.Spec.Target.Namespace = deployItem.Namespace
 	if err := c.lsClient.Get(ctx, deployItem.Spec.Target.NamespacedName(), target); err != nil {
 		return nil, false, fmt.Errorf("unable to get target for deploy item: %w", err)
 	}
@@ -343,7 +353,7 @@ func returnAndLogReconcileResult(logger logr.Logger, result extension.HookResult
 	return result.ReconcileResult
 }
 
-func (c *controller) reconcile(ctx context.Context, deployItem *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (c *controller) reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, deployItem *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	if !controllerutil.ContainsFinalizer(deployItem, lsv1alpha1.LandscaperFinalizer) {
 		controllerutil.AddFinalizer(deployItem, lsv1alpha1.LandscaperFinalizer)
 		if err := c.lsClient.Update(ctx, deployItem); err != nil {
@@ -352,11 +362,11 @@ func (c *controller) reconcile(ctx context.Context, deployItem *lsv1alpha1.Deplo
 		}
 	}
 
-	return c.deployer.Reconcile(ctx, deployItem, target)
+	return c.deployer.Reconcile(ctx, lsCtx, deployItem, target)
 }
 
-func (c *controller) delete(ctx context.Context, deployItem *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	if err := c.deployer.Delete(ctx, deployItem, target); err != nil {
+func (c *controller) delete(ctx context.Context, lsCtx *lsv1alpha1.Context, deployItem *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	if err := c.deployer.Delete(ctx, lsCtx, deployItem, target); err != nil {
 		return err
 	}
 	if controllerutil.ContainsFinalizer(deployItem, lsv1alpha1.LandscaperFinalizer) {

--- a/pkg/deployer/lib/targetselector/e2e_suite_test.go
+++ b/pkg/deployer/lib/targetselector/e2e_suite_test.go
@@ -81,6 +81,11 @@ var _ = Describe("E2E", func() {
 		testutils.ExpectNoError(err)
 		testutils.ExpectNoError(state.Create(ctx, di))
 
+		defaultContext := &lsv1alpha1.Context{}
+		defaultContext.Name = lsv1alpha1.DefaultContextName
+		defaultContext.Namespace = state.Namespace
+		testutils.ExpectNoError(state.Create(ctx, defaultContext))
+
 		ctrl, err := mock.NewController(logr.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024), mockv1alpha1.Configuration{
 			TargetSelector: []lsv1alpha1.TargetSelector{
 				{

--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -193,3 +193,16 @@ func CreateOrUpdateExport(ctx context.Context, kubeClient client.Client, deployI
 	}
 	return nil
 }
+
+// GetRegistryPullSecretsFromContext returns the object references to
+// registry pull secrets defined by the landscaper context.
+func GetRegistryPullSecretsFromContext(lsCtx *lsv1alpha1.Context) []lsv1alpha1.ObjectReference {
+	refs := make([]lsv1alpha1.ObjectReference, len(lsCtx.RegistryPullSecrets))
+	for i, r := range lsCtx.RegistryPullSecrets {
+		refs[i] = lsv1alpha1.ObjectReference{
+			Name:      r.Name,
+			Namespace: lsCtx.Namespace,
+		}
+	}
+	return refs
+}

--- a/pkg/deployer/manifest/controller.go
+++ b/pkg/deployer/manifest/controller.go
@@ -47,7 +47,7 @@ type deployer struct {
 	hooks      extension.ReconcileExtensionHooks
 }
 
-func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Reconcile(ctx context.Context, _ *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace}.String())
 	manifest, err := New(logger, d.lsClient, d.hostClient, &d.config, di, target)
 	if err != nil {
@@ -56,7 +56,7 @@ func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di 
 	return manifest.Reconcile(ctx)
 }
 
-func (d deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d deployer) Delete(ctx context.Context, _ *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace}.String())
 	manifest, err := New(logger, d.lsClient, d.hostClient, &d.config, di, target)
 	if err != nil {

--- a/pkg/deployer/manifest/controller.go
+++ b/pkg/deployer/manifest/controller.go
@@ -47,7 +47,7 @@ type deployer struct {
 	hooks      extension.ReconcileExtensionHooks
 }
 
-func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace}.String())
 	manifest, err := New(logger, d.lsClient, d.hostClient, &d.config, di, target)
 	if err != nil {
@@ -56,7 +56,7 @@ func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, tar
 	return manifest.Reconcile(ctx)
 }
 
-func (d deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace}.String())
 	manifest, err := New(logger, d.lsClient, d.hostClient, &d.config, di, target)
 	if err != nil {
@@ -65,15 +65,15 @@ func (d deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target 
 	return manifest.Delete(ctx)
 }
 
-func (d *deployer) ForceReconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	if err := d.Reconcile(ctx, di, target); err != nil {
+func (d *deployer) ForceReconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	if err := d.Reconcile(ctx, lsCtx, di, target); err != nil {
 		return err
 	}
 	delete(di.Annotations, lsv1alpha1.OperationAnnotation)
 	return nil
 }
 
-func (d *deployer) Abort(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Abort(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	d.log.Info("abort is not yet implemented")
 	return nil
 }

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -73,6 +73,11 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/01-di.yaml")
 
+		defaultContext := &lsv1alpha1.Context{}
+		defaultContext.Name = lsv1alpha1.DefaultContextName
+		defaultContext.Namespace = state.Namespace
+		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+
 		// First reconcile will add a finalizer
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -122,6 +127,11 @@ var _ = Describe("Manifest Deployer", func() {
 		By("create deploy item")
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/01-di.yaml")
 
+		defaultContext := &lsv1alpha1.Context{}
+		defaultContext.Name = lsv1alpha1.DefaultContextName
+		defaultContext.Namespace = state.Namespace
+		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+
 		// First reconcile will add a finalizer
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -166,6 +176,11 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/04-di-invalid.yaml")
 
+		defaultContext := &lsv1alpha1.Context{}
+		defaultContext.Name = lsv1alpha1.DefaultContextName
+		defaultContext.Namespace = state.Namespace
+		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+
 		// First reconcile will add a finalizer
 		_ = testutil.ShouldNotReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
 
@@ -200,6 +215,11 @@ var _ = Describe("Manifest Deployer", func() {
 		defer ctx.Done()
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "conrec-test-di", "./testdata/07-di-con-rec.yaml")
+
+		defaultContext := &lsv1alpha1.Context{}
+		defaultContext.Name = lsv1alpha1.DefaultContextName
+		defaultContext.Namespace = state.Namespace
+		testutil.ExpectNoError(state.Create(ctx, defaultContext))
 
 		// reconcile once to generate status
 		recRes, err := ctrl.Reconcile(ctx, kutil.ReconcileRequestFromObject(di))
@@ -247,6 +267,11 @@ func checkUpdate(pathToDI1, pathToDI2 string, state *envtest.State, ctrl reconci
 
 	By("create deploy item")
 	di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", pathToDI1)
+
+	defaultContext := &lsv1alpha1.Context{}
+	defaultContext.Name = lsv1alpha1.DefaultContextName
+	defaultContext.Namespace = state.Namespace
+	testutil.ExpectNoError(state.Create(ctx, defaultContext))
 
 	// First reconcile will add a finalizer
 	testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -73,10 +73,7 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/01-di.yaml")
 
-		defaultContext := &lsv1alpha1.Context{}
-		defaultContext.Name = lsv1alpha1.DefaultContextName
-		defaultContext.Namespace = state.Namespace
-		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
 
 		// First reconcile will add a finalizer
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -127,10 +124,7 @@ var _ = Describe("Manifest Deployer", func() {
 		By("create deploy item")
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/01-di.yaml")
 
-		defaultContext := &lsv1alpha1.Context{}
-		defaultContext.Name = lsv1alpha1.DefaultContextName
-		defaultContext.Namespace = state.Namespace
-		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
 
 		// First reconcile will add a finalizer
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -176,10 +170,7 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/04-di-invalid.yaml")
 
-		defaultContext := &lsv1alpha1.Context{}
-		defaultContext.Name = lsv1alpha1.DefaultContextName
-		defaultContext.Namespace = state.Namespace
-		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
 
 		// First reconcile will add a finalizer
 		_ = testutil.ShouldNotReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -216,10 +207,7 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "conrec-test-di", "./testdata/07-di-con-rec.yaml")
 
-		defaultContext := &lsv1alpha1.Context{}
-		defaultContext.Name = lsv1alpha1.DefaultContextName
-		defaultContext.Namespace = state.Namespace
-		testutil.ExpectNoError(state.Create(ctx, defaultContext))
+		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
 
 		// reconcile once to generate status
 		recRes, err := ctrl.Reconcile(ctx, kutil.ReconcileRequestFromObject(di))
@@ -268,10 +256,7 @@ func checkUpdate(pathToDI1, pathToDI2 string, state *envtest.State, ctrl reconci
 	By("create deploy item")
 	di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", pathToDI1)
 
-	defaultContext := &lsv1alpha1.Context{}
-	defaultContext.Name = lsv1alpha1.DefaultContextName
-	defaultContext.Namespace = state.Namespace
-	testutil.ExpectNoError(state.Create(ctx, defaultContext))
+	testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
 
 	// First reconcile will add a finalizer
 	testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/01-di.yaml")
 
-		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
+		Expect(testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)).ToNot(HaveOccurred())
 
 		// First reconcile will add a finalizer
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -124,7 +124,7 @@ var _ = Describe("Manifest Deployer", func() {
 		By("create deploy item")
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/01-di.yaml")
 
-		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
+		Expect(testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)).ToNot(HaveOccurred())
 
 		// First reconcile will add a finalizer
 		testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -170,7 +170,7 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", "./testdata/04-di-invalid.yaml")
 
-		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
+		Expect(testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)).ToNot(HaveOccurred())
 
 		// First reconcile will add a finalizer
 		_ = testutil.ShouldNotReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))
@@ -207,7 +207,7 @@ var _ = Describe("Manifest Deployer", func() {
 
 		di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "conrec-test-di", "./testdata/07-di-con-rec.yaml")
 
-		testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
+		Expect(testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)).ToNot(HaveOccurred())
 
 		// reconcile once to generate status
 		recRes, err := ctrl.Reconcile(ctx, kutil.ReconcileRequestFromObject(di))
@@ -256,7 +256,7 @@ func checkUpdate(pathToDI1, pathToDI2 string, state *envtest.State, ctrl reconci
 	By("create deploy item")
 	di := testutil.ReadAndCreateOrUpdateDeployItem(ctx, testenv, state, "ingress-test-di", pathToDI1)
 
-	testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)
+	Expect(testutil.CreateDefaultContext(ctx, testenv.Client, nil, state.Namespace)).ToNot(HaveOccurred())
 
 	// First reconcile will add a finalizer
 	testutil.ShouldReconcile(ctx, ctrl, testutil.Request(di.GetName(), di.GetNamespace()))

--- a/pkg/deployer/mock/controller.go
+++ b/pkg/deployer/mock/controller.go
@@ -50,7 +50,7 @@ type deployer struct {
 	hooks      extension.ReconcileExtensionHooks
 }
 
-func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, _ *lsv1alpha1.Target) error {
+func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, _ *lsv1alpha1.Target) error {
 	config, err := d.getConfig(ctx, di)
 	if err != nil {
 		return err
@@ -79,19 +79,19 @@ func (d *deployer) Reconcile(ctx context.Context, di *lsv1alpha1.DeployItem, _ *
 	return d.lsClient.Status().Update(ctx, di)
 }
 
-func (d *deployer) Delete(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	return d.ensureDeletion(ctx, di)
 }
 
-func (d *deployer) ForceReconcile(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	if err := d.Reconcile(ctx, di, target); err != nil {
+func (d *deployer) ForceReconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+	if err := d.Reconcile(ctx, lsCtx, di, target); err != nil {
 		return err
 	}
 	delete(di.Annotations, lsv1alpha1.OperationAnnotation)
 	return nil
 }
 
-func (d *deployer) Abort(ctx context.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
+func (d *deployer) Abort(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
 	d.log.Info("abort is not yet implemented")
 	return nil
 }

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -279,14 +279,14 @@ func (dm *DeployerManagement) EnsureRBACRoles(ctx context.Context) error {
 				Verbs:     []string{"get", "watch", "list", "update", "patch"},
 			},
 			{
-				APIGroups: []string{corev1.SchemeGroupVersion.Group},
-				Resources: []string{"events"},
-				Verbs:     []string{"create", "get", "watch", "patch", "update"},
+				APIGroups: []string{lsv1alpha1.SchemeGroupVersion.Group},
+				Resources: []string{"contexts"},
+				Verbs:     []string{"get", "watch", "list"},
 			},
 			{
 				APIGroups: []string{corev1.SchemeGroupVersion.Group},
-				Resources: []string{"contexts"},
-				Verbs:     []string{"get", "watch", "list"},
+				Resources: []string{"events"},
+				Verbs:     []string{"create", "get", "watch", "patch", "update"},
 			},
 		}
 		return nil

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -283,6 +283,11 @@ func (dm *DeployerManagement) EnsureRBACRoles(ctx context.Context) error {
 				Resources: []string{"events"},
 				Verbs:     []string{"create", "get", "watch", "patch", "update"},
 			},
+			{
+				APIGroups: []string{corev1.SchemeGroupVersion.Group},
+				Resources: []string{"contexts"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
 		}
 		return nil
 	}); err != nil {

--- a/pkg/landscaper/controllers/deployitem/testdata/04-default-context.yaml
+++ b/pkg/landscaper/controllers/deployitem/testdata/04-default-context.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Context
+metadata:
+  name: default
+  namespace: {{ .Namespace }}

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
@@ -41,7 +41,7 @@ spec:
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
               context:
-                description: Context defines the current context of the installation.
+                description: Context defines the current context of the deployitem.
                 type: string
               registryPullSecrets:
                 description: 'RegistryPullSecrets defines a list of registry credentials

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
@@ -40,6 +40,9 @@ spec:
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
+              context:
+                description: Context defines the current context of the installation.
+                type: string
               registryPullSecrets:
                 description: 'RegistryPullSecrets defines a list of registry credentials
                   that are used to pull blueprints, component descriptors and jsonschemas

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -32,6 +32,9 @@ spec:
           spec:
             description: Spec defines a execution and its items
             properties:
+              context:
+                description: Context defines the current context of the installation.
+                type: string
               deployItems:
                 description: DeployItems defines all execution items that need to
                   be scheduled.

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -33,7 +33,7 @@ spec:
             description: Spec defines a execution and its items
             properties:
               context:
-                description: Context defines the current context of the installation.
+                description: Context defines the current context of the execution.
                 type: string
               deployItems:
                 description: DeployItems defines all execution items that need to

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -166,6 +166,8 @@ func (o *Operation) deployOrTrigger(ctx context.Context, item executionItem) err
 	if _, err := kutil.CreateOrUpdate(ctx, o.Client(), item.DeployItem, func() error {
 		ApplyDeployItemTemplate(item.DeployItem, item.Info)
 		kutil.SetMetaDataLabel(&item.DeployItem.ObjectMeta, lsv1alpha1.ExecutionManagedByLabel, o.exec.Name)
+		item.DeployItem.Spec.Context = o.exec.Spec.Context
+		o.Scheme().Default(item.DeployItem)
 		return controllerutil.SetControllerReference(o.exec, item.DeployItem, o.Scheme())
 	}); err != nil {
 		return err

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -79,6 +79,7 @@ func (o *ExecutionOperation) Ensure(ctx context.Context, inst *installations.Ins
 	exec.Namespace = inst.Info.Namespace
 	exec.Spec.RegistryPullSecrets = inst.Info.Spec.RegistryPullSecrets
 	if _, err := kutil.CreateOrUpdate(ctx, o.Client(), exec, func() error {
+		exec.Spec.Context = inst.Info.Spec.Context
 		exec.Spec.DeployItems = executions
 
 		if lsv1alpha1helper.HasOperation(inst.Info.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
@@ -90,6 +91,7 @@ func (o *ExecutionOperation) Ensure(ctx context.Context, inst *installations.Ins
 		if err := controllerutil.SetControllerReference(inst.Info, exec, api.LandscaperScheme); err != nil {
 			return err
 		}
+		o.Scheme().Default(exec)
 		return nil
 	}); err != nil {
 		cond = lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -319,6 +319,7 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 	}
 
 	_, err = controllerruntime.CreateOrUpdate(ctx, o.Client(), subInst, func() error {
+		subInst.Spec.Context = inst.Spec.Context
 		subInst.Labels = map[string]string{
 			lsv1alpha1.EncompassedByLabel: inst.Name,
 		}
@@ -338,6 +339,7 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 			ExportDataMappings:  subInstTmpl.ExportDataMappings,
 		}
 
+		o.Scheme().Default(subInst)
 		return nil
 	})
 	if err != nil {

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -117,6 +117,7 @@ var _ = Describe("SubInstallation", func() {
 			Expect(si.Ensure(ctx)).To(Succeed())
 
 			Expect(resInst.Labels).To(HaveKeyWithValue(lsv1alpha1.EncompassedByLabel, "root"))
+			Expect(resInst.Spec.Context).To(Equal("default"))
 			Expect(resInst.Spec.ComponentDescriptor.Reference).NotTo(BeNil())
 			Expect(resInst.Spec.ComponentDescriptor.Reference.RepositoryContext.Object).To(gstruct.MatchKeys(0, gstruct.Keys{
 				"type":    Equal("ociRegistry"),

--- a/pkg/utils/builders.go
+++ b/pkg/utils/builders.go
@@ -25,6 +25,7 @@ type DeployItemBuilder struct {
 	ProviderConfiguration runtime.Object
 	target                *lsv1alpha1.ObjectReference
 	annotations           map[string]string
+	Context               string
 }
 
 // NewDeployItemBuilder creates a new deploy item builder
@@ -110,6 +111,13 @@ func (b *DeployItemBuilder) AddAnnotation(key, val string) *DeployItemBuilder {
 	return b
 }
 
+// WithContext sets the Landscaper Context to use for the deployitem.
+// If not set explicitly, the default context will be used.
+func (b *DeployItemBuilder) WithContext(name string) *DeployItemBuilder {
+	b.Context = name
+	return b
+}
+
 // Build creates the deploy items using the given options.
 func (b *DeployItemBuilder) Build() (*lsv1alpha1.DeployItem, error) {
 	b.applyDefaults()
@@ -126,6 +134,7 @@ func (b *DeployItemBuilder) Build() (*lsv1alpha1.DeployItem, error) {
 	di.Spec.Type = lsv1alpha1.DeployItemType(b.Type)
 	di.Spec.Target = b.target
 	di.Spec.Configuration = ext
+	di.Spec.Context = b.Context
 
 	if b.ObjectKey != nil {
 		di.Namespace = b.ObjectKey.Namespace
@@ -134,6 +143,11 @@ func (b *DeployItemBuilder) Build() (*lsv1alpha1.DeployItem, error) {
 	if b.annotations != nil {
 		di.SetAnnotations(b.annotations)
 	}
+
+	if len(di.Spec.Context) == 0 {
+		di.Spec.Context = lsv1alpha1.DefaultContextName
+	}
+
 	return di, nil
 }
 

--- a/test/utils/cnudie.go
+++ b/test/utils/cnudie.go
@@ -42,7 +42,9 @@ func CreateDefaultContext(ctx context.Context, kubeClient client.Client, repoCtx
 		lsCtx.Name = lsv1alpha1.DefaultContextName
 		lsCtx.Namespace = ns
 		if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, lsCtx, func() error {
-			lsCtx.RepositoryContext = MakeRepositoryContext(repoCtx)
+			if repoCtx != nil {
+				lsCtx.RepositoryContext = MakeRepositoryContext(repoCtx)
+			}
 			return nil
 		}); err != nil {
 			return err

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -104,6 +104,15 @@ func InitStateWithNamespace(ctx context.Context, c client.Client) (*State, error
 	}
 	state.Namespace = ns.Name
 
+	/*
+		defaultContext := &lsv1alpha1.Context{}
+		defaultContext.Name = "default"
+		defaultContext.Namespace = state.Namespace
+		if err := c.Create(ctx, defaultContext); err != nil {
+			return nil, err
+		}
+	*/
+
 	return state, nil
 }
 
@@ -232,6 +241,12 @@ func decodeAndAppendLSObject(data []byte, objects []client.Object, state *State)
 		}
 		state.Targets[types.NamespacedName{Name: target.Name, Namespace: target.Namespace}.String()] = target
 		return append(objects, target), nil
+	case ContextGVK.Kind:
+		context := &lsv1alpha1.Context{}
+		if _, _, err := decoder.Decode(data, nil, context); err != nil {
+			return nil, fmt.Errorf("unable to decode file as context: %w", err)
+		}
+		return append(objects, context), nil
 	case SecretGVK.Kind:
 		secret := &corev1.Secret{}
 		if _, _, err := decoder.Decode(data, nil, secret); err != nil {

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -103,16 +103,6 @@ func InitStateWithNamespace(ctx context.Context, c client.Client) (*State, error
 		return nil, err
 	}
 	state.Namespace = ns.Name
-
-	/*
-		defaultContext := &lsv1alpha1.Context{}
-		defaultContext.Name = "default"
-		defaultContext.Namespace = state.Namespace
-		if err := c.Create(ctx, defaultContext); err != nil {
-			return nil, err
-		}
-	*/
-
 	return state, nil
 }
 

--- a/test/utils/envtest/types.go
+++ b/test/utils/envtest/types.go
@@ -20,6 +20,7 @@ var (
 	DeployItemGVK   schema.GroupVersionKind
 	DataObjectGVK   schema.GroupVersionKind
 	TargetGVK       schema.GroupVersionKind
+	ContextGVK      schema.GroupVersionKind
 	SecretGVK       schema.GroupVersionKind
 	ConfigMapGVK    schema.GroupVersionKind
 )
@@ -35,6 +36,8 @@ func init() {
 	DataObjectGVK, err = apiutil.GVKForObject(&lsv1alpha1.DataObject{}, api.LandscaperScheme)
 	utilruntime.Must(err)
 	TargetGVK, err = apiutil.GVKForObject(&lsv1alpha1.Target{}, api.LandscaperScheme)
+	utilruntime.Must(err)
+	ContextGVK, err = apiutil.GVKForObject(&lsv1alpha1.Context{}, api.LandscaperScheme)
 	utilruntime.Must(err)
 	SecretGVK, err = apiutil.GVKForObject(&corev1.Secret{}, api.LandscaperScheme)
 	utilruntime.Must(err)

--- a/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -46,6 +46,9 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -49,6 +49,9 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -138,3 +138,19 @@ func SetDefaults_Installation(obj *Installation) {
 		}
 	}
 }
+
+// SetDefaults_Execution sets default values for Execution objects
+func SetDefaults_Execution(obj *Execution) {
+	// default the repository context to "default"
+	if len(obj.Spec.Context) == 0 {
+		obj.Spec.Context = DefaultContextName
+	}
+}
+
+// SetDefaults_DeployItem sets default values for DeployItem objects
+func SetDefaults_DeployItem(obj *DeployItem) {
+	// default the repository context to "default"
+	if len(obj.Spec.Context) == 0 {
+		obj.Spec.Context = DefaultContextName
+	}
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -88,6 +88,9 @@ type DeployItemSpec struct {
 	// It is also used by the deployers to determine the ownernship.
 	// +optional
 	Target *ObjectReference `json:"target,omitempty"`
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -103,6 +103,10 @@ type Execution struct {
 
 // ExecutionSpec defines a execution plan.
 type ExecutionSpec struct {
+	// Context defines the current context of the installation.
+	// +optional
+	Context string `json:"context,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1516,6 +1516,7 @@ func Convert_core_DeployItemList_To_v1alpha1_DeployItemList(in *core.DeployItemL
 func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSpec, out *core.DeployItemSpec, s conversion.Scope) error {
 	out.Type = core.DeployItemType(in.Type)
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
+	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
@@ -1530,6 +1531,7 @@ func Convert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSpec, 
 func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployItemSpec, out *DeployItemSpec, s conversion.Scope) error {
 	out.Type = DeployItemType(in.Type)
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
+	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
@@ -1948,12 +1950,14 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 }
 
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
+	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
+	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.defaults.go
@@ -19,6 +19,10 @@ import (
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&Blueprint{}, func(obj interface{}) { SetObjectDefaults_Blueprint(obj.(*Blueprint)) })
+	scheme.AddTypeDefaultingFunc(&DeployItem{}, func(obj interface{}) { SetObjectDefaults_DeployItem(obj.(*DeployItem)) })
+	scheme.AddTypeDefaultingFunc(&DeployItemList{}, func(obj interface{}) { SetObjectDefaults_DeployItemList(obj.(*DeployItemList)) })
+	scheme.AddTypeDefaultingFunc(&Execution{}, func(obj interface{}) { SetObjectDefaults_Execution(obj.(*Execution)) })
+	scheme.AddTypeDefaultingFunc(&ExecutionList{}, func(obj interface{}) { SetObjectDefaults_ExecutionList(obj.(*ExecutionList)) })
 	scheme.AddTypeDefaultingFunc(&Installation{}, func(obj interface{}) { SetObjectDefaults_Installation(obj.(*Installation)) })
 	scheme.AddTypeDefaultingFunc(&InstallationList{}, func(obj interface{}) { SetObjectDefaults_InstallationList(obj.(*InstallationList)) })
 	return nil
@@ -26,6 +30,28 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_Blueprint(in *Blueprint) {
 	SetDefaults_Blueprint(in)
+}
+
+func SetObjectDefaults_DeployItem(in *DeployItem) {
+	SetDefaults_DeployItem(in)
+}
+
+func SetObjectDefaults_DeployItemList(in *DeployItemList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_DeployItem(a)
+	}
+}
+
+func SetObjectDefaults_Execution(in *Execution) {
+	SetDefaults_Execution(in)
+}
+
+func SetObjectDefaults_ExecutionList(in *ExecutionList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Execution(a)
+	}
 }
 
 func SetObjectDefaults_Installation(in *Installation) {


### PR DESCRIPTION
**How to categorize this PR?**

This PR is a follow-up of PR #372 since the original PR can't no longer be modified. 

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/priority 3

**What this PR does / why we need it**:

The context reference specified in the installation is now passed to the subinstallations, execution and deploy items.
With that it is now possible for the deployers to use namespaced secrets to access oci or other artifacts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The context reference is not properly passed to all DeployItems and subinstallations.
With that the deployers are now able to use the secrets defined in the Context to access remote artifacts.
This is especially useful for multi-tenant scenarios where everything should be isolated by the namespace.

```
