### PR TITLE
fix regression with annotations on the same level as references in JSON schemas

### DIFF
--- a/pkg/landscaper/jsonschema/jsonschema_suite_test.go
+++ b/pkg/landscaper/jsonschema/jsonschema_suite_test.go
@@ -144,6 +144,16 @@ var _ = Describe("jsonschema", func() {
 			Expect(jsonschema.ValidateBytes(schemaBytes, pass, config)).To(Succeed())
 			Expect(jsonschema.ValidateBytes(schemaBytes, fail, config)).To(HaveOccurred())
 		})
+
+		It("should pass with a schema from a blueprint file reference and additional metadata", func() {
+			localSchema := []byte(`{ "type": "string"}`)
+			Expect(vfs.WriteFile(config.BlueprintFs, "myfile", localSchema, os.ModePerm)).To(Succeed())
+
+			schemaBytes := []byte(`{ "title": "My Schema", "$ref": "blueprint://myfile", "description": "this is a schema"}`)
+			data := []byte(`"valid"`)
+
+			Expect(jsonschema.ValidateBytes(schemaBytes, data, config)).To(Succeed())
+		})
 	})
 
 	Context("LocalReference", func() {

--- a/pkg/landscaper/jsonschema/reference.go
+++ b/pkg/landscaper/jsonschema/reference.go
@@ -95,10 +95,6 @@ func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath
 	res := map[string]interface{}{}
 	for k, v := range data {
 		subPath := currentPath.Child(k)
-		if k == gojsonschema.KEY_REF {
-			// map contains a reference
-			return nil, fmt.Errorf("invalid reference at %s: there are no other fields allowed next to %q", subPath.String(), gojsonschema.KEY_REF)
-		}
 		sub, err := rr.resolve(v, subPath, alreadyResolved)
 		if err != nil {
 			return nil, err
@@ -113,7 +109,7 @@ func (rr *ReferenceResolver) resolveMap(data map[string]interface{}, currentPath
 // Otherwise, it returns false and an empty string.
 func checkForReference(data map[string]interface{}, currentPath *field.Path) (bool, string, error) {
 	value, ok := data[gojsonschema.KEY_REF]
-	if len(data) != 1 || !ok {
+	if !ok {
 		// no reference
 		return false, "", nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind regression
/priority 3

**What this PR does / why we need it**:

JSON Schema allows to add annotations to any location within a schema. https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.7.7
There is a regression with the recent changes to reference resolving in JSON Schemas, which is fixed by this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed regression that prevented the usage of annotation on the same level as references ($ref) in JSON schemas.
```
