### PR TITLE
Ignore annotation and operation annotation improvements

### DIFF
--- a/apis/core/v1alpha1/constants.go
+++ b/apis/core/v1alpha1/constants.go
@@ -31,6 +31,10 @@ const (
 	// AbortTimestampAnnotation is used to recognize timeouts in deployitems
 	AbortTimestampAnnotation = "landscaper.gardener.cloud/abort-time"
 
+	// IgnoreAnnotation can be used to stop reconciliation for landscaper resources.
+	// Will only have an effect if set to 'true'.
+	IgnoreAnnotation = "landscaper.gardener.cloud/ignore"
+
 	// Labels
 
 	// LandscaperComponentLabelName is the name of the labels the holds the information about landscaper components.

--- a/apis/core/v1alpha1/helper/helpers.go
+++ b/apis/core/v1alpha1/helper/helpers.go
@@ -306,3 +306,11 @@ func CombinedExecutionPhase(phases ...v1alpha1.ExecutionPhase) v1alpha1.Executio
 	}
 	return v1alpha1.ExecutionPhase(CombinedInstallationPhase(intPhases...))
 }
+
+// HasIgnoreAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/ignore' annotation
+// and its value is 'true'.
+func HasIgnoreAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.IgnoreAnnotation]
+	return ok && v == "true"
+}

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -31,6 +31,10 @@ const (
 	// AbortTimestampAnnotation is used to recognize timeouts in deployitems
 	AbortTimestampAnnotation = "landscaper.gardener.cloud/abort-time"
 
+	// IgnoreAnnotation can be used to stop reconciliation for landscaper resources.
+	// Will only have an effect if set to 'true'.
+	IgnoreAnnotation = "landscaper.gardener.cloud/ignore"
+
 	// Labels
 
 	// LandscaperComponentLabelName is the name of the labels the holds the information about landscaper components.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 - [Component Overwrites](./usage/ComponentOverwrites.md)
 - [Conditional Imports](./usage/ConditionalImports.md)
 - [Context](./usage/Context.md)
+- [Controlling the Landscaper via annotations](./usage/Annotations.md)
 
 ### Deployers
 - [Overview](./deployer)

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -21,7 +21,7 @@ The operation annotation is removed during the reconciliation.
 **force-reconcile**
 This enforces a redeployment of executions and subinstallations. The checks, whether any of them is still progressing or the installation's imports are outdated, are skipped.
 In order to fix potentially broken executions of subinstallations, the force-reconcile annotation will be propagated to the subinstallations.
-The operation annotation is removed during the force-reconciliation.
+The operation annotation is removed during the reconciliation.
 
 **abort**
 If the abort operation annotation is set, a reconcile will be stopped before checking whether the installation needs to be updated.
@@ -31,25 +31,32 @@ The abort operation annotation is not removed automatically.
 #### Effect on Executions
 
 **reconcile**
-TODO
+When the landscaper finds a reconcile operation annotation on an execution, it will set its phase to `Init`. This will trigger a standard reconciliation.
+The operation annotation is removed during the reconciliation.
 
 **force-reconcile**
-TODO
+The force-reconcile annotation will also set the phase to `Init`, but it causes the landscaper to skip the checks whether the deployitems are up-to-date and they will be redeployed in every case.
+This will not (re)deploy deployitems which depend on another deployitem that is not finished and up-to-date.
+The operation annotation is removed during the reconciliation.
 
 **abort**
-TODO
+The abort operation is not implemented for executions. As executions are just an intermediate helper struct to deploy deployitems, there is no need for them to be aborted anyway.
+If any of the deployitems finishes with a non-`Succeeded` phase, deployitems which depend on it won't be deployed, so it is possible to interrupt the flow of the deployitems by aborting the one which is currently running.
 
 
 #### Effect on DeployItems
 
 **reconcile**
-TODO
+The reconcile operation annotation causes the landscaper to set the deployitem's phase to `Init`, which will trigger a standard reconciliation.
+The operation annotation is removed during the reconciliation.
 
 **force-reconcile**
-TODO
+The force-reconcile operation annotation behaves similarly to the reconcile operation annotation, but it will call the deployer's `ForceReconcile` method instead of the `Reconcile` one. How both methods differ depends on the deployer implementation.
+The operation annotation is removed during the reconciliation.
 
 **abort**
-TODO
+The deployer's `Abort` method will be called. The effect depends on the deployer implementation.
+The abort operation annotation is not removed automatically.
 
 
 ## Ignore Annotation
@@ -61,4 +68,4 @@ TODO
 #### Effect on Installations/Executions/DeployItems
 
 The effect of this annotation is the same for all landscaper resources: the respective resource will not be reconciled by the landscaper, even if its spec changed or the operation annotation says otherwise. Only resources in a final phase are affected, to interrupt a running installation/execution/deployitem, the `landscaper.gardener.cloud/operation=abort` annotation has to be used.
-Please note that as long as an update of a resource is blocked from reconciliation by this annotation, all other landscaper resources which are waiting for the update (because they depend on the resource) won't be able to be reconciled either and will be stuck in the `PendingDependencies` phase.
+Please note that as long as an update of a resource is blocked from reconciliation by this annotation, all other landscaper resources which are waiting for the update (because they depend on the resource) won't be able to be reconciled either and will be stuck.

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -15,19 +15,23 @@ Please note that the effects which an annotation has on a deployitem depend on t
 #### Effect on Installations
 
 **reconcile**
-The installation will be queued for reconciliation just as if someone had changed its `spec`. The operation annotation will be removed during the reconciliation.
+The installation will be queued for reconciliation. This is the standard way of triggering an installation without changing its spec. Note that the landscaper checks whether the installation is up-to-date, so setting this annotation will not necessarily result in redeploying the executions and subinstallations. 
+The operation annotation is removed during the reconciliation.
 
 **force-reconcile**
-TODO
+This enforces a redeployment of executions and subinstallations. The checks, whether any of them is still progressing or the installation's imports are outdated, are skipped.
+In order to fix potentially broken executions of subinstallations, the force-reconcile annotation will be propagated to the subinstallations.
+The operation annotation is removed during the force-reconciliation.
 
 **abort**
-TODO
+If the abort operation annotation is set, a reconcile will be stopped before checking whether the installation needs to be updated.
+The abort operation annotation is not removed automatically.
 
 
 #### Effect on Executions
 
 **reconcile**
-Equivalent to the effect on installations.
+TODO
 
 **force-reconcile**
 TODO
@@ -39,7 +43,7 @@ TODO
 #### Effect on DeployItems
 
 **reconcile**
-Equivalent to the effect on installations.
+TODO
 
 **force-reconcile**
 TODO

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -1,0 +1,60 @@
+# Controlling the Landscaper via Annotations
+
+There are a few annotations which can be set on landscaper objects to influence the reconciliation flow.
+
+Please note that the effects which an annotation has on a deployitem depend on the implementation of the deployer responsible for that deployitem. Depending on the functionality of the deployer, developers might decide to deviate from the expected behavior (e.g. if deployitems of that type cannot be aborted). The 'effects on deployitems' described below therefore describe the default case, as it is implemented by the deployer library (as far as possible). 
+
+## Operation Annotation
+
+**Annotation:** `landscaper.gardener.cloud/operation`
+**Accepted values:**
+  - `reconcile`
+  - `force-reconcile`
+  - `abort`
+
+#### Effect on Installations
+
+**reconcile**
+The installation will be queued for reconciliation just as if someone had changed its `spec`. The operation annotation will be removed during the reconciliation.
+
+**force-reconcile**
+TODO
+
+**abort**
+TODO
+
+
+#### Effect on Executions
+
+**reconcile**
+Equivalent to the effect on installations.
+
+**force-reconcile**
+TODO
+
+**abort**
+TODO
+
+
+#### Effect on DeployItems
+
+**reconcile**
+Equivalent to the effect on installations.
+
+**force-reconcile**
+TODO
+
+**abort**
+TODO
+
+
+## Ignore Annotation
+
+**Annotation:** `landscaper.gardener.cloud/ignore`
+**Accepted values:**
+  - `true`
+
+#### Effect on Installations/Executions/DeployItems
+
+The effect of this annotation is the same for all landscaper resources: the respective resource will not be reconciled by the landscaper, even if its spec changed or the operation annotation says otherwise. Only resources in a final phase are affected, to interrupt a running installation/execution/deployitem, the `landscaper.gardener.cloud/operation=abort` annotation has to be used.
+Please note that as long as an update of a resource is blocked from reconciliation by this annotation, all other landscaper resources which are waiting for the update (because they depend on the resource) won't be able to be reconciled either and will be stuck in the `PendingDependencies` phase.

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -67,5 +67,5 @@ The abort operation annotation is not removed automatically.
 
 #### Effect on Installations/Executions/DeployItems
 
-The effect of this annotation is the same for all landscaper resources: the respective resource will not be reconciled by the landscaper, even if its spec changed or the operation annotation says otherwise. Only resources in a final phase are affected, to interrupt a running installation/execution/deployitem, the `landscaper.gardener.cloud/operation=abort` annotation has to be used.
+The effect of this annotation is the same for all landscaper resources: the respective resource will not be reconciled by the landscaper, even if its spec changed or the operation annotation says otherwise. Only resources in a non-final phase are affected, to interrupt a running installation/execution/deployitem, the `landscaper.gardener.cloud/operation: abort` annotation has to be used. The phases `Succeeded`, `Failed`, and `Aborted` are considered to be final.
 Please note that as long as an update of a resource is blocked from reconciliation by this annotation, all other landscaper resources which are waiting for the update (because they depend on the resource) won't be able to be reconciled either and will be stuck.

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -171,6 +171,13 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		return reconcile.Result{}, err
 	}
