### PR TITLE
fixed the calculation of the line prefix width

### DIFF
--- a/pkg/landscaper/installations/executions/template/gotemplate/gotemplate_suite_test.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/gotemplate_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gotemplate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Installations Executions Test Suite")
+}

--- a/pkg/landscaper/installations/executions/template/gotemplate/helper.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/helper.go
@@ -6,6 +6,7 @@ package gotemplate
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -14,6 +15,8 @@ const (
 	sourceCodePrepend = 5
 	// sourceCodeAppend the number of lines after the error line that are printed.
 	sourceCodeAppend = 5
+	// sourceIndentation is the fixed width of the code line prefix containing the line number.
+	sourceIndentation = 6
 )
 
 // CreateSourceSnippet creates an excerpt of lines of source code, containing some lines before
@@ -40,7 +43,6 @@ func CreateSourceSnippet(errorLine, errorColumn int, source []string) string {
 	sourceStartLine = errorLine - sourceCodePrepend
 	if sourceStartLine < 0 {
 		sourceStartLine = 0
-
 	}
 
 	errorLine -= sourceStartLine
@@ -57,8 +59,14 @@ func CreateSourceSnippet(errorLine, errorColumn int, source []string) string {
 	for i, line := range source {
 		// for printing, the line has to be converted back to one based index
 		realLine := sourceStartLine + i + 1
+		realLineWidth := int(math.Log10(float64(realLine)) + 1)
+		// account for the colon after the line number
+		repeat := sourceIndentation - realLineWidth - 1
+		if repeat < 0 {
+			repeat = 0
+		}
 		// the prefix contains the line number and some amount of whitespaces to keep the correct indentation
-		prefix := fmt.Sprintf("%d:%s", realLine, strings.Repeat(" ", 4-(realLine/10)))
+		prefix := fmt.Sprintf("%d:%s", realLine, strings.Repeat(" ", repeat))
 		formatted.WriteString(fmt.Sprintf("%s%s\n", prefix, line))
 
 		if i == errorLine {

--- a/pkg/landscaper/installations/executions/template/gotemplate/helper_test.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/helper_test.go
@@ -6,6 +6,7 @@ package gotemplate_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/pkg/landscaper/installations/executions/template/gotemplate/helper_test.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/helper_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gotemplate_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/gotemplate"
+)
+
+var _ = Describe("SourceSnippet", func() {
+	It("should format a source snippet with the correct format", func() {
+		lines := make([]string, 0, 5)
+		for i := 0; i < 50; i++ {
+			lines = append(lines, fmt.Sprintf("val%d: %d", i, i))
+		}
+		snippet := gotemplate.CreateSourceSnippet(len(lines)-1, 7, lines)
+		expected := "44:   val43: 43\n45:   val44: 44\n46:   val45: 45\n47:   val46: 46\n48:   val47: 47\n49:   val48: 48\n             \u02c6≈≈≈≈≈≈≈\n50:   val49: 49\n"
+		Expect(snippet).To(Equal(expected))
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority 3

**What this PR does / why we need it**:

Fixes the calculation of the line prefix width containing the line number. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
