### PR TITLE
Update chart version for integration tests and tutorials

### DIFF
--- a/docs/tutorials/01-create-simple-blueprint.md
+++ b/docs/tutorials/01-create-simple-blueprint.md
@@ -1,6 +1,6 @@
 # Tutorial 01: Developing a simple Blueprint
 
-This tutorial describes the basics of developing Blueprints. It covers the whole manual workflow from wrtting the Blueprint together with a Component Descriptor and storing them in a remote OCI repository.
+This tutorial describes the basics of developing Blueprints. It covers the whole manual workflow from writing the Blueprint together with a Component Descriptor and storing them in a remote OCI repository.
 
 For this tutorial, we are going to use the [NGINX ingress controller](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) as the example application which will get deployed via its upstream helm chart.
 
@@ -43,7 +43,7 @@ helm repo add stable https://charts.helm.sh/stable
 helm repo update
 
 # download the nginx ingress helm chart and extract it to /tmp/nginx-ingress
-helm pull ingress-nginx/ingress-nginx --version 3.29.0 --untar --destination /tmp
+helm pull ingress-nginx/ingress-nginx --version 4.0.17 --untar --destination /tmp
 
 # upload the helm chart to an OCI registry
 export OCI_REGISTRY="oci://eu.gcr.io" # <-- replace this with the URL of your own OCI registry, DO NOT FORGET the OCI protocol prefix oci://
@@ -51,8 +51,8 @@ export CHART_REF_PREFIX="$OCI_REGISTRY/chart-prefix/" # e.g. eu.gcr.io/gardener-
 export HELM_EXPERIMENTAL_OCI=1
 helm registry login -u myuser $OCI_REGISTRY
 helm package /tmp/ingress-nginx -d /tmp
-helm push /tmp/ingress-nginx-3.29.0.tgz $CHART_REF_PREFIX
-# the helm chart is uploaded as oci artifact to $CHART_REF_PREFIX/chart-name:chart-version" e.g. eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:3.29.0
+helm push /tmp/ingress-nginx-4.0.17.tgz $CHART_REF_PREFIX
+# the helm chart is uploaded as oci artifact to $CHART_REF_PREFIX/chart-name:chart-version" e.g. eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
 ```
 
 See details for Helm version < `3.7`.
@@ -65,11 +65,11 @@ helm repo add stable https://charts.helm.sh/stable
 helm repo update
 
 # download the nginx ingress helm chart and extract it to /tmp/nginx-ingress
-helm pull ingress-nginx/ingress-nginx --version 3.29.0 --untar --destination /tmp
+helm pull ingress-nginx/ingress-nginx --version 4.0.17 --untar --destination /tmp
 
 # upload the helm chart to an OCI registry
 export OCI_REGISTRY="eu.gcr.io" # <-- replace this with the URL of your own OCI registry
-export CHART_REF="$OCI_REGISTRY/mychart/reference:my-version" # e.g. eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
+export CHART_REF="$OCI_REGISTRY/mychart/reference:my-version" # e.g. eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
 export HELM_EXPERIMENTAL_OCI=1
 helm registry login -u myuser $OCI_REGISTRY
 helm package /tmp/ingress-nginx $CHART_REF
@@ -82,7 +82,7 @@ helm push $CHART_REF
 
 A Component Descriptor contains references and locations to all _resources_ that are used by Landscaper to deploy and install an application. In this example, the only kind of _resources_ is a `helm` chart (that of the nginx-ingress controller that we uploaded to an OCI registry in the previous step) but it could also be `oci images` or even `node modules`.
 
-If a Helm chart is referenced through a component descriptor, the version of the chart in the component descriptor should match the version of the chart itself. Since we are using version v3.29.0 of the _ingress-nginx_ Helm chart in this tutorial, the component descriptor references it accordingly.
+If a Helm chart is referenced through a component descriptor, the version of the chart in the component descriptor should match the version of the chart itself. Since we are using version 4.0.17 of the _ingress-nginx_ Helm chart in this tutorial, the component descriptor references it accordingly.
 
 For more information about the component descriptor and the usage of the different fields, refer to the [component descriptor documentation](https://github.com/gardener/component-spec).
 
@@ -105,11 +105,11 @@ component:
   resources:
   - type: helm
     name: ingress-nginx-chart
-    version: v3.29.0
+    version: 4.0.17
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io.gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
+      imageReference: eu.gcr.io.gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
 ```
 
 ## Step 3: Create a Blueprint
@@ -340,7 +340,7 @@ spec:
   config:
     apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
     chart:
-      ref: eu.gcr.io/myproject/charts/nginx-ingress:v3.29.0
+      ref: eu.gcr.io/myproject/charts/nginx-ingress:4.0.17
     exportsFromManifests:
     - jsonPath: .Values.controller.ingressClass
       key: ingressClass
