### PR TITLE
Integrationtest version check

### DIFF
--- a/test/integration/deployers/helmcharts/chartstests.go
+++ b/test/integration/deployers/helmcharts/chartstests.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -128,14 +127,7 @@ func deployDeployItemAndWaitForSuccess(
 	By("Waiting for the DeployItem to succeed")
 	utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
 	By("Waiting for the corresponding Deployment to become ready")
-
-	// check deployment image version
-	deploy := &appsv1.Deployment{}
 	deployKey := kutil.ObjectKey(deployerName, state.Namespace)
-	utils.ExpectNoError(f.Client.Get(ctx, deployKey, deploy))
-	splitImage := strings.Split(deploy.Spec.Template.Spec.Containers[0].Image, ":")
-	Expect(splitImage[len(splitImage)-1]).To(Equal(f.LsVersion))
-
 	utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, deployKey, 2*time.Minute))
 
 	return di

--- a/test/integration/deployers/register.go
+++ b/test/integration/deployers/register.go
@@ -6,15 +6,18 @@ package deployers
 
 import (
 	"github.com/gardener/landscaper/test/framework"
+	"github.com/gardener/landscaper/test/integration/deployers/blueprints"
+	"github.com/gardener/landscaper/test/integration/deployers/continuousreconcile"
 	"github.com/gardener/landscaper/test/integration/deployers/helmcharts"
+	"github.com/gardener/landscaper/test/integration/deployers/management"
 )
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	//ContainerDeployerTests(f)
-	//ManifestDeployerTests(f)
+	ContainerDeployerTests(f)
+	ManifestDeployerTests(f)
 	helmcharts.RegisterTests(f)
-	//blueprints.RegisterTests(f)
-	//management.RegisterTests(f)
-	//continuousreconcile.RegisterTests(f)
+	blueprints.RegisterTests(f)
+	management.RegisterTests(f)
+	continuousreconcile.RegisterTests(f)
 }

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -9,6 +9,13 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/gardener/landscaper/test/integration/core"
+	"github.com/gardener/landscaper/test/integration/deployitems"
+	"github.com/gardener/landscaper/test/integration/executions"
+	"github.com/gardener/landscaper/test/integration/installations"
+	"github.com/gardener/landscaper/test/integration/tutorial"
+	"github.com/gardener/landscaper/test/integration/webhook"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -46,13 +53,13 @@ func TestConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//tutorial.RegisterTests(f)
-	//webhook.RegisterTests(f)
-	//core.RegisterTests(f)
+	tutorial.RegisterTests(f)
+	webhook.RegisterTests(f)
+	core.RegisterTests(f)
 	deployers.RegisterTests(f)
-	//deployitems.RegisterTests(f)
-	//installations.RegisterTests(f)
-	//executions.RegisterTests(f)
+	deployitems.RegisterTests(f)
+	installations.RegisterTests(f)
+	executions.RegisterTests(f)
 
 	AfterSuite(func() {
 		f.Cleanup.Run()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority 3

**What this PR does / why we need it**:
Fixes the integration test and the failing release job.

At the time when the integration test runs during a release job, the change which increases the version numbers in the `Chart.yaml` files of the Landscaper helm charts has not yet been committed. Therefore, the new numbers are not set if the test machinery clones the Landscaper repository and runs the tests based on the cloned repository. The check, that expects the new version number, must therefore fail. This pull request removes the check. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
