### PR TITLE
export ReferenceResolver type and detect cyclic dependencies

### DIFF
--- a/pkg/landscaper/jsonschema/reference.go
+++ b/pkg/landscaper/jsonschema/reference.go
@@ -40,17 +40,17 @@ type ReferenceContext struct {
 	ComponentResolver ctf.ComponentResolver
 }
 
-type referenceResolver struct {
+type ReferenceResolver struct {
 	*ReferenceContext
 }
 
-func NewReferenceResolver(refCtx *ReferenceContext) *referenceResolver {
-	return &referenceResolver{refCtx}
+func NewReferenceResolver(refCtx *ReferenceContext) *ReferenceResolver {
+	return &ReferenceResolver{refCtx}
 }
 
 // Resolve walks through the given json schema and recursively resolves all references which use one of
 // the "local", "blueprint", or "cd" schemes.
-func (rr *referenceResolver) Resolve(schemaBytes []byte) (interface{}, error) {
+func (rr *ReferenceResolver) Resolve(schemaBytes []byte) (interface{}, error) {
 	data, err := decodeJSON(schemaBytes)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (rr *referenceResolver) Resolve(schemaBytes []byte) (interface{}, error) {
 	return rr.resolve(data, field.NewPath(""))
 }
 
-func (rr *referenceResolver) resolve(data interface{}, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolve(data interface{}, currentPath *field.Path) (interface{}, error) {
 	switch typedData := data.(type) {
 	case map[string]interface{}:
 		return rr.resolveMap(typedData, currentPath)
@@ -69,7 +69,7 @@ func (rr *referenceResolver) resolve(data interface{}, currentPath *field.Path) 
 }
 
 // resolveMap is a helper function which can recursively resolve a map
-func (rr *referenceResolver) resolveMap(data map[string]interface{}, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath *field.Path) (interface{}, error) {
 	isRef, uri, err := checkForReference(data, currentPath)
 	if err != nil {
 		return err, nil
@@ -119,7 +119,7 @@ func checkForReference(data map[string]interface{}, currentPath *field.Path) (bo
 }
 
 // resolveList is a helper function which can recursively resolve a list
-func (rr *referenceResolver) resolveList(data []interface{}, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolveList(data []interface{}, currentPath *field.Path) (interface{}, error) {
 	resList := make([]interface{}, len(data))
 	for i, e := range data {
 		sub, err := rr.resolve(e, currentPath.Index(i))
@@ -132,7 +132,7 @@ func (rr *referenceResolver) resolveList(data []interface{}, currentPath *field.
 }
 
 // resolveReference resolves a reference
-func (rr *referenceResolver) resolveReference(s string, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolveReference(s string, currentPath *field.Path) (interface{}, error) {
 	uri, err := url.Parse(s)
 	if err != nil {
 		return nil, fmt.Errorf("invalid url: %w", err)
@@ -153,7 +153,7 @@ func (rr *referenceResolver) resolveReference(s string, currentPath *field.Path)
 	}, nil
 }
 
-func (rr *referenceResolver) handleLocalReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) handleLocalReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
 	if len(uri.Path) != 0 {
 		return nil, errors.New("a path is not supported for local resources")
 	}
@@ -172,7 +172,7 @@ func (rr *referenceResolver) handleLocalReference(uri *url.URL, currentPath *fie
 	return resolveFragment(uri, res)
 }
 
-func (rr *referenceResolver) handleBlueprintReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) handleBlueprintReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
 	if rr.BlueprintFs == nil {
 		return nil, errors.New("no filesystem defined to read a local schema")
 	}
@@ -192,7 +192,7 @@ func (rr *referenceResolver) handleBlueprintReference(uri *url.URL, currentPath 
 	return resolveFragment(uri, res)
 }
 
-func (rr *referenceResolver) handleComponentDescriptorReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
 	if rr.ComponentDescriptor == nil {
 		return nil, errors.New("no component descriptor defined to resolve the ref")
 	}

--- a/pkg/landscaper/jsonschema/reference.go
+++ b/pkg/landscaper/jsonschema/reference.go
@@ -45,6 +45,9 @@ type ReferenceResolver struct {
 }
 
 func NewReferenceResolver(refCtx *ReferenceContext) *ReferenceResolver {
+	if refCtx == nil {
+		refCtx = &ReferenceContext{}
+	}
 	return &ReferenceResolver{refCtx}
 }
 
@@ -55,21 +58,21 @@ func (rr *ReferenceResolver) Resolve(schemaBytes []byte) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rr.resolve(data, field.NewPath(""))
+	return rr.resolve(data, field.NewPath(""), nil)
 }
 
-func (rr *ReferenceResolver) resolve(data interface{}, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolve(data interface{}, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	switch typedData := data.(type) {
 	case map[string]interface{}:
-		return rr.resolveMap(typedData, currentPath)
+		return rr.resolveMap(typedData, currentPath, newStringSet(alreadyResolved))
 	case []interface{}:
-		return rr.resolveList(typedData, currentPath)
+		return rr.resolveList(typedData, currentPath, newStringSet(alreadyResolved))
 	}
 	return data, nil
 }
 
 // resolveMap is a helper function which can recursively resolve a map
-func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	isRef, uri, err := checkForReference(data, currentPath)
 	if err != nil {
 		return err, nil
@@ -77,7 +80,7 @@ func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath
 
 	if isRef {
 		// current map is a reference
-		sub, err := rr.resolveReference(uri, currentPath)
+		sub, err := rr.resolveReference(uri, currentPath, alreadyResolved)
 		if err != nil {
 			return nil, fmt.Errorf("error resolving reference at %s: %w", currentPath.Child(gojsonschema.KEY_REF).String(), err)
 		}
@@ -93,7 +96,7 @@ func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath
 			// map contains a reference
 			return nil, fmt.Errorf("invalid reference at %s: there are no other fields allowed next to %q", subPath.String(), gojsonschema.KEY_REF)
 		}
-		sub, err := rr.resolve(v, subPath)
+		sub, err := rr.resolve(v, subPath, alreadyResolved)
 		if err != nil {
 			return nil, err
 		}
@@ -119,10 +122,10 @@ func checkForReference(data map[string]interface{}, currentPath *field.Path) (bo
 }
 
 // resolveList is a helper function which can recursively resolve a list
-func (rr *ReferenceResolver) resolveList(data []interface{}, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolveList(data []interface{}, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	resList := make([]interface{}, len(data))
 	for i, e := range data {
-		sub, err := rr.resolve(e, currentPath.Index(i))
+		sub, err := rr.resolve(e, currentPath.Index(i), alreadyResolved)
 		if err != nil {
 			return nil, err
 		}
@@ -132,18 +135,26 @@ func (rr *ReferenceResolver) resolveList(data []interface{}, currentPath *field.
 }
 
 // resolveReference resolves a reference
-func (rr *ReferenceResolver) resolveReference(s string, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) resolveReference(s string, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	uri, err := url.Parse(s)
 	if err != nil {
 		return nil, fmt.Errorf("invalid url: %w", err)
 	}
+	if rr == nil || rr.ReferenceContext == nil {
+		return nil, fmt.Errorf("reference resolver/context must not be nil when resolving references")
+	}
+	refID := absoluteRef(rr.ComponentDescriptor, s)
+	if alreadyResolved.contains(refID) {
+		return nil, fmt.Errorf("cyclic references detected: reference %q from component %s:%s is part of a cycle", s, rr.ComponentDescriptor.Name, rr.ComponentDescriptor.Version)
+	}
+	alreadyResolved.add(refID)
 	switch uri.Scheme {
 	case "local":
-		return rr.handleLocalReference(uri, currentPath)
+		return rr.handleLocalReference(uri, currentPath, alreadyResolved)
 	case "blueprint":
-		return rr.handleBlueprintReference(uri, currentPath)
+		return rr.handleBlueprintReference(uri, currentPath, alreadyResolved)
 	case "cd":
-		return rr.handleComponentDescriptorReference(uri, currentPath)
+		return rr.handleComponentDescriptorReference(uri, currentPath, alreadyResolved)
 	}
 
 	// unknown reference scheme
@@ -153,7 +164,7 @@ func (rr *ReferenceResolver) resolveReference(s string, currentPath *field.Path)
 	}, nil
 }
 
-func (rr *ReferenceResolver) handleLocalReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) handleLocalReference(uri *url.URL, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	if len(uri.Path) != 0 {
 		return nil, errors.New("a path is not supported for local resources")
 	}
@@ -165,14 +176,14 @@ func (rr *ReferenceResolver) handleLocalReference(uri *url.URL, currentPath *fie
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling json into go struct: %w", err)
 	}
-	res, err := rr.resolve(data, currentPath)
+	res, err := rr.resolve(data, currentPath, alreadyResolved)
 	if err != nil {
 		return nil, err
 	}
 	return resolveFragment(uri, res)
 }
 
-func (rr *ReferenceResolver) handleBlueprintReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) handleBlueprintReference(uri *url.URL, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	if rr.BlueprintFs == nil {
 		return nil, errors.New("no filesystem defined to read a local schema")
 	}
@@ -185,14 +196,14 @@ func (rr *ReferenceResolver) handleBlueprintReference(uri *url.URL, currentPath 
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling json into go struct: %w", err)
 	}
-	res, err := rr.resolve(data, currentPath)
+	res, err := rr.resolve(data, currentPath, alreadyResolved)
 	if err != nil {
 		return nil, err
 	}
 	return resolveFragment(uri, res)
 }
 
-func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, currentPath *field.Path) (interface{}, error) {
+func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, currentPath *field.Path, alreadyResolved stringSet) (interface{}, error) {
 	if rr.ComponentDescriptor == nil {
 		return nil, errors.New("no component descriptor defined to resolve the ref")
 	}
@@ -254,7 +265,7 @@ func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, cu
 		BlueprintFs:         nil,
 		ComponentDescriptor: cd,
 		ComponentResolver:   rr.ComponentResolver,
-	}).resolve(data, currentPath)
+	}).resolve(data, currentPath, alreadyResolved)
 	if err != nil {
 		return nil, err
 	}
@@ -295,4 +306,33 @@ func resolveFragment(uri *url.URL, data interface{}) (interface{}, error) {
 		path = path.Child(f)
 	}
 	return current, nil
+}
+
+// auxiliary type
+type stringSet map[string]struct{}
+
+func (s stringSet) contains(key string) bool {
+	_, ok := s[key]
+	return ok
+}
+
+func (s stringSet) add(key string) {
+	s[key] = struct{}{}
+}
+
+// absoluteRef prefixes a given refstring with name and version of the component descriptor where it came from
+// this transforms the relative references into an absolute identifier
+func absoluteRef(cd *cdv2.ComponentDescriptor, ref string) string {
+	if cd == nil {
+		return ref
+	}
+	return fmt.Sprintf("%s:%s::%s", cd.Name, cd.Version, ref)
+}
+
+func newStringSet(old stringSet) stringSet {
+	res := stringSet{}
+	for k := range old {
+		res.add(k)
+	}
+	return res
 }

--- a/pkg/landscaper/jsonschema/reference.go
+++ b/pkg/landscaper/jsonschema/reference.go
@@ -140,9 +140,6 @@ func (rr *ReferenceResolver) resolveReference(s string, currentPath *field.Path,
 	if err != nil {
 		return nil, fmt.Errorf("invalid url: %w", err)
 	}
-	if rr == nil || rr.ReferenceContext == nil {
-		return nil, fmt.Errorf("reference resolver/context must not be nil when resolving references")
-	}
 	refID := absoluteRef(rr.ComponentDescriptor, s)
 	if alreadyResolved.contains(refID) {
 		return nil, fmt.Errorf("cyclic references detected: reference %q from component %s:%s is part of a cycle", s, rr.ComponentDescriptor.Name, rr.ComponentDescriptor.Version)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/kind api-change
/priority 3

**What this PR does / why we need it**:
This PR does two things:
1. The `ReferenceResolver` type is now public. This allows for better coding in the landscaper CLI tooling.
2. Cyclic references will now be detected instead of causing endless recursion.

**Special notes for your reviewer**:
Prerequisite for the landscaper CLI fix.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Cyclic references in jsonschema files are now detected and cause a corresponding error instead of getting the landscaper stuck in endless recursion.
```