@@ -386,7 +386,7 @@ meta:
 
 component:
   name: github.com/gardener/landscaper/ingress-nginx
-  version: v0.3.0
+  version: v0.3.2
 
   provider: internal
   sources: []
@@ -399,11 +399,11 @@ component:
   resources:  
   - type: helm
     name: ingress-nginx-chart
-    version: v3.29.0
+    version: 4.0.17
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
   - type: blueprint
     name: ingress-nginx-blueprint
     relation: local
@@ -424,7 +424,7 @@ landscaper-cli component-cli ca remote push <path to directory with component-de
 landscaper-cli component-cli ca remote push ./docs/tutorials/resources/ingress-nginx
 ```
 
-Once the upload succeeds, the Component Descriptor should be accessible at `eu.gcr.io/gardener-project/landscaper/tutorials/components/component-descriptors/github.com/gardener/landscaper/ingress-nginx/v0.3.0` in the registry.
+Once the upload succeeds, the Component Descriptor should be accessible at `eu.gcr.io/gardener-project/landscaper/tutorials/components/component-descriptors/github.com/gardener/landscaper/ingress-nginx/v0.3.2` in the registry.
 
 ## Step 6: Installation
 
@@ -483,7 +483,7 @@ componentDescriptor:
       type: ociRegistry
       baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
     componentName: github.com/gardener/landscaper/ingress-nginx
-    version: v0.3.0
+    version: v0.3.2
 ```
 
 __Blueprint__: Once the Component Descriptor is given, the Blueprint artifact in the component descriptor is specified by its resource with the unique name `ingress-nginx-blueprint`.
@@ -544,7 +544,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/ingress-nginx
-      version: v0.3.0
+      version: v0.3.2
 
   blueprint:
     ref:
@@ -600,7 +600,7 @@ spec:
   - config:
       apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
       chart:
-        ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
+        ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
       exportsFromManifests:
       - jsonPath: .Values.controller.ingressClass
         key: ingressClass
@@ -640,7 +640,7 @@ spec:
   config:
     apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
     chart:
-      ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
+      ref: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17
     exportsFromManifests:
     - jsonPath: .Values.controller.ingressClass
       key: ingressClass

--- a/docs/tutorials/04-aggregated-blueprint.md
+++ b/docs/tutorials/04-aggregated-blueprint.md
@@ -227,7 +227,7 @@ subinstallations:
 
 Upload the blueprint artifact to the registry:
 ```shell script
-landscaper-cli blueprints push eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:v0.2.0 docs/tutorials/resources/aggregated/blueprint
+landscaper-cli blueprints push eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:v0.2.2 docs/tutorials/resources/aggregated/blueprint
 ```
 
 #### Create the ComponentDescriptor
@@ -246,7 +246,7 @@ meta:
 
 component:
   name: github.com/gardener/landscaper/simple-aggregated
-  version: v0.2.0
+  version: v0.2.2
 
   provider: internal
 
@@ -257,16 +257,16 @@ component:
   resources:
   - type: blueprint
     name: simple-aggregated
-    version: v0.2.0
+    version: v0.2.2
     relation: local
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:v0.2.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:v0.2.2
 
   componentReferences:
   - name: ingress
     componentName: github.com/gardener/landscaper/ingress-nginx
-    version: v0.3.0
+    version: v0.3.2
   - name: server
     componentName: github.com/gardener/landscaper/echo-server
     version: v0.2.0
@@ -299,7 +299,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/my-project/comp
       componentName: github.com/gardener/landscaper/simple-aggregated
-      version: v0.2.0
+      version: v0.2.2
 
   blueprint:
     ref:

--- a/docs/tutorials/resources/aggregated/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/aggregated/blueprint/blueprint.yaml
@@ -4,7 +4,7 @@
 
 # This version number is parsed by hack/upload-tutorial-resources.sh - it is not part of any official blueprint
 #
-# TUTORIAL_BLUEPRINT_VERSION: v0.2.0
+# TUTORIAL_BLUEPRINT_VERSION: v0.2.2
 
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint

--- a/docs/tutorials/resources/aggregated/component-descriptor.yaml
+++ b/docs/tutorials/resources/aggregated/component-descriptor.yaml
@@ -7,7 +7,7 @@ meta:
 
 component:
   name: github.com/gardener/landscaper/simple-aggregated
-  version: v0.2.0
+  version: v0.2.2
 
   provider: internal
 
@@ -20,16 +20,16 @@ component:
   resources:
   - type: blueprint
     name: simple-aggregated
-    version: v0.2.0
+    version: v0.2.2
     relation: local
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:v0.2.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/simple-aggregated:v0.2.2
 
   componentReferences:
   - name: ingress
     componentName: github.com/gardener/landscaper/ingress-nginx
