### PR TITLE
make setup-envtest working on darwin/arm64

### DIFF
--- a/hack/setup-testenv.sh
+++ b/hack/setup-testenv.sh
@@ -12,7 +12,15 @@ echo "> Setup Test Environment for K8s Version ${K8S_VERSION}"
 
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
-export KUBEBUILDER_ASSETS=$(setup-envtest use -p path ${K8S_VERSION})
+
+# TODO: setup-envtest currently doesnt support darwin/arm64 / force amd64
+ARCH_ARG=""
+if [[ $(go env GOOS) == "darwin" && $(go env GOARCH) == "arm64" ]]; then
+  ARCH_ARG="--arch amd64"
+fi
+
+export KUBEBUILDER_ASSETS=$(setup-envtest use -p path ${K8S_VERSION} ${ARCH_ARG})
+
 mkdir -p ${PROJECT_ROOT}/tmp/test
 rm -f ${PROJECT_ROOT}/tmp/test/bin
 ln -s "${KUBEBUILDER_ASSETS}" ${PROJECT_ROOT}/tmp/test/bin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Makes envtest in Landscaper unit test working locally on darwin arm64.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE

```
