### PR TITLE
Fix marshalling complete secrets

### DIFF
--- a/pkg/landscaper/installations/helper_test.go
+++ b/pkg/landscaper/installations/helper_test.go
@@ -170,7 +170,11 @@ var _ = Describe("helper", func() {
 			cm.Name = "test-cm"
 			cm.Namespace = "default"
 			cm.Data = map[string]string{
-				"key1": "\"val1\"",
+				"key1": `"val1"`,
+				"key2": `val2`,
+				"key3": `["a", "b", "c"]`,
+				"key4": `true`,
+				"key5": `{"x": {"y": "z"}}`,
 			}
 			Expect(kubeClient.Create(ctx, cm)).To(Succeed())
 
@@ -186,8 +190,54 @@ var _ = Describe("helper", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(owner).To(BeNil())
-			Expect(do.Data).To(Equal(map[string]interface{}{
-				"key1": "val1",
+
+			Expect(do.Data).To(HaveKeyWithValue("key1", "val1"))
+			Expect(do.Data).To(HaveKeyWithValue("key2", "val2"))
+			Expect(do.Data).To(HaveKeyWithValue("key3", []interface{}{"a", "b", "c"}))
+			Expect(do.Data).To(HaveKeyWithValue("key4", true))
+			Expect(do.Data).To(HaveKeyWithValue("key5", map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": "z",
+				},
+			}))
+		})
+
+		It("should get an import from the binary data of whole configmap as object", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+			cm := &corev1.ConfigMap{}
+			cm.Name = "test-cm"
+			cm.Namespace = "default"
+			cm.BinaryData = map[string][]byte{
+				"key1": []byte(`"val1"`),
+				"key2": []byte(`val2`),
+				"key3": []byte(`["a", "b", "c"]`),
+				"key4": []byte(`true`),
+				"key5": []byte(`{"x": {"y": "z"}}`),
+			}
+			Expect(kubeClient.Create(ctx, cm)).To(Succeed())
+
+			do, owner, err := installations.GetDataImport(ctx, kubeClient, "", &installations.InstallationBase{}, lsv1alpha1.DataImport{
+				Name: "imp",
+				ConfigMapRef: &lsv1alpha1.ConfigMapReference{
+					ObjectReference: lsv1alpha1.ObjectReference{
+						Name:      cm.Name,
+						Namespace: cm.Namespace,
+					},
+					Key: "",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(owner).To(BeNil())
+
+			Expect(do.Data).To(HaveKeyWithValue("key1", "val1"))
+			Expect(do.Data).To(HaveKeyWithValue("key2", "val2"))
+			Expect(do.Data).To(HaveKeyWithValue("key3", []interface{}{"a", "b", "c"}))
+			Expect(do.Data).To(HaveKeyWithValue("key4", true))
+			Expect(do.Data).To(HaveKeyWithValue("key5", map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": "z",
+				},
 			}))
 		})
 
@@ -248,7 +298,11 @@ var _ = Describe("helper", func() {
 			secret.Name = "test-secret"
 			secret.Namespace = "default"
 			secret.Data = map[string][]byte{
-				"key1": []byte("\"val1\""),
+				"key1": []byte(`"val1"`),
+				"key2": []byte(`val2`),
+				"key3": []byte(`["a", "b", "c"]`),
+				"key4": []byte(`true`),
+				"key5": []byte(`{"x": {"y": "z"}}`),
 			}
 			Expect(kubeClient.Create(ctx, secret)).To(Succeed())
 
@@ -264,8 +318,15 @@ var _ = Describe("helper", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(owner).To(BeNil())
-			Expect(do.Data).To(Equal(map[string]interface{}{
-				"key1": "val1",
+
+			Expect(do.Data).To(HaveKeyWithValue("key1", "val1"))
+			Expect(do.Data).To(HaveKeyWithValue("key2", "val2"))
+			Expect(do.Data).To(HaveKeyWithValue("key3", []interface{}{"a", "b", "c"}))
+			Expect(do.Data).To(HaveKeyWithValue("key4", true))
+			Expect(do.Data).To(HaveKeyWithValue("key5", map[string]interface{}{
+				"x": map[string]interface{}{
+					"y": "z",
+				},
 			}))
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority 3

**What this PR does / why we need it**:
This PR fixes issue #398 (Problem with marshalling complete secrets).

**Which issue(s) this PR fixes**:
Fixes #398 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- bugfix concerning the import of a complete secret or config map
```
