### PR TITLE
order subinstallations by dependencies

### DIFF
--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -148,6 +148,8 @@ const (
 	ErrorReadinessCheckTimeout ErrorCode = "ERR_READINESS_CHECK_TIMEOUT"
 	// ErrorTimeout indicates that an operation timed out.
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
+	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
+	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 )
 
 // Condition holds the information about the state of a resource.

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -155,6 +155,8 @@ const (
 	ErrorReadinessCheckTimeout ErrorCode = "ERR_READINESS_CHECK_TIMEOUT"
 	// ErrorTimeout indicates that an operation timed out.
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
+	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
+	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes
@@ -163,6 +165,7 @@ var UnrecoverableErrorCodes = []ErrorCode{
 	ErrorInternalProblem,
 	ErrorReadinessCheckTimeout,
 	ErrorTimeout,
+	ErrorCyclicDependencies,
 }
 
 // Condition holds the information about the state of a resource.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -148,6 +148,8 @@ const (
 	ErrorReadinessCheckTimeout ErrorCode = "ERR_READINESS_CHECK_TIMEOUT"
 	// ErrorTimeout indicates that an operation timed out.
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
+	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
+	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 )
 
 // Condition holds the information about the state of a resource.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -155,6 +155,8 @@ const (
 	ErrorReadinessCheckTimeout ErrorCode = "ERR_READINESS_CHECK_TIMEOUT"
 	// ErrorTimeout indicates that an operation timed out.
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
+	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
+	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes
@@ -163,6 +165,7 @@ var UnrecoverableErrorCodes = []ErrorCode{
 	ErrorInternalProblem,
 	ErrorReadinessCheckTimeout,
 	ErrorTimeout,
+	ErrorCyclicDependencies,
 }
 
 // Condition holds the information about the state of a resource.

--- a/pkg/landscaper/installations/subinstallations/helper.go
+++ b/pkg/landscaper/installations/subinstallations/helper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/component-spec/bindings-go/codec"
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -106,15 +107,121 @@ func GetBlueprintDefinitionFromInstallationTemplate(
 	return subBlueprint, cdDef, nil
 }
 
