### PR TITLE
helm 3 as default

### DIFF
--- a/.landscaper/container-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/container-deployer/blueprint/blueprint.yaml
@@ -64,6 +64,7 @@ deployExecutions:
         updateStrategy: update
         name: {{ .imports.releaseName }}
         namespace: {{ .imports.releaseNamespace }}
+        helmDeployment: false
         chart:
           {{ $resource := getResource .cd "name" "container-deployer-chart" }}
           ref: {{ $resource.access.imageReference }}

--- a/.landscaper/helm-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/helm-deployer/blueprint/blueprint.yaml
@@ -64,6 +64,7 @@ deployExecutions:
         updateStrategy: update
         name: {{ .imports.releaseName }}
         namespace: {{ .imports.releaseNamespace }}
+        helmDeployment: false
         chart:
           {{ $resource := getResource .cd "name" "helm-deployer-chart" }}
           ref: {{ $resource.access.imageReference }}

--- a/.landscaper/manifest-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/manifest-deployer/blueprint/blueprint.yaml
@@ -64,6 +64,7 @@ deployExecutions:
         updateStrategy: update
         name: {{ .imports.releaseName }}
         namespace: {{ .imports.releaseNamespace }}
+        helmDeployment: false
         chart:
           {{ $resource := getResource .cd "name" "manifest-deployer-chart" }}
           ref: {{ $resource.access.imageReference }}

--- a/.landscaper/mock-deployer/blueprint/blueprint.yaml
+++ b/.landscaper/mock-deployer/blueprint/blueprint.yaml
@@ -64,6 +64,7 @@ deployExecutions:
         updateStrategy: update
         name: {{ .imports.releaseName }}
         namespace: {{ .imports.releaseNamespace }}
+        helmDeployment: false
         chart:
           {{ $resource := getResource .cd "name" "mock-deployer-chart" }}
           ref: {{ $resource.access.imageReference }}

--- a/apis/.schemes/helm-v1alpha1-ProviderConfiguration.json
+++ b/apis/.schemes/helm-v1alpha1-ProviderConfiguration.json
@@ -746,7 +746,7 @@
       "type": "array"
     },
     "helmDeployment": {
-      "description": "HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating.",
+      "description": "HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating. Default is true.",
       "type": "boolean"
     },
     "helmDeploymentConfig": {

--- a/apis/deployer/helm/types_provider.go
+++ b/apis/deployer/helm/types_provider.go
@@ -75,8 +75,9 @@ type ProviderConfiguration struct {
 	ContinuousReconcile *cr.ContinuousReconcileSpec `json:"continuousReconcile,omitempty"`
 
 	// HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating.
+	// Default is true.
 	// +optional
-	HelmDeployment bool `json:"helmDeployment,omitempty"`
+	HelmDeployment *bool `json:"helmDeployment,omitempty"`
 
 	// HelmDeploymentConfig contains settings for helm operations. Only relevant if HelmDeployment is true.
 	// +optional

--- a/apis/deployer/helm/v1alpha1/types_provider.go
+++ b/apis/deployer/helm/v1alpha1/types_provider.go
@@ -73,8 +73,9 @@ type ProviderConfiguration struct {
 	ContinuousReconcile *cr.ContinuousReconcileSpec `json:"continuousReconcile,omitempty"`
 
 	// HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating.
+	// Default is true.
 	// +optional
-	HelmDeployment bool `json:"helmDeployment,omitempty"`
+	HelmDeployment *bool `json:"helmDeployment,omitempty"`
 
 	// HelmDeploymentConfig contains settings for helm operations. Only relevant if HelmDeployment is true.
 	// +optional

--- a/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -422,7 +422,7 @@ func autoConvert_v1alpha1_ProviderConfiguration_To_helm_ProviderConfiguration(in
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))
 	out.ContinuousReconcile = (*continuousreconcile.ContinuousReconcileSpec)(unsafe.Pointer(in.ContinuousReconcile))
-	out.HelmDeployment = in.HelmDeployment
+	out.HelmDeployment = (*bool)(unsafe.Pointer(in.HelmDeployment))
 	out.HelmDeploymentConfig = (*helm.HelmDeploymentConfiguration)(unsafe.Pointer(in.HelmDeploymentConfig))
 	return nil
 }
@@ -447,7 +447,7 @@ func autoConvert_helm_ProviderConfiguration_To_v1alpha1_ProviderConfiguration(in
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))
 	out.ContinuousReconcile = (*continuousreconcile.ContinuousReconcileSpec)(unsafe.Pointer(in.ContinuousReconcile))
