### PR TITLE
Update version of nginx helm chart in first example

### DIFF
--- a/docs/level_0/first_example_component.md
+++ b/docs/level_0/first_example_component.md
@@ -23,7 +23,7 @@ deployItems:
     kind: ProviderConfiguration
 
     chart:
-      ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0"           # (4)
+      ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17"           # (4)
 
     updateStrategy: patch
 
@@ -110,20 +110,20 @@ component:
   resources:
     - type: blueprint
       name: first-example-blueprint
-      version: v0.1.0
+      version: v0.1.3
       relation: local
       access:
         type: ociRegistry
-        imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/first-example:v0.1.0
+        imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/first-example:v0.1.3
     - type: helm.io/chart
       name: nginx-chart
-      version: 0.1.0
+      version: 4.0.17
       relation: external
       access:
-        imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+        imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
         type: ociRegistry
   sources: []
-  version: v0.1.0
+  version: v0.1.3
 meta:
   schemaVersion: v2
 ```

--- a/docs/level_0/first_example_installation.md
+++ b/docs/level_0/first_example_installation.md
@@ -58,7 +58,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/first-example
-      version: v0.1.0
+      version: v0.1.3
 
   blueprint:
     ref:

--- a/docs/level_0/resources/blueprint/deploy-execution-nginx.yaml
+++ b/docs/level_0/resources/blueprint/deploy-execution-nginx.yaml
@@ -9,7 +9,7 @@ deployItems:
     kind: ProviderConfiguration
 
     chart:
-      ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
 
     updateStrategy: patch
 

--- a/docs/level_0/resources/component-descriptor.yaml
+++ b/docs/level_0/resources/component-descriptor.yaml
@@ -8,19 +8,19 @@ component:
   resources:
   - type: blueprint
     name: first-example-blueprint
-    version: v0.1.0
+    version: v0.1.3
     relation: local
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/first-example:v0.1.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/first-example:v0.1.3
   - type: helm
     name: nginx-chart
-    version: 0.1.0
+    version: 4.0.17
     relation: external
     access:
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
       type: ociRegistry
   sources: []
-  version: v0.1.0
+  version: v0.1.3
 meta:
   schemaVersion: v2

--- a/docs/level_0/resources/installation.yaml
+++ b/docs/level_0/resources/installation.yaml
@@ -10,7 +10,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/first-example
-      version: v0.1.0
+      version: v0.1.3
 
   blueprint:
     ref:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug
/priority 3

**What this PR does / why we need it**:
This pull request increases the version of the nginx  helm chart that is used in the first example installation / component descriptor. The new version is 4.0.17.

**Which issue(s) this PR fixes**:
Fixes #428 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