-    version: v0.3.0
+    version: v0.3.2
   - name: server
     componentName: github.com/gardener/landscaper/echo-server
     version: v0.2.0

--- a/docs/tutorials/resources/aggregated/installation.yaml
+++ b/docs/tutorials/resources/aggregated/installation.yaml
@@ -13,7 +13,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/simple-aggregated
-      version: v0.2.0
+      version: v0.2.2
 
   blueprint:
     ref:

--- a/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
@@ -37,6 +37,8 @@ deployExecutions:
           {{ $resource := getResource .cd "name" "ingress-nginx-chart" }}
           ref: {{ $resource.access.imageReference }}
 
+        helmDeployment: true
+
         updateStrategy: patch
 
         name: test

--- a/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/ingress-nginx/blueprint/blueprint.yaml
@@ -4,7 +4,7 @@
 
 # This version number is parsed by hack/upload-tutorial-resources.sh - it is not part of any official blueprint
 #
-# TUTORIAL_BLUEPRINT_VERSION: v0.3.1
+# TUTORIAL_BLUEPRINT_VERSION: v0.3.2
 
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Blueprint

--- a/docs/tutorials/resources/ingress-nginx/component-descriptor.yaml
+++ b/docs/tutorials/resources/ingress-nginx/component-descriptor.yaml
@@ -7,7 +7,7 @@ meta:
 
 component:
   name: github.com/gardener/landscaper/ingress-nginx
-  version: v0.3.1
+  version: v0.3.2
 
   provider: internal
 
@@ -21,15 +21,15 @@ component:
   resources:
   - type: blueprint
     name: ingress-nginx-blueprint
-    version: v0.3.1
+    version: v0.3.2
     relation: local
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:v0.3.1
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:v0.3.2
   - type: helm
     name: ingress-nginx-chart
-    version: v3.29.0
+    version: 4.0.17
     relation: external
     access:
       type: ociRegistry
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17

--- a/docs/tutorials/resources/ingress-nginx/installation.yaml
+++ b/docs/tutorials/resources/ingress-nginx/installation.yaml
@@ -13,7 +13,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/ingress-nginx
-      version: v0.3.1
+      version: v0.3.2
 
   blueprint:
     ref:

--- a/docs/tutorials/resources/local-ingress-nginx/blueprint/blueprint.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/blueprint/blueprint.yaml
@@ -34,6 +34,8 @@ deployExecutions:
     {{ toYaml .componentDescriptorDef | indent 8 }}
             resourceName: ingress-nginx-chart
 
+        helmDeployment: true
+
         updateStrategy: patch
 
         name: test

--- a/docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/component-descriptor.yaml
@@ -5,24 +5,8 @@ component:
   repositoryContexts:
   - baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
     type: ociRegistry
-  resources:
-  - access:
-      filename: sha256:06228646f3e2a11957a7700cfe39a1d6cd094ae4127b1fa0ba18bd5a3346cf53
-      mediaType: application/gzip
-      type: localFilesystemBlob
-    name: ingress-nginx-chart
-    relation: external
-    type: helm
-    version: v3.29.0
-  - access:
-      filename: sha256:a3df07057c53ca29c6cd35ac75d38d71d473210351a34a22bf154575c66702d3
-      mediaType: application/vnd.gardener.landscaper.blueprint.v1+tar+gzip
-      type: localFilesystemBlob
-    name: ingress-nginx-blueprint
-    relation: local
-    type: blueprint
-    version: v0.3.1
+  resources: []
   sources: []
-  version: v0.3.1
+  version: v0.3.2
 meta:
   schemaVersion: v2

--- a/docs/tutorials/resources/local-ingress-nginx/installation.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/installation.yaml
@@ -13,7 +13,7 @@ spec:
         type: ociRegistry
         baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
       componentName: github.com/gardener/landscaper/local/ingress-nginx
-      version: v0.3.1
+      version: v0.3.2
   blueprint:
     ref:
       resourceName: ingress-nginx-blueprint

--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -116,6 +116,9 @@ func (h *Helm) ApplyFiles(ctx context.Context, files, crds map[string]string, ex
 		return err
 	}
 
+	h.DeployItem.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
+	h.DeployItem.Status.LastError = nil
+
 	return nil
 }
 
@@ -224,9 +227,6 @@ func (h *Helm) checkResourcesReady(ctx context.Context, client client.Client) er
 			}
 		}
 	}
-
-	h.DeployItem.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
-	h.DeployItem.Status.LastError = nil
 
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority 3

**What this PR does / why we need it**:
- This pull request updates the version of the ingress-nginx chart that is used in the tutorials and integration tests.
- The tests are now using the "real" helm deployer for this chart.
- The helm deployer sets the phase `Succeeded`after collecting export data. This solves issue #445 .

**Which issue(s) this PR fixes**:
Fixes #445 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