+
+	// don't reconcile if ignore annotation is set and installation is not currently running
+	if lsv1alpha1helper.HasIgnoreAnnotation(di.ObjectMeta) && lsv1alpha1helper.IsCompletedExecutionPhase(di.Status.Phase) {
+		logger.V(7).Info("skipping reconcile due to ignore annotation")
+		return reconcile.Result{}, nil
+	}
+
 	c.lsScheme.Default(di)
 
 	errHdl := HandleErrorFunc(logger, c.lsClient, c.lsEventRecorder, di)

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -275,6 +275,11 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if hookRes.AbortReconcile {
 			return returnAndLogReconcileResult(logger, *hookRes), nil
 		}
+		logger.V(5).Info("removing reconcile annotation")
+		delete(di.ObjectMeta.Annotations, lsv1alpha1.OperationAnnotation)
+		if err := c.lsClient.Update(ctx, di); err != nil {
+			return reconcile.Result{}, err
+		}
 		if err := errHdl(ctx, c.deployer.ForceReconcile(ctx, lsCtx, di, target)); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -41,11 +41,14 @@ func HandleAnnotationsAndGeneration(ctx context.Context,
 	deployerInfo lsv1alpha1.DeployerInformation) error {
 	changedMeta := false
 	hasReconcileAnnotation := lsv1alpha1helper.HasOperation(di.ObjectMeta, lsv1alpha1.ReconcileOperation)
-	if hasReconcileAnnotation || di.Status.ObservedGeneration != di.Generation {
+	hasForceReconcileAnnotation := lsv1alpha1helper.HasOperation(di.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
+	if hasReconcileAnnotation || hasForceReconcileAnnotation || di.Status.ObservedGeneration != di.Generation {
 		// reconcile necessary due to one of
 		// - reconcile annotation
+		// - force-reconcile annotation
 		// - outdated generation
-		log.V(5).Info("reconcile required, setting observed generation, phase, and last change reconcile timestamp", "reconcileAnnotation", hasReconcileAnnotation, "observedGeneration", di.Status.ObservedGeneration, "generation", di.Generation)
+		opAnn := lsv1alpha1helper.GetOperation(di.ObjectMeta)
+		log.V(5).Info("reconcile required, setting observed generation, phase, and last change reconcile timestamp", "operationAnnotation", opAnn, "observedGeneration", di.Status.ObservedGeneration, "generation", di.Generation)
 		if err := PrepareReconcile(ctx, log, kubeClient, di, deployerInfo); err != nil {
 			return err
 		}

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -58,6 +58,12 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
+	// don't reconcile if ignore annotation is set and execution is not currently running
+	if lsv1alpha1helper.HasIgnoreAnnotation(exec.ObjectMeta) && lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) {
+		logger.V(7).Info("skipping reconcile due to ignore annotation")
+		return reconcile.Result{}, nil
+	}
+
 	errHdl := HandleErrorFunc(logger, c.client, c.eventRecorder, exec)
 
 	if err := HandleAnnotationsAndGeneration(ctx, logger, c.client, exec); err != nil {

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -157,6 +157,8 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, errHdl(ctx, c.reconcile(ctx, inst))
 }
 
+// initPrerequisites prepares installation operations by fetching context and registries, resolving the blueprint and creating an internal installation.
+// It does not modify the installation resource in the cluster in any way.
 func (c *Controller) initPrerequisites(ctx context.Context, inst *lsv1alpha1.Installation) (*installations.Operation, error) {
 	currOp := "InitPrerequisites"
 	op := c.Operation.Copy()

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -99,6 +99,13 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		return reconcile.Result{}, err
 	}
+
+	// don't reconcile if ignore annotation is set and installation is not currently running
+	if lsv1alpha1helper.HasIgnoreAnnotation(inst.ObjectMeta) && lsv1alpha1helper.IsCompletedInstallationPhase(inst.Status.Phase) {
+		logger.V(7).Info("skipping reconcile due to ignore annotation")
+		return reconcile.Result{}, nil
+	}
+
 	// default the installation as it not done by the Controller runtime
 	api.LandscaperScheme.Default(inst)
 	errHdl := HandleErrorFunc(logger, c.Client(), c.EventRecorder(), inst)

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -75,7 +75,7 @@ func (c *Controller) reconcile(ctx context.Context, inst *lsv1alpha1.Installatio
 	if eligibleToUpdate {
 		inst.Status.Phase = lsv1alpha1.ComponentPhasePending
 		// need to return and not continue with export validation
-		return c.Update(ctx, instOp)
+		return c.Update(ctx, instOp, false)
 	}
 
 	if combinedState != lsv1alpha1.ComponentPhaseSucceeded {
@@ -115,7 +115,7 @@ func (c *Controller) forceReconcile(ctx context.Context, inst *lsv1alpha1.Instal
 	}
 
 	instOp.Inst.Info.Status.Phase = lsv1alpha1.ComponentPhasePending
-	if err := c.Update(ctx, instOp); err != nil {
+	if err := c.Update(ctx, instOp, true); err != nil {
 		return err
 	}
 
@@ -152,7 +152,7 @@ func (c *Controller) eligibleToUpdate(ctx context.Context, op *installations.Ope
 }
 
 // Update redeploys subinstallations and deploy items.
-func (c *Controller) Update(ctx context.Context, op *installations.Operation) error {
+func (c *Controller) Update(ctx context.Context, op *installations.Operation, forced bool) error {
 	currOp := "Validate"
 	inst := op.Inst
 
@@ -184,6 +184,7 @@ func (c *Controller) Update(ctx context.Context, op *installations.Operation) er
 	inst.Info.Status.Phase = lsv1alpha1.ComponentPhaseProgressing
 
 	subinstallation := subinstallations.New(op)
+	subinstallation.Forced = forced
 	if err := subinstallation.Ensure(ctx); err != nil {
 		return err
 	}

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -38,7 +38,7 @@ func (c *Controller) handleDelete(ctx context.Context, inst *lsv1alpha1.Installa
 		if err != nil {
 			return err
 		}
-		if err := c.Update(ctx, instOp); err != nil {
+		if err := c.Update(ctx, instOp, false); err != nil {
 			return err
 		}
 		if err := DeleteExecutionAndSubinstallations(ctx, instOp); err != nil {
@@ -108,7 +108,7 @@ func (c *Controller) handleDelete(ctx context.Context, inst *lsv1alpha1.Installa
 	if eligibleToUpdate {
 		log.V(2).Info("installation outdated. Updating before deletion.")
 		inst.Status.Phase = lsv1alpha1.ComponentPhasePending
-		if err := c.Update(ctx, instOp); err != nil {
+		if err := c.Update(ctx, instOp, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/landscaper/installations/subinstallations/operation.go
+++ b/pkg/landscaper/installations/subinstallations/operation.go
@@ -9,11 +9,13 @@ import "github.com/gardener/landscaper/pkg/landscaper/installations"
 // Operation contains all subinstallation operations
 type Operation struct {
 	*installations.Operation
+	Forced bool
 }
 
 // New creates a new subinstallation operation
 func New(op *installations.Operation) *Operation {
 	return &Operation{
 		Operation: op,
+		Forced:    false,
 	}
 }

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -328,6 +328,10 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 		subInst.Annotations = map[string]string{
 			lsv1alpha1.SubinstallationNameAnnotation: subInstTmpl.Name,
 		}
+		if o.Forced {
+			// propagate force-reconcile annotation to subinstallations
+			lsv1alpha1helper.SetOperation(&subInst.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
+		}
 		if err := controllerutil.SetControllerReference(inst, subInst, o.Scheme()); err != nil {
 			return errors.Wrapf(err, "unable to set owner reference")
 		}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -31,6 +31,10 @@ const (
 	// AbortTimestampAnnotation is used to recognize timeouts in deployitems
 	AbortTimestampAnnotation = "landscaper.gardener.cloud/abort-time"
 
+	// IgnoreAnnotation can be used to stop reconciliation for landscaper resources.
+	// Will only have an effect if set to 'true'.
+	IgnoreAnnotation = "landscaper.gardener.cloud/ignore"
+
 	// Labels
 
 	// LandscaperComponentLabelName is the name of the labels the holds the information about landscaper components.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -306,3 +306,11 @@ func CombinedExecutionPhase(phases ...v1alpha1.ExecutionPhase) v1alpha1.Executio
 	}
 	return v1alpha1.ExecutionPhase(CombinedInstallationPhase(intPhases...))
 }
+
+// HasIgnoreAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/ignore' annotation
+// and its value is 'true'.
+func HasIgnoreAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.IgnoreAnnotation]
+	return ok && v == "true"
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 2

**What this PR does / why we need it**:
Adds an 'ignore' annotation to disable landscaper operations on specific resources.
Also slightly modifies the effects of operation annotations - especially force-reconcile - to be more consistent.
Adds documentation for the annotations.

**Which issue(s) this PR fixes**:
Part of #408 
Fixes #399 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to annotate Installations, Executions, and DeployItems with `landscaper.gardener.cloud/ignore: true`. This will prevent reconciliation of the respective resource. Please note that this blocks reconciliation of depending resources and the annotation is neither set nor removed by Landscaper itself. See the new [Annotations documentation](docs/usage/Annotations.md) for details.
```
```bugfix user
The `landscaper.gardener.cloud/operation: force-reconcile` annotation on an Installation is now propagated to all subinstallations of that installation. This ensures that not only the direct Executions of that Installation are reconciled, but also the transitive ones.
```