### PR TITLE
Set succeeded after checking exports (Reference)

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -9,19 +9,12 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/gardener/landscaper/test/integration/deployitems"
-	"github.com/gardener/landscaper/test/integration/installations"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/landscaper/pkg/utils/simplelogger"
 	"github.com/gardener/landscaper/test/framework"
-	"github.com/gardener/landscaper/test/integration/core"
-	"github.com/gardener/landscaper/test/integration/deployers"
-	"github.com/gardener/landscaper/test/integration/executions"
 	"github.com/gardener/landscaper/test/integration/tutorial"
-	"github.com/gardener/landscaper/test/integration/webhook"
 )
 
 var opts *framework.Options
@@ -54,12 +47,12 @@ func TestConfig(t *testing.T) {
 	}
 
 	tutorial.RegisterTests(f)
-	webhook.RegisterTests(f)
-	core.RegisterTests(f)
-	deployers.RegisterTests(f)
-	deployitems.RegisterTests(f)
-	installations.RegisterTests(f)
-	executions.RegisterTests(f)
+	//webhook.RegisterTests(f)
+	//core.RegisterTests(f)
+	//deployers.RegisterTests(f)
+	//deployitems.RegisterTests(f)
+	//installations.RegisterTests(f)
+	//executions.RegisterTests(f)
 
 	AfterSuite(func() {
 		f.Cleanup.Run()

--- a/test/integration/tutorial/register.go
+++ b/test/integration/tutorial/register.go
@@ -8,8 +8,8 @@ import "github.com/gardener/landscaper/test/framework"
 
 // RegisterTests registers all tests of the package
 func RegisterTests(f *framework.Framework) {
-	NginxIngressTest(f)
+	//NginxIngressTest(f)
 	SimpleImport(f)
-	AggregatedBlueprint(f)
-	ExternalJSONSchemaTest(f)
+	//AggregatedBlueprint(f)
+	//ExternalJSONSchemaTest(f)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR should not be merged. It is just a reference for checking a reduced set of integration tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