+// ComputeSubinstallationDependencies computes the dependencies between the given subinstallations.
+// It checks for every import of every subinstallation, whether that import is exported from another subinstallation.
+// The resulting map contains one entry for every given subinstallation template, mapping that templates name to the
+// set of templates (by name) it depends on.
+func ComputeSubinstallationDependencies(installationTmpl []*lsv1alpha1.InstallationTemplate) map[string]sets.String {
+	dataExports := map[string]string{}
+	targetExports := map[string]string{}
+	for _, tmpl := range installationTmpl {
+		for _, exp := range tmpl.Exports.Data {
+			dataExports[exp.DataRef] = tmpl.Name
+		}
+		for _, exp := range tmpl.Exports.Targets {
+			targetExports[exp.Target] = tmpl.Name
+		}
+	}
+
+	deps := map[string]sets.String{}
+	for _, tmpl := range installationTmpl {
+		tmp := sets.NewString()
+		for _, imp := range tmpl.Imports.Data {
+			if len(imp.DataRef) == 0 {
+				// only dataRef imports can refer to sibling exports
+				continue
+			}
+			source, ok := dataExports[imp.DataRef]
+			if !ok {
+				// no sibling exports this import, it has to come from the parent
+				// this is already checked by validation, no need to verify it here
+				continue
+			}
+			tmp.Insert(source)
+		}
+		for _, imp := range tmpl.Imports.Targets {
+			targets := []string{}
+			if len(imp.Target) != 0 {
+				targets = append(targets, imp.Target)
+			} else if len(imp.Targets) != 0 {
+				targets = imp.Targets
+			} else {
+				// targetListReferences can only refer to parent imports, not to sibling exports
+				continue
+			}
+			for _, t := range targets {
+				source, ok := targetExports[t]
+				if !ok {
+					// no sibling exports this import, it has to come from the parent
+					// this is already checked by validation, no need to verify it here
+					continue
+				}
+				tmp.Insert(source)
+			}
+		}
+		deps[tmpl.Name] = tmp
+	}
+	return deps
+}
+
+// OrderInstallationTemplates takes a list of installation templates and orders them according to their dependencies (as computed by ComputeSubinstallationDependencies).
+// Installation templates which have been put into the new order are referred to as 'scheduled'.
+func OrderInstallationTemplates(installationTmpl []*lsv1alpha1.InstallationTemplate) ([]*lsv1alpha1.InstallationTemplate, error) {
+	// 'done' and 'ordered' more or less contain the same information:
+	// which installation templates have been ordered yet.
+	// 'ordered' is a list to preserve the computed order,
+	// while 'done' is a set to efficiently check whether a specific installation template is already scheduled.
+	ordered := []*lsv1alpha1.InstallationTemplate{}
+	done := sets.NewString()
+	dependencies := ComputeSubinstallationDependencies(installationTmpl)
+	// repeat until either
+	// - all items from installationTmpl have been transferred to ordered (we are finished)
+	// - no new items have been scheduled during the last run
+	//   which hints that all items left are part of a cycle and the dependencies cannot be resolved
+	for oldSize := -1; oldSize != len(done) && len(ordered) != len(installationTmpl); {
+		oldSize = len(done)
+		for _, tmpl := range installationTmpl {
+			// skip if already scheduled
+			if done.Has(tmpl.Name) {
+				continue
+			}
+			// verify that all dependencies of the current subinstallation are already scheduled
+			deps, ok := dependencies[tmpl.Name]
+			if !ok {
+				return nil, fmt.Errorf("subinstallation template %q not found in dependency hierarchy", tmpl.Name)
+			}
+			if len(deps) > len(done) {
+				// installation template has more dependencies than are currently scheduled
+				// so we don't have to check whether all of them are fulfilled because at least one won't be
+				continue
+			}
+			canBeScheduled := true
+			for d := range deps {
+				if !done.Has(d) {
+					// at least one dependency has not been scheduled yet
+					canBeScheduled = false
+					break
+				}
+			}
+			// schedule subinstallation, if possible
+			if canBeScheduled {
+				ordered = append(ordered, tmpl)
+				done.Insert(tmpl.Name)
+			}
+		}
+	}
+	if len(done) != len(installationTmpl) || len(ordered) != len(installationTmpl) { // these comparisons should be equivalent, just checking both to be sure ...
+		// TODO: give more information on cyclic dependency
+		return nil, fmt.Errorf("cyclic dependency detected")
+	}
+	return ordered, nil
+}
+
 // ValidateSubinstallations validates the installation templates in context of the current blueprint.
 func (o *Operation) ValidateSubinstallations(installationTmpl []*lsv1alpha1.InstallationTemplate) error {
-	coreInstTmpls := make([]*core.InstallationTemplate, len(installationTmpl))
-	for i, tmpl := range installationTmpl {
-		coreTmpl := &core.InstallationTemplate{}
-		if err := lsv1alpha1.Convert_v1alpha1_InstallationTemplate_To_core_InstallationTemplate(tmpl, coreTmpl, nil); err != nil {
-			return err
-		}
-		coreInstTmpls[i] = coreTmpl
+	coreInstTmpls, err := convertToCoreInstallationTemplates(installationTmpl)
+	if err != nil {
+		return err
 	}
 
 	coreImports, err := o.buildCoreImports(o.Inst.Blueprint.Info.Imports)
@@ -126,6 +233,19 @@ func (o *Operation) ValidateSubinstallations(installationTmpl []*lsv1alpha1.Inst
 		return o.NewError(allErrs.ToAggregate(), "ValidateSubInstallations", allErrs.ToAggregate().Error())
 	}
 	return nil
+}
+
+// convertToCoreInstallationTemplates converts a list of v1alpha1 InstallationTemplates to their core version
+func convertToCoreInstallationTemplates(installationTmpl []*lsv1alpha1.InstallationTemplate) ([]*core.InstallationTemplate, error) {
+	coreInstTmpls := make([]*core.InstallationTemplate, len(installationTmpl))
+	for i, tmpl := range installationTmpl {
+		coreTmpl := &core.InstallationTemplate{}
+		if err := lsv1alpha1.Convert_v1alpha1_InstallationTemplate_To_core_InstallationTemplate(tmpl, coreTmpl, nil); err != nil {
+			return nil, err
+		}
+		coreInstTmpls[i] = coreTmpl
+	}
+	return coreInstTmpls, nil
 }
 
 // buildCoreImports converts the given list of versioned ImportDefinitions (potentially containing nested conditional imports) into a flattened list of core ImportDefinitions.

--- a/pkg/landscaper/installations/subinstallations/helper.go
+++ b/pkg/landscaper/installations/subinstallations/helper.go
@@ -118,6 +118,9 @@ func ComputeSubinstallationDependencies(installationTmpl []*lsv1alpha1.Installat
 		for _, exp := range tmpl.Exports.Data {
 			dataExports[exp.DataRef] = tmpl.Name
 		}
+		for exp := range tmpl.ExportDataMappings {
+			dataExports[exp] = tmpl.Name
+		}
 		for _, exp := range tmpl.Exports.Targets {
 			targetExports[exp.Target] = tmpl.Name
 		}

--- a/pkg/landscaper/installations/subinstallations/helper_test.go
+++ b/pkg/landscaper/installations/subinstallations/helper_test.go
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package subinstallations_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations"
+)
+
+var _ = Describe("SubinstallationsHelper", func() {
+
+	Context("DependencyComputation", func() {
+
+		It("should not compute dependencies for independent installation templates", func() {
+			deps := map[string][]string{
+				"a": nil,
+				"b": nil,
+				"c": nil,
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(dataDependency))
+			computedDeps := subinstallations.ComputeSubinstallationDependencies(tmpls)
+			for k, v := range computedDeps {
+				Expect(v).To(BeEmpty(), "entry %q has non-empty dependency list", k)
+			}
+		})
+
+		It("should correctly detect data dependencies", func() {
+			deps := map[string][]string{
+				"a": nil,
+				"b": {"a"},
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(dataDependency))
+			computedDeps := subinstallations.ComputeSubinstallationDependencies(tmpls)
+			Expect(computedDeps).To(HaveKeyWithValue("b", HaveKey("a")))
+		})
+		It("should correctly detect target dependencies", func() {
+			deps := map[string][]string{
+				"a": nil,
+				"b": {"a"},
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(targetDependency))
+			computedDeps := subinstallations.ComputeSubinstallationDependencies(tmpls)
+			Expect(computedDeps).To(HaveKeyWithValue("b", HaveKey("a")))
+		})
+		It("should correctly detect dependencies defined in exportDataMappings", func() {
+			deps := map[string][]string{
+				"a": nil,
+				"b": {"a"},
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(mappingDependency))
+			computedDeps := subinstallations.ComputeSubinstallationDependencies(tmpls)
+			Expect(computedDeps).To(HaveKeyWithValue("b", HaveKey("a")))
+		})
+
+	})
+
+	Context("InstallationTemplateOrdering", func() {
+
+		It("should return independent installation templates in the same order they were given", func() {
+			deps := map[string][]string{
+				"a": nil,
+				"b": nil,
+				"c": nil,
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(dataDependency))
+			ordered, err := subinstallations.OrderInstallationTemplates(tmpls)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ordered).To(Equal(tmpls))
+		})
+
+		It("should correctly order based on data dependencies", func() {
+			deps := map[string][]string{
+				"a": {"b"},
+				"b": nil,
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(dataDependency))
+			sortInstallationTemplatesAlphabetically(tmpls)
+			ordered, err := subinstallations.OrderInstallationTemplates(tmpls)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(installationTemplatesToNames(ordered)).To(Equal([]string{"b", "a"}))
+		})
+		It("should correctly order based on target dependencies", func() {
+			deps := map[string][]string{
+				"a": {"b"},
+				"b": nil,
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(targetDependency))
+			sortInstallationTemplatesAlphabetically(tmpls)
+			ordered, err := subinstallations.OrderInstallationTemplates(tmpls)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(installationTemplatesToNames(ordered)).To(Equal([]string{"b", "a"}))
+		})
+		It("should correctly order based on dependencies defined in exportDataMappings", func() {
+			deps := map[string][]string{
+				"a": {"b"},
+				"b": nil,
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(mappingDependency))
+			sortInstallationTemplatesAlphabetically(tmpls)
+			ordered, err := subinstallations.OrderInstallationTemplates(tmpls)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(installationTemplatesToNames(ordered)).To(Equal([]string{"b", "a"}))
+		})
+
+		It("should correctly order based on dependencies", func() {
+			deps := map[string][]string{
+				"a": {"f"},
+				"b": nil,
+				"c": {"b"},
+				"d": {"b"},
+				"e": {"b", "c"},
+				"f": {"e"},
+				"g": nil,
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(mixedDependency))
+			sortInstallationTemplatesAlphabetically(tmpls)
+			ordered, err := subinstallations.OrderInstallationTemplates(tmpls)
+			Expect(err).ToNot(HaveOccurred())
+			indices := stringSliceToIndexMap(installationTemplatesToNames(ordered))
+			Expect(indices["b"]).To(BeNumerically("<", indices["c"]))
+			Expect(indices["b"]).To(BeNumerically("<", indices["d"]))
+			Expect(indices["b"]).To(BeNumerically("<", indices["e"]))
+			Expect(indices["b"]).To(BeNumerically("<", indices["f"]))
+			Expect(indices["b"]).To(BeNumerically("<", indices["a"]))
+			Expect(indices["c"]).To(BeNumerically("<", indices["e"]))
+			Expect(indices["c"]).To(BeNumerically("<", indices["f"]))
+			Expect(indices["c"]).To(BeNumerically("<", indices["a"]))
+			Expect(indices["d"]).To(BeNumerically("<", indices["a"]))
+			Expect(indices["e"]).To(BeNumerically("<", indices["f"]))
+			Expect(indices["e"]).To(BeNumerically("<", indices["a"]))
+			Expect(indices["f"]).To(BeNumerically("<", indices["a"]))
+		})
+
+		It("should detect cycles", func() {
+			deps := map[string][]string{
+				"a": nil,
+				"b": nil,
+				"c": {"e"},
+				"d": {"c"},
+				"e": {"d"},
+			}
+			tmpls := generateSubinstallationTemplates(deps, newDependencyProvider(mappingDependency))
+			sortInstallationTemplatesAlphabetically(tmpls)
+			_, err := subinstallations.OrderInstallationTemplates(tmpls)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("cyclic dependency detected"))
+		})
+
+	})
+
+})
+
+type dependencyMode string
+
+const (
+	dataDependency    = dependencyMode("data")
+	targetDependency  = dependencyMode("target")
+	mappingDependency = dependencyMode("mapping")
+	mixedDependency   = dependencyMode("mixed")
+)
+
+// dependencyProvider is a helper struct to iterate over dependency modes
+type dependencyProvider struct {
+	count int
+	mode  dependencyMode
+}
+
+func newDependencyProvider(mode dependencyMode) dependencyProvider {
+	return dependencyProvider{
+		mode: mode,
+	}
+}
+
+func (d dependencyProvider) nextMode() string {
+	mode := d.mode
+	if mode == mixedDependency {
+		cur := d.count % 3
+		switch cur {
+		case 0:
+			mode = dataDependency
+		case 1:
+			mode = targetDependency
+		case 2:
+			mode = mappingDependency
+		}
+		d.count++
+	}
+	return string(mode)
+}
+
+// generateSubinstallationTemplates describes dependencies between the subinstallation templates which should be created
+// There is expected to be one key for each installation template
+// and the value should list the names of all other installation templates this one depends on.
+// The 'mode' argument can be set to 'data', 'target', or 'mapping' and controls whether the import is satisfied by a
+// data export, target export, or something exported in the exportDataMappings, respectively.
+func generateSubinstallationTemplates(deps map[string][]string, dProv dependencyProvider) []*lsv1alpha1.InstallationTemplate {
+	res := []*lsv1alpha1.InstallationTemplate{}
+	for k, v := range deps {
+		tmpl := &lsv1alpha1.InstallationTemplate{
+			Name: k,
+			Imports: lsv1alpha1.InstallationImports{
+				Data: []lsv1alpha1.DataImport{},
+			},
+			Exports: lsv1alpha1.InstallationExports{
+				Data: []lsv1alpha1.DataExport{
+					{
+						Name:    "foo_data",
+						DataRef: fmt.Sprintf("%s_data", k),
+					},
+				},
+				Targets: []lsv1alpha1.TargetExport{
+					{
+						Name:   "foo_target",
+						Target: fmt.Sprintf("%s_target", k),
+					},
+				},
+			},
+			ExportDataMappings: map[string]lsv1alpha1.AnyJSON{
+				fmt.Sprintf("%s_mapping", k): lsv1alpha1.NewAnyJSON([]byte("foo_mapping_value")),
+			},
+		}
+		for i, dep := range v {
+			mode := dProv.nextMode()
+			if mode == string(targetDependency) {
+				tmpl.Imports.Targets = append(tmpl.Imports.Targets, lsv1alpha1.TargetImport{
+					Name:   fmt.Sprintf("%s_%d", k, i),
+					Target: fmt.Sprintf("%s_%s", dep, mode),
+				})
+			} else {
+				tmpl.Imports.Data = append(tmpl.Imports.Data, lsv1alpha1.DataImport{
+					Name:    fmt.Sprintf("%s_%d", k, i),
+					DataRef: fmt.Sprintf("%s_%s", dep, mode),
+				})
+			}
+		}
+		res = append(res, tmpl)
+	}
+	return res
+}
+
+// sortInstallationTemplatesAlphabetically sorts a slice of installation templates by name
+// This can be used to get templates into a deterministic order before checking for ordering by dependencies.
+func sortInstallationTemplatesAlphabetically(templates []*lsv1alpha1.InstallationTemplate) {
+	sort.Slice(templates, func(i, j int) bool {
+		return strings.Compare(templates[i].Name, templates[j].Name) < 0
+	})
+}
+
+// installationTemplatesToNames takes a slice of installation templates and returns a slice of their names, in the same order
+func installationTemplatesToNames(templates []*lsv1alpha1.InstallationTemplate) []string {
+	res := make([]string, len(templates))
+	for i, tmpl := range templates {
+		res[i] = tmpl.Name
+	}
+	return res
+}
+
+// stringSliceToIndexMap takes a slice of unique(!) strings and returns a mapping of these strings to their respective indices in the slice
+func stringSliceToIndexMap(data []string) map[string]int {
+	res := map[string]int{}
+	for i, elem := range data {
+		res[elem] = i
+	}
+	return res
+}

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -283,7 +283,13 @@ func (o *Operation) createOrUpdateSubinstallations(ctx context.Context,
 		return nil
 	}
 