-	out.HelmDeployment = in.HelmDeployment
+	out.HelmDeployment = (*bool)(unsafe.Pointer(in.HelmDeployment))
 	out.HelmDeploymentConfig = (*HelmDeploymentConfiguration)(unsafe.Pointer(in.HelmDeploymentConfig))
 	return nil
 }

--- a/apis/deployer/helm/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/deployer/helm/v1alpha1/zz_generated.deepcopy.go
@@ -297,6 +297,11 @@ func (in *ProviderConfiguration) DeepCopyInto(out *ProviderConfiguration) {
 		*out = new(continuousreconcile.ContinuousReconcileSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HelmDeployment != nil {
+		in, out := &in.HelmDeployment, &out.HelmDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HelmDeploymentConfig != nil {
 		in, out := &in.HelmDeploymentConfig, &out.HelmDeploymentConfig
 		*out = new(HelmDeploymentConfiguration)

--- a/apis/deployer/helm/zz_generated.deepcopy.go
+++ b/apis/deployer/helm/zz_generated.deepcopy.go
@@ -298,6 +298,11 @@ func (in *ProviderConfiguration) DeepCopyInto(out *ProviderConfiguration) {
 		*out = new(continuousreconcile.ContinuousReconcileSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HelmDeployment != nil {
+		in, out := &in.HelmDeployment, &out.HelmDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HelmDeploymentConfig != nil {
 		in, out := &in.HelmDeploymentConfig, &out.HelmDeploymentConfig
 		*out = new(HelmDeploymentConfiguration)

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -7812,7 +7812,7 @@ func schema_apis_deployer_helm_v1alpha1_ProviderConfiguration(ref common.Referen
 					},
 					"helmDeployment": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating.",
+							Description: "HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating. Default is true.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -2,7 +2,7 @@
 
 The helm deployer is a controller that reconciles DeployItems of type `landscaper.gardener.cloud/helm`. There are two
 alternative working modes of the helm deployer. One renders a given helm chart and deploys the resulting manifest into 
-a cluster. The other deploys a helm chart with [helm 3](https://helm.sh/). 
+a cluster. The other deploys a helm chart with [helm 3](https://helm.sh/). The second case is the default.
 
 By default, the helm deployer checks the health of the deployed resources. See [healthchecks.md](healthchecks.md) for more info.
 
@@ -11,10 +11,10 @@ By default, the helm deployer checks the health of the deployed resources. See [
 - [Provider Status](#status)
 - [Deployer Configuration](#deployer-configuration)
 
-### Provider Configuration
+## Provider Configuration
 
-This sections describes the provider specific configuration. The following example defines a deployment which just 
-renders the manifests with helm and deploys them. 
+This sections describes the provider specific configuration. The following example defines a deployment which deploys
+a helm chart with helm 3. 
 
 ```yaml
 apiVersion: landscaper.gardener.cloud/v1alpha1
@@ -45,6 +45,17 @@ spec:
         resourceName: my-helm-chart
       archive:
         raw: "" # base64 encoded helm chart tar.gz
+
+    # settings for the different helm 3 operations 
+    helmDeploymentConfig:
+      install: # see  https://helm.sh/docs/helm/helm_install/#options
+        atomic: true
+        timeout: 10m
+      upgrade: # see https://helm.sh/docs/helm/helm_upgrade/#options
+        atomic: true
+        timeout: 10m
+      uninstall: # see https://helm.sh/docs/helm/helm_uninstall/#options
+        timeout: 15m
 
     # base64 encoded kubeconfig pointing to the cluster to install the chart
     kubeconfig: xxx
@@ -170,9 +181,10 @@ For a complete documentation of the available jsonPath see here (https://kuberne
 
 :warning: Only unique identifiable resources (_apiVersion_, _kind_, _name_ and _namespace_).
 
-If you want to deploy the chart with helm 3 you just need to add the field `helmDeployment: true` to the provider 
-configuration as shown in the following example. A complete example could be found 
-[here](https://github.com/gardener/landscaper-examples/tree/master/helm-deployer/real-helm-deployment).
+## Manifest-Only Deployment
+
+If you want to deploy the chart not with helm 3 but only apply the manifests you just need to add the field 
+`helmDeployment: false` to the provider configuration as shown in the following example. 
 
 ```yaml
 apiVersion: landscaper.gardener.cloud/v1alpha1
@@ -193,35 +205,9 @@ spec:
     chart:
       ...
 
-    # specifies that helm 3 is used to deploy the chart
-    helmDeployment: true
-    
-    # settings for the different helm 3 operations
-    helmDeploymentConfig:
-      install:
-        atomic: true
-        timeout: 10m
-      upgrade:
-        atomic: true
-        timeout: 10m
-      uninstall:
-        timeout: 15m
-    ...
+    # specifies that only the rendered manifests are applied
+    helmDeployment: false
 ```
-
-For the deployment with helm 3 you could specify an optional `helmDeploymentConfig` where you could specify 
-the following settings for the install, upgrade and uninstall command:
-
-- `atomic`
-- `timeout`
-
-You find more information about these setting here:
-
-- https://helm.sh/docs/helm/helm_install/#options
-- https://helm.sh/docs/helm/helm_upgrade/#options
-- https://helm.sh/docs/helm/helm_uninstall/#options
-
-In the future further options of helm 3 will be supported.
 
 ##### Continuous Reconciliation
 For information on the continuous reconciliation configuration, see [here](../development/deployer-extensions##continuous-reconcile-extension) under 'usage'.
@@ -404,4 +390,7 @@ CR.
 
 You find a complete example [here](https://github.com/gardener/landscaper-examples/tree/master/helm-deployer/helm-repo-protected).
 
+## Examples
 
+Other example could be found
+[here](https://github.com/gardener/landscaper-examples/tree/master/helm-deployer).

--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -71,7 +71,7 @@ func (h *Helm) ApplyFiles(ctx context.Context, files, crds map[string]string, ex
 		deployErr                 error
 	)
 
-	if !h.ProviderConfiguration.HelmDeployment {
+	if h.ProviderConfiguration.HelmDeployment != nil && !(*h.ProviderConfiguration.HelmDeployment) {
 		var applier *resourcemanager.ManifestApplier
 		applier, deployErr = h.applyManifests(ctx, targetClient, targetClientSet, manifests)
 		managedResourceStatusList = applier.GetManagedResourcesStatus()
@@ -267,7 +267,7 @@ func (h *Helm) readExportValues(ctx context.Context, currOp string, targetClient
 
 // DeleteFiles deletes the managed resources from the target cluster.
 func (h *Helm) DeleteFiles(ctx context.Context) error {
-	if !h.ProviderConfiguration.HelmDeployment {
+	if h.ProviderConfiguration.HelmDeployment != nil && !(*h.ProviderConfiguration.HelmDeployment) {
 		return h.deleteManifests(ctx)
 	} else {
 		return h.deleteManifestsWithRealHelmDeployer(ctx)

--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Helm Deployer", func() {
 
 		// create helm provider config
 		providerConfig := &helmv1alpha1.ProviderConfiguration{}
+		providerConfig.HelmDeployment = pointer.Bool(false)
 		providerConfig.Chart.Ref = "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0"
 		providerConfig.Name = "ingress-test"
 		providerConfig.Namespace = state.Namespace

--- a/test/landscaper/deployer_blueprints/deployer_blueprint_test.go
+++ b/test/landscaper/deployer_blueprints/deployer_blueprint_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Blueprint", func() {
   "chart": {
     "ref": "eu.gcr.io/gardener-project/landscaper/charts/container-deployer-controller:v0.5.3"
   },
+  "helmDeployment": false,
   "kind": "ProviderConfiguration",
   "name": "landscaper-container-deployer",
   "namespace": "container-deployer",
@@ -104,6 +105,7 @@ var _ = Describe("Blueprint", func() {
   "chart": {
     "ref": "eu.gcr.io/gardener-project/landscaper/charts/helm-deployer-controller:v0.5.3"
   },
+  "helmDeployment": false,
   "kind": "ProviderConfiguration",
   "name": "landscaper-helm-deployer",
   "namespace": "helm-deployer",
@@ -145,6 +147,7 @@ var _ = Describe("Blueprint", func() {
   "chart": {
     "ref": "eu.gcr.io/gardener-project/landscaper/charts/manifest-deployer-controller:v0.5.3"
   },
+  "helmDeployment": false,
   "kind": "ProviderConfiguration",
   "name": "landscaper-manifest-deployer",
   "namespace": "manifest-deployer",
@@ -186,6 +189,7 @@ var _ = Describe("Blueprint", func() {
   "chart": {
     "ref": "eu.gcr.io/gardener-project/landscaper/charts/mock-deployer-controller:v0.5.3"
   },
+  "helmDeployment": false,
   "kind": "ProviderConfiguration",
   "name": "landscaper-mock-deployer",
   "namespace": "mock-deployer",

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/types_provider.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/types_provider.go
@@ -75,8 +75,9 @@ type ProviderConfiguration struct {
 	ContinuousReconcile *cr.ContinuousReconcileSpec `json:"continuousReconcile,omitempty"`
 
 	// HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating.
+	// Default is true.
 	// +optional
-	HelmDeployment bool `json:"helmDeployment,omitempty"`
+	HelmDeployment *bool `json:"helmDeployment,omitempty"`
 
 	// HelmDeploymentConfig contains settings for helm operations. Only relevant if HelmDeployment is true.
 	// +optional

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/types_provider.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/types_provider.go
@@ -73,8 +73,9 @@ type ProviderConfiguration struct {
 	ContinuousReconcile *cr.ContinuousReconcileSpec `json:"continuousReconcile,omitempty"`
 
 	// HelmDeployment indicates that helm is used as complete deployment mechanism and not only helm templating.
+	// Default is true.
 	// +optional
-	HelmDeployment bool `json:"helmDeployment,omitempty"`
+	HelmDeployment *bool `json:"helmDeployment,omitempty"`
 
 	// HelmDeploymentConfig contains settings for helm operations. Only relevant if HelmDeployment is true.
 	// +optional

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -422,7 +422,7 @@ func autoConvert_v1alpha1_ProviderConfiguration_To_helm_ProviderConfiguration(in
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))
 	out.ContinuousReconcile = (*continuousreconcile.ContinuousReconcileSpec)(unsafe.Pointer(in.ContinuousReconcile))
-	out.HelmDeployment = in.HelmDeployment
+	out.HelmDeployment = (*bool)(unsafe.Pointer(in.HelmDeployment))
 	out.HelmDeploymentConfig = (*helm.HelmDeploymentConfiguration)(unsafe.Pointer(in.HelmDeploymentConfig))
 	return nil
 }
@@ -447,7 +447,7 @@ func autoConvert_helm_ProviderConfiguration_To_v1alpha1_ProviderConfiguration(in
 	out.ExportsFromManifests = *(*[]managedresource.Export)(unsafe.Pointer(&in.ExportsFromManifests))
 	out.Exports = (*managedresource.Exports)(unsafe.Pointer(in.Exports))
 	out.ContinuousReconcile = (*continuousreconcile.ContinuousReconcileSpec)(unsafe.Pointer(in.ContinuousReconcile))
-	out.HelmDeployment = in.HelmDeployment
+	out.HelmDeployment = (*bool)(unsafe.Pointer(in.HelmDeployment))
 	out.HelmDeploymentConfig = (*HelmDeploymentConfiguration)(unsafe.Pointer(in.HelmDeploymentConfig))
 	return nil
 }

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.deepcopy.go
@@ -297,6 +297,11 @@ func (in *ProviderConfiguration) DeepCopyInto(out *ProviderConfiguration) {
 		*out = new(continuousreconcile.ContinuousReconcileSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HelmDeployment != nil {
+		in, out := &in.HelmDeployment, &out.HelmDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HelmDeploymentConfig != nil {
 		in, out := &in.HelmDeploymentConfig, &out.HelmDeploymentConfig
 		*out = new(HelmDeploymentConfiguration)

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/zz_generated.deepcopy.go
@@ -298,6 +298,11 @@ func (in *ProviderConfiguration) DeepCopyInto(out *ProviderConfiguration) {
 		*out = new(continuousreconcile.ContinuousReconcileSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HelmDeployment != nil {
+		in, out := &in.HelmDeployment, &out.HelmDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HelmDeploymentConfig != nil {
 		in, out := &in.HelmDeploymentConfig, &out.HelmDeploymentConfig
 		*out = new(HelmDeploymentConfiguration)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind api-change
/priority 3

**What this PR does / why we need it**:

Helm charts are deployed with helm 3 per default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Helm charts are deployed with helm 3 per default.
```
