### PR TITLE
Prepare gardener

### DIFF
--- a/pkg/landscaper/installations/imports/helper.go
+++ b/pkg/landscaper/installations/imports/helper.go
@@ -86,6 +86,11 @@ func CheckCompletedSiblingDependents(ctx context.Context,
 			return false, false, nil
 		}
 
+		if inst.Generation != inst.Status.ObservedGeneration {
+			log.V(3).Info("dependent installation completed but not up-to-date", "inst", sourceRef.NamespacedName().String())
+			return false, false, nil
+		}
+
 		intInst := installations.CreateInternalInstallationBase(inst)
 
 		isCompleted, err = CheckCompletedSiblingDependents(ctx, kubeClient, contextName, intInst)

--- a/pkg/landscaper/installations/imports/validation.go
+++ b/pkg/landscaper/installations/imports/validation.go
@@ -390,7 +390,6 @@ func (v *Validator) checkStateForSiblingExport(ctx context.Context, fldPath *fie
 		return installations.NewNotCompletedDependentsErrorf(nil, "%s: Sibling Installation has to be completed to get exports", fldPath.String())
 	}
 
-	// todo: check generation of other components in the dependency tree
 	// we expect that no dependent siblings are running
 	isCompleted, err := CheckCompletedSiblingDependents(ctx, v.Operation.Client(), v.Operation.Context().Name, sibling)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Currently, the landscaper checks whether all dependents are in a final phase before starting to reconcile an installation. However, in theory this could lead to a race condition when multiple installations are updated simultaneously - if a depending installation performs this check after its dependents have been updated, but before the landscaper has put them into the pending phase, it will be reconciled as everything seems alright. This is not intended.

With this PR, the check now also verifies that `Status.ObservedGeneration == Generation`, which should prevent the mentioned case.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Before starting to reconcile an installation, landscaper now checks whether any installation it depends on has had an update which has not yet been processed and blocks the reconciliation if this is the case. This is identified by comparing the installations' `generation` to the `observedGeneration` in their status fields.
```