-	for _, subInstTmpl := range installationTmpl {
+	// order subinstallations according to their dependencies
+	orderedSubinstallationTemplates, err := OrderInstallationTemplates(installationTmpl)
+	if err != nil {
+		return fmt.Errorf("unable to compute order for subinstallations: %w", err)
+	}
+
+	for _, subInstTmpl := range orderedSubinstallationTemplates {
 		subInst := subInstallations[subInstTmpl.Name]
 		_, err := o.createOrUpdateNewInstallation(ctx, o.Inst.Info, subInstTmpl, subInst)
 		if err != nil {

--- a/pkg/utils/cyclicdependencies.go
+++ b/pkg/utils/cyclicdependencies.go
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type DependencyCycle struct {
+	origin *dependencyCycleElement
+	last   *dependencyCycleElement
+	size   int
+}
+
+type dependencyCycleElement struct {
+	name        string                  // name of the importing entity
+	importNames sets.String             // names of the imports which cause the dependency
+	dependsOn   *dependencyCycleElement // where the import comes from
+}
+
+// copy copies the given element. The dependsOn pointer is set to nil and not copied.
+func (dce *dependencyCycleElement) copy() *dependencyCycleElement {
+	res := &dependencyCycleElement{
+		name: dce.name,
+	}
+	res.importNames = copyStringSet(dce.importNames)
+	return res
+}
+
+// NewDependencyCycle starts a new dependency cycle. It must be initialized with one element.
+// Internally, it works like a linked list, except that it is expected to form a cycle at some point.
+func NewDependencyCycle(templateName string) *DependencyCycle {
+	dc := &DependencyCycle{
+		origin: &dependencyCycleElement{
+			name: templateName,
+		},
+	}
+	dc.last = dc.origin
+	return dc
+}
+
+// Add adds a new dependency to the cycle. It returns a bool indicating whether the cycle is closed:
+// it is true if the given name matches the name of the origin element of the cycle.
+// No-op if the cycle is already closed.
+func (dc *DependencyCycle) Add(templateName string, importNames sets.String) bool {
+	if dc.IsClosed() {
+		// cycle is already closed, can't add to it
+		return true
+	}
+
+	dc.last.importNames = importNames
+	if templateName == dc.origin.name {
+		dc.last.dependsOn = dc.origin
+		return true
+	}
+	dc.last.dependsOn = &dependencyCycleElement{
+		name: templateName,
+	}
+	dc.last = dc.last.dependsOn
+	dc.size++
+	return false
+}
+
+// Copy copies the dependency cycle.
+func (dc *DependencyCycle) Copy() *DependencyCycle {
+	res := &DependencyCycle{}
+	res.origin = dc.origin.copy()
+	res.size = dc.size
+	originCurrent := dc.origin.dependsOn
+	newLast := res.origin
+	for originCurrent != nil {
+		newLast.dependsOn = originCurrent.copy()
+		originCurrent = originCurrent.dependsOn
+		newLast = newLast.dependsOn
+		if originCurrent == dc.origin {
+			// end of closed cycle reached
+			break
+		}
+	}
+	if originCurrent == nil {
+		// only set last if the cycle is not closed
+		res.last = newLast
+	}
+	return res
+}
+
+// IsClosed returns whether the cycle is closed.
+func (dc *DependencyCycle) IsClosed() bool {
+	return dc.last == nil
+}
+
+// Size returns the number of elements in this cycle.
+// Note that closing the cycle - by adding its origin element to it - does not increase the size.
+func (dc *DependencyCycle) Size() int {
+	return dc.size
+}
+
+// List returns the names of all templates which are part of this cycle.
+func (dc *DependencyCycle) List() []string {
+	current := dc.origin
+	res := make([]string, 0, dc.size)
+	for current != nil {
+		res = append(res, current.name)
+		current = current.dependsOn
+		if current == dc.origin {
+			break
+		}
+	}
+	return res
+}
+
+// Has returns true if the given name is part of the cycle.
+func (dc *DependencyCycle) Has(name string) bool {
+	current := dc.origin
+	for current != nil {
+		if current.name == name {
+			return true
+		}
+		current = current.dependsOn
+		if current == dc.origin {
+			break
+		}
+	}
+	return false
+}
+
+// Last returns the name of the last element of the cycle.
+// If the cycle is closed, it returns an empty string.
+func (dc *DependencyCycle) Last() string {
+	if dc.last != nil {
+		return dc.last.name
+	}
+	return ""
+}
+
+// Origin returns the name of the origin element of the cycle.
+func (dc *DependencyCycle) Origin() string {
+	return dc.origin.name
+}
+
+// Close adds an element which has the same name as the origin, closing the cycle.
+// Returns the cycle for chaining
+func (dc *DependencyCycle) Close(importNames sets.String) *DependencyCycle {
+	if !dc.IsClosed() {
+		dc.Add(dc.origin.name, importNames)
+	}
+	return dc
+}
+
+type RelationshipTuple struct {
+	Exporting string
+	Importing string
+}
+
+// ImportRelationships maps tuples of entities to the set of im-/exports which connect them
+type ImportRelationships map[RelationshipTuple]sets.String
+
+func (ir ImportRelationships) Get(exporting, importing string) (sets.String, bool) {
+	tmp := RelationshipTuple{
+		Exporting: exporting,
+		Importing: importing,
+	}
+	imps, ok := ir[tmp]
+	return imps, ok
+}
+
+func (ir ImportRelationships) Add(exporting, importing, imp string) ImportRelationships {
+	tmp := RelationshipTuple{
+		Exporting: exporting,
+		Importing: importing,
+	}
+	if _, ok := ir[tmp]; !ok {
+		ir[tmp] = sets.NewString()
+	}
+	ir[tmp].Insert(imp)
+	return ir
+}
+
+// Equal returns true if both objects describe the same cycle
+// meaning the same template names in the same order.
+// Cycles which are not closed are only equal if they have the same origin,
+// for closed cycles, this doesn't matter.
+// If only one of the cycles is closed, they are considered to be not equal.
+// The actual cycle must not be nil, if the given cycle is nil, they are considered to be not equal.
+func (dc *DependencyCycle) Equal(other *DependencyCycle) bool {
+	if other == nil {
+		// we assume that dc is not nil
+		return false
+	}
+	otherOrigin := other.origin
+	if dc.IsClosed() {
+		if !other.IsClosed() {
+			return false
+		}
+		if dc.origin.name != otherOrigin.name {
+			// find matching element, if any, in case of different origins
+			for tmp := otherOrigin.dependsOn; tmp != otherOrigin; tmp = tmp.dependsOn {
+				if tmp.name == dc.origin.name {
+					// found matching element
+					otherOrigin = tmp
+					break
+				}
+			}
+		}
+	}
+	if dc.origin.name != otherOrigin.name {
+		// no matching origin found, cycles cannot be equal
+		return false
+	}
+	for thisCurrent, otherCurrent := dc.origin.dependsOn, otherOrigin.dependsOn; thisCurrent != dc.origin && otherCurrent != otherOrigin; thisCurrent, otherCurrent = thisCurrent.dependsOn, otherCurrent.dependsOn {
+		if thisCurrent.name != otherCurrent.name {
+			return false
+		}
+		if thisCurrent.importNames != nil {
+			if !thisCurrent.importNames.Equal(otherCurrent.importNames) {
+				return false
+			}
+		} else {
+			if otherCurrent.importNames != nil {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (dc *DependencyCycle) String() string {
+	return dc.StringWithSeparator(" -> ", " -", "-> ", "[", ", ", "]")
+}
+
+func (dc *DependencyCycle) StringWithSeparator(sep, sepBeforeImports, sepAfterImports, importStart, importSep, importEnd string) string {
+	var sb strings.Builder
+	current := dc.origin
+	for current != nil {
+		sb.WriteString(current.name)
+		if current.dependsOn != nil {
+			if current.importNames != nil {
+				sb.WriteString(sepBeforeImports)
+				sb.WriteString(importStart)
+				sb.WriteString(strings.Join(current.importNames.List(), importSep))
+				sb.WriteString(importEnd)
+				sb.WriteString(sepAfterImports)
+			} else {
+				sb.WriteString(sep)
+			}
+		}
+		current = current.dependsOn
+		if current == dc.origin {
+			sb.WriteString(current.name)
+			break
+		}
+	}
+	return sb.String()
+}
+
+// DetermineCyclicDependencyDetails takes a list of installation templates which all depend on each other in a cyclic manner
+// and a mapping from template names to the names of the templates they depend on.
+// Optionally, the import relationships (which two elements are connected by which imports) can be given.
+// It returns a list of found cycles.
+func DetermineCyclicDependencyDetails(elements sets.String, dependencies map[string]sets.String, impRel ImportRelationships) []*DependencyCycle {
+	res := []*DependencyCycle{}
+	elemList := elements.List()
+
+	// All cycles which contain elem will be found with a call to determineCycles(nil, elem, ...)
+	// To also find all cycles which don't contain elem, we remove elem from the set of elements and then repeat the process
+	for i := 0; i < len(elemList); i++ {
+		res = append(res, determineCycles(nil, elemList[i], sets.NewString().Insert(elemList[i+1:]...), dependencies, impRel)...)
+	}
+
+	return res
+}
+
+// determineCycles tries to add another element to the given cycle.
+// The arguments are:
+// - cycle: the current cycle. May be nil, then a new one will be created.
+// - current: the current element.
+// - elements: the set of potential elements. It is expected to contain only elements which are not already part of the cycle.
+// - dependencies: a mapping from elements to all elements they depend on
+// - impRel: optional mapping from im-/export relationships to the im-/exports causing the relationship
+func determineCycles(cycle *DependencyCycle, current string, elements sets.String, dependencies map[string]sets.String, impRel ImportRelationships) []*DependencyCycle {
+	res := []*DependencyCycle{}
+	if len(current) == 0 {
+		return res
+	}
+	if cycle == nil {
+		cycle = NewDependencyCycle(current)
+	} else {
+		// fetch connecting imports, if given
+		var imps sets.String
+		if impRel != nil {
+			imps, _ = impRel.Get(current, cycle.Last())
+		}
+
+		// add current element to cycle
+		if cycle.Add(current, imps) {
+			// cycle is closed
+			// this case should not occur, since it would be catched before by the check below
+			res = append(res, cycle)
+			return res
+		}
+	}
+
+	// check if we can close the cycle
+	if dependencies[current].Has(cycle.Origin()) {
+		// the current element, which was just added to the cycle, depends on the origin of the cycle
+		// => add the origin again to close the cycle and add it to the result
+		var imps sets.String
+		if impRel != nil {
+			imps, _ = impRel.Get(cycle.Origin(), current)
+		}
+		res = append(res, cycle.Copy().Close(imps))
+	}
+
+	for elem := range elements {
+		if dependencies[current].Has(elem) {
+			// we want to ignore all elements which are already part of the cycle
+			// so let's build a new element list and remove the element we just added to the cycle
+			newElements := copyStringSetWithoutElement(elements, current)
+			// recursion
+			// copy cycle to not alter the original
+			res = append(res, determineCycles(cycle.Copy(), elem, newElements, dependencies, impRel)...)
+		}
+	}
+	return res
+}
+
+func copyStringSet(set sets.String) sets.String {
+	if set == nil {
+		return nil
+	}
+	res := sets.NewString()
+	for elem := range set {
+		res.Insert(elem)
+	}
+	return res
+}
+func copyStringSetWithoutElement(set sets.String, element string) sets.String {
+	if set == nil {
+		return nil
+	}
+	res := sets.NewString()
+	for elem := range set {
+		if elem == element {
+			continue
+		}
+		res.Insert(elem)
+	}
+	return res
+}

--- a/pkg/utils/cyclicdependencies.go
+++ b/pkg/utils/cyclicdependencies.go
@@ -206,6 +206,10 @@ func (dc *DependencyCycle) Equal(other *DependencyCycle) bool {
 				}
 			}
 		}
+	} else {
+		if other.IsClosed() {
+			return false
+		}
 	}
 	if dc.origin.name != otherOrigin.name {
 		// no matching origin found, cycles cannot be equal

--- a/pkg/utils/cyclicdependencies_test.go
+++ b/pkg/utils/cyclicdependencies_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/gardener/landscaper/pkg/utils"
+)
+
+var _ = Describe("Cyclic Dependency Determination Tests", func() {
+
+	Context("DetermineCyclicDependencyDetails", func() {
+
+		It("should not detect cyclic dependencies if there aren't any", func() {
+			deps := map[string]sets.String{
+				"c": sets.NewString().Insert("b"),
+				"b": sets.NewString().Insert("a"),
+				"a": sets.NewString(),
+			}
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, nil)
+			Expect(cycles).To(HaveLen(0))
+		})
+
+		It("should detect simple cyclic dependencies", func() {
+			deps := map[string]sets.String{
+				"c": sets.NewString().Insert("b"),
+				"b": sets.NewString().Insert("a"),
+				"a": sets.NewString().Insert("c"),
+			}
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, nil)
+			Expect(cycles).To(HaveLen(1))
+			cmp := utils.NewDependencyCycle("a")
+			cmp.Add("c", nil)
+			cmp.Add("b", nil)
+			cmp.Close(nil)
+			Expect(cycles[0]).To(beEqualToCycle(cmp))
+		})
+
+		It("should detect one-elemented cyclic dependencies", func() {
+			deps := map[string]sets.String{
+				"a": sets.NewString().Insert("a"),
+			}
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, nil)
+			Expect(cycles).To(HaveLen(1))
+			Expect(cycles[0]).To(beEqualToCycle(utils.NewDependencyCycle("a").Close(nil)))
+		})
+
+		It("should detect multiple independent cycles", func() {
+			deps := map[string]sets.String{
+				"d": sets.NewString().Insert("c"),
+				"c": sets.NewString().Insert("d"),
+				"b": sets.NewString().Insert("a"),
+				"a": sets.NewString().Insert("b"),
+			}
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, nil)
+			cmp1 := utils.NewDependencyCycle("a")
+			cmp1.Add("b", nil)
+			cmp1.Close(nil)
+			cmp2 := utils.NewDependencyCycle("c")
+			cmp2.Add("d", nil)
+			cmp2.Close(nil)
+			Expect(cycles).To(ConsistOf(beEqualToCycle(cmp1), beEqualToCycle(cmp2)))
+		})
+
+		It("should detect multiple connected cycles", func() {
+			deps := map[string]sets.String{
+				"d": sets.NewString().Insert("c"),
+				"c": sets.NewString().Insert("d", "b"),
+				"b": sets.NewString().Insert("a"),
+				"a": sets.NewString().Insert("d"),
+			}
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, nil)
+			cmp1 := utils.NewDependencyCycle("a")
+			cmp1.Add("d", nil)
+			cmp1.Add("c", nil)
+			cmp1.Add("b", nil)
+			cmp1.Close(nil)
+			cmp2 := utils.NewDependencyCycle("c")
+			cmp2.Add("d", nil)
+			cmp2.Close(nil)
+			Expect(cycles).To(ConsistOf(beEqualToCycle(cmp1), beEqualToCycle(cmp2)))
+		})
+
+		It("should detect simple cyclic dependencies with import relationships", func() {
+			deps := map[string]sets.String{
+				"c": sets.NewString().Insert("b"),
+				"b": sets.NewString().Insert("a"),
+				"a": sets.NewString().Insert("c"),
+			}
+			impRels := utils.ImportRelationships{}
+			impRels.Add("c", "a", "c_to_a").Add("a", "b", "a_to_b").Add("b", "c", "b_to_c")
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, impRels)
+			Expect(cycles).To(HaveLen(1))
+			cmp := utils.NewDependencyCycle("a")
+			tmp, _ := impRels.Get("c", "a")
+			cmp.Add("c", tmp)
+			tmp, _ = impRels.Get("b", "c")
+			cmp.Add("b", tmp)
+			tmp, _ = impRels.Get("a", "b")
+			cmp.Close(tmp)
+			Expect(cycles[0]).To(beEqualToCycle(cmp))
+		})
+
+		It("should detect one-elemented cyclic dependencies with import relationships", func() {
+			deps := map[string]sets.String{
+				"a": sets.NewString().Insert("a"),
+			}
+			impRels := utils.ImportRelationships{}
+			impRels.Add("a", "a", "a_to_a")
+
+			cycles := utils.DetermineCyclicDependencyDetails(sets.StringKeySet(deps), deps, impRels)
+			Expect(cycles).To(HaveLen(1))
+			tmp, _ := impRels.Get("a", "a")
+			Expect(cycles[0]).To(beEqualToCycle(utils.NewDependencyCycle("a").Close(tmp)))
+		})
+
+	})
+
+	Context("DependencyCycle", func() {
+
+		Context("String", func() {
+
+			It("should print the cycle", func() {
+				c := utils.NewDependencyCycle("a")
+				c.Add("b", nil)
+				c.Add("c", nil)
+				Expect(c.String()).To(Equal("a -> b -> c"))
+			})
+
+			It("should print the cycle and add the starting element if it is closed", func() {
+				c := utils.NewDependencyCycle("a")
+				c.Add("b", nil)
+				c.Add("c", nil)
+				c.Close(nil)
+				Expect(c.String()).To(Equal("a -> b -> c -> a"))
+			})
+
+			It("should print the imports if given", func() {
+				c := utils.NewDependencyCycle("a")
+				c.Add("b", sets.NewString().Insert("foo"))
+				c.Add("c", sets.NewString().Insert("bar"))
+				c.Close(sets.NewString().Insert("foobar", "baz"))
+				Expect(c.String()).To(Equal("a -[foo]-> b -[bar]-> c -[baz, foobar]-> a"))
+			})
+
+		})
+
+	})
+
+})
+
+func beEqualToCycle(cmp *utils.DependencyCycle) types.GomegaMatcher {
+	return And(
+		Not(BeNil()),
+		WithTransform(func(dc *utils.DependencyCycle) bool {
+			return cmp != nil && dc.Equal(cmp)
+		}, BeTrue()),
+	)
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -148,6 +148,8 @@ const (
 	ErrorReadinessCheckTimeout ErrorCode = "ERR_READINESS_CHECK_TIMEOUT"
 	// ErrorTimeout indicates that an operation timed out.
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
+	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
+	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 )
 
 // Condition holds the information about the state of a resource.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -155,6 +155,8 @@ const (
 	ErrorReadinessCheckTimeout ErrorCode = "ERR_READINESS_CHECK_TIMEOUT"
 	// ErrorTimeout indicates that an operation timed out.
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
+	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
+	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes
@@ -163,6 +165,7 @@ var UnrecoverableErrorCodes = []ErrorCode{
 	ErrorInternalProblem,
 	ErrorReadinessCheckTimeout,
 	ErrorTimeout,
+	ErrorCyclicDependencies,
 }
 
 // Condition holds the information about the state of a resource.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 2

**Which issue(s) this PR fixes**:
Fixes #409 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Landscaper now takes dependencies into account when applying subinstallations. Before, they were applied in the order they were given in, which could mean that a subinstallation that depends on another one was updated and processed by the landscaper before the one it depends on was updated, making simultaneous updates of multiple components impossible.
```
