### PR TITLE
Integration test for a helm chart upgrade

### DIFF
--- a/docs/tutorials/resources/ingress-nginx-upgrade/README.md
+++ b/docs/tutorials/resources/ingress-nginx-upgrade/README.md
@@ -1,0 +1,3 @@
+This directory contains a newer version of the component descriptor 
+[ingress-nginx/component-descriptor.yaml](../ingress-nginx/component-descriptor.yaml).
+This newer version uses the same blueprint, and a newer version of the ingress-nginx helm chart.

--- a/docs/tutorials/resources/ingress-nginx-upgrade/component-descriptor.yaml
+++ b/docs/tutorials/resources/ingress-nginx-upgrade/component-descriptor.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: v2
+
+component:
+  name: github.com/gardener/landscaper/ingress-nginx
+  version: v0.3.3
+
+  provider: internal
+
+  repositoryContexts:
+  - type: ociRegistry
+    baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
+
+  sources: [ ]
+  componentReferences: [ ]
+
+  resources:
+  - type: blueprint
+    name: ingress-nginx-blueprint
+    version: v0.3.3
+    relation: local
+    access:
+      type: ociRegistry
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/blueprints/ingress-nginx:v0.3.2
+  - type: helm
+    name: ingress-nginx-chart
+    version: 4.0.18
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18

--- a/docs/tutorials/resources/ingress-nginx-upgrade/installation.yaml
+++ b/docs/tutorials/resources/ingress-nginx-upgrade/installation.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: my-ingress
+spec:
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: ociRegistry
+        baseUrl: eu.gcr.io/gardener-project/landscaper/tutorials/components
+      componentName: github.com/gardener/landscaper/ingress-nginx
+      version: v0.3.3
+
+  blueprint:
+    ref:
+      resourceName: ingress-nginx-blueprint
+
+  imports:
+    targets:
+    - name: cluster
+      # the "#" forces the landscaper to use the target with the name "my-cluster" in the same namespace
+      target: "#my-cluster"
+    data:
+    - name: namespace
+      configMapRef:
+        key: "namespace"
+        name: "my-imports" # name of the configmap;
+        # namespace: default # the namespace will be defaulted to the namespace of the installation.
+
+  exports:
+    data:
+    - name: ingressClass
+      dataRef: "myIngressClass"

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -69,6 +69,32 @@ func NginxIngressTest(f *framework.Framework) {
 			nginxIngressObjectKey := kutil.ObjectKey(nginxIngressDeploymentName, state.Namespace)
 			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, nginxIngressObjectKey, 2*time.Minute))
 
+			// Update the installation to use the next component descriptor version (see
+			// docs/tutorials/resources/ingress-nginx-upgrade/component-descriptor.yaml) with the next nginx version.
+			ginkgo.By("Upgrade installation")
+			instKey := kutil.ObjectKey(inst.Name, inst.Namespace)
+			inst = &lsv1alpha1.Installation{}
+			utils.ExpectNoError(f.Client.Get(ctx, instKey, inst))
+			inst.Spec.ComponentDescriptor.Reference.Version = "v0.3.3"
+			err = f.Client.Update(ctx, inst)
+			utils.ExpectNoError(err)
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, inst, 2*time.Minute))
+
+			deployItems, err = lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			utils.ExpectNoError(err)
+			gomega.Expect(deployItems).To(gomega.HaveLen(1))
+			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+
+			// expect that the nginx deployment is successfully running
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, nginxIngressObjectKey, 2*time.Minute))
+
+			// check the new chart version in label "helm.sh/chart" of the deployment
+			deploy := &appsv1.Deployment{}
+			utils.ExpectNoError(f.Client.Get(ctx, nginxIngressObjectKey, deploy))
+			gomega.Expect(deploy.GetLabels()).To(gomega.HaveKeyWithValue("helm.sh/chart", "ingress-nginx-4.0.18"))
+
 			ginkgo.By("Delete installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind test
/priority 3

**What this PR does / why we need it**:
This pull requests enhances the integration tests of the helm deployer. It adds a test for the upgrade of a helm chart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
