### PR TITLE
reference context takes an explicit repository context used for reference resolving

### DIFF
--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -120,6 +120,7 @@ func (o *Operation) JSONSchemaValidator(schema []byte) (*jsonschema.Validator, e
 		BlueprintFs:         o.Inst.Blueprint.Fs,
 		ComponentDescriptor: o.ComponentDescriptor,
 		ComponentResolver:   o.ComponentsRegistry(),
+		RepositoryContext:   o.context.External.RepositoryContext,
 	})
 	err := v.CompileSchema(schema)
 	if err != nil {

--- a/pkg/landscaper/jsonschema/reference.go
+++ b/pkg/landscaper/jsonschema/reference.go
@@ -38,6 +38,9 @@ type ReferenceContext struct {
 	ComponentDescriptor *cdv2.ComponentDescriptor
 	// ComponentResolver is a object that can resolve component descriptors.
 	ComponentResolver ctf.ComponentResolver
+	// RepositoryContext can be used to overwrite the effective repository context of the component descriptor.
+	// If not set, the effective repository context of the ComponentDescriptor will be used.
+	RepositoryContext *cdv2.UnstructuredTypedObject
 }
 
 type ReferenceResolver struct {
@@ -211,7 +214,11 @@ func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, cu
 	if err != nil {
 		return nil, err
 	}
-	cd, res, err := cdUri.GetResource(rr.ComponentDescriptor, rr.ComponentResolver)
+	repositoryContext := rr.RepositoryContext
+	if repositoryContext == nil {
+		repositoryContext = rr.ComponentDescriptor.GetEffectiveRepositoryContext()
+	}
+	cd, res, err := cdUri.GetResourceWithRepositoryContext(rr.ComponentDescriptor, rr.ComponentResolver, repositoryContext)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +226,11 @@ func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, cu
 	// get the blob resolver for the specific component
 	ctx := context.Background()
 	defer ctx.Done()
-	_, blobResolver, err := rr.ComponentResolver.ResolveWithBlobResolver(ctx, cd.GetEffectiveRepositoryContext(), cd.GetName(), cd.GetVersion())
+	repositoryContext = rr.RepositoryContext
+	if repositoryContext == nil {
+		repositoryContext = cd.GetEffectiveRepositoryContext()
+	}
+	_, blobResolver, err := rr.ComponentResolver.ResolveWithBlobResolver(ctx, repositoryContext, cd.GetName(), cd.GetVersion())
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch component descriptor %s:%s for %q: %w", cd.GetName(), cd.GetVersion(), uri.String(), err)
 	}
@@ -262,6 +273,7 @@ func (rr *ReferenceResolver) handleComponentDescriptorReference(uri *url.URL, cu
 		BlueprintFs:         nil,
 		ComponentDescriptor: cd,
 		ComponentResolver:   rr.ComponentResolver,
+		RepositoryContext:   rr.RepositoryContext,
 	}).resolve(data, currentPath, alreadyResolved)
 	if err != nil {
 		return nil, err

--- a/pkg/landscaper/jsonschema/testdata/registry/ref-1/blobs/schema/schema.json
+++ b/pkg/landscaper/jsonschema/testdata/registry/ref-1/blobs/schema/schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "cpu": {
+      "type": "string"
+    },
+    "memory": {
+      "$ref": "cd://componentReferences/ref-2/resources/memoryschema"
+    }
+  }
+}

--- a/pkg/landscaper/jsonschema/testdata/registry/ref-1/component-descriptor.yaml
+++ b/pkg/landscaper/jsonschema/testdata/registry/ref-1/component-descriptor.yaml
@@ -1,0 +1,29 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/ref-1
+  version: v0.1.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "example.com"
+
+  componentReferences:
+    - componentName: example.com/ref-2
+      name: ref-2
+      version: v0.1.0
+
+  sources: []
+
+  resources:
+    - type: landscaper.gardener.cloud/jsonschema
+      name: resourcesschema
+      relation: local
+      version: v0.1.0
+      access:
+        type: localFilesystemBlob
+        mediaType: application/vnd.gardener.landscaper.jsonschema.layer.v1.json
+        filename: schema/schema.json

--- a/pkg/landscaper/jsonschema/testdata/registry/ref-2/blobs/schema/schema.json
+++ b/pkg/landscaper/jsonschema/testdata/registry/ref-2/blobs/schema/schema.json
@@ -1,0 +1,3 @@
+{
+  "type": "string"
+}

--- a/pkg/landscaper/jsonschema/testdata/registry/ref-2/component-descriptor.yaml
+++ b/pkg/landscaper/jsonschema/testdata/registry/ref-2/component-descriptor.yaml
@@ -1,0 +1,25 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/ref-2
+  version: v0.1.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "example.com"
+
+  componentReferences: []
+  sources: []
+
+  resources:
+    - type: landscaper.gardener.cloud/jsonschema
+      name: memoryschema
+      relation: local
+      version: v0.1.0
+      access:
+        type: localFilesystemBlob
+        mediaType: application/vnd.gardener.landscaper.jsonschema.layer.v1.json
+        filename: schema/schema.json

--- a/pkg/landscaper/jsonschema/testdata/registry/root/component-descriptor.yaml
+++ b/pkg/landscaper/jsonschema/testdata/registry/root/component-descriptor.yaml
@@ -1,0 +1,21 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/root
+  version: v0.1.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "example.com"
+
+  componentReferences:
+    - componentName: example.com/ref-1
+      name: ref-1
+      version: v0.1.0
+
+  sources: []
+  resources: []
+

--- a/pkg/landscaper/registry/components/cdutils/uri.go
+++ b/pkg/landscaper/registry/components/cdutils/uri.go
@@ -163,6 +163,12 @@ func (u *URI) GetComponent(cd *cdv2.ComponentDescriptor, compResolver ctf.Compon
 // GetResource resolves to a resource specified by the URI.
 // It also returns the resource kind.
 func (u *URI) GetResource(cd *cdv2.ComponentDescriptor, compResolver ctf.ComponentResolver) (*cdv2.ComponentDescriptor, cdv2.Resource, error) {
+	return u.GetResourceWithRepositoryContext(cd, compResolver, cd.GetEffectiveRepositoryContext())
+}
+
+// GetResourceWithRepositoryContext resolves to a resource specified by the URI with the given repository context.
+// It also returns the resource kind.
+func (u *URI) GetResourceWithRepositoryContext(cd *cdv2.ComponentDescriptor, compResolver ctf.ComponentResolver, repositoryContext *cdv2.UnstructuredTypedObject) (*cdv2.ComponentDescriptor, cdv2.Resource, error) {
 	var (
 		ctx       = context.Background()
 		component = cd
@@ -178,7 +184,7 @@ func (u *URI) GetResource(cd *cdv2.ComponentDescriptor, compResolver ctf.Compone
 			}
 
 			ref := refs[0]
-			component, err = compResolver.Resolve(ctx, cd.GetEffectiveRepositoryContext(), ref.ComponentName, ref.Version)
+			component, err = compResolver.Resolve(ctx, repositoryContext, ref.ComponentName, ref.Version)
 			if err != nil {
 				return nil, cdv2.Resource{}, fmt.Errorf("component %s cannot be found", elem.Value)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Previously the JSON schema reference resolver was only using the effective repository context of the component descriptor, ignoring the explicit setting of the repository context via Landscaper Context, Installation or ComponentOverwrite.
This PR changes that the reference resolver is now using the correct repository context as configured for an Installation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
