### PR TITLE
Delete without uninstall

### DIFF
--- a/apis/core/v1alpha1/constants.go
+++ b/apis/core/v1alpha1/constants.go
@@ -25,6 +25,10 @@ const (
 	// OperationAnnotation is the annotation that specifies a operation for a component
 	OperationAnnotation = "landscaper.gardener.cloud/operation"
 
+	// DeleteWithoutUninstallAnnotation is the annotation that specifies that root installations are deleted without
+	// uninstalling the deployed artifacts
+	DeleteWithoutUninstallAnnotation = "landscaper.gardener.cloud/delete-without-uninstall"
+
 	// ReconcileTimestampAnnotation is used to recognize timeouts in deployitems
 	ReconcileTimestampAnnotation = "landscaper.gardener.cloud/reconcile-time"
 

--- a/apis/core/v1alpha1/helper/helpers.go
+++ b/apis/core/v1alpha1/helper/helpers.go
@@ -314,3 +314,11 @@ func HasIgnoreAnnotation(obj metav1.ObjectMeta) bool {
 	v, ok := obj.GetAnnotations()[v1alpha1.IgnoreAnnotation]
 	return ok && v == "true"
 }
+
+// HasDeleteWithoutUninstallAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/delete-without-uninstall' annotation
+// and its value is 'true'.
+func HasDeleteWithoutUninstallAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.DeleteWithoutUninstallAnnotation]
+	return ok && v == "true"
+}

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -25,6 +25,10 @@ const (
 	// OperationAnnotation is the annotation that specifies a operation for a component
 	OperationAnnotation = "landscaper.gardener.cloud/operation"
 
+	// DeleteWithoutUninstallAnnotation is the annotation that specifies that root installations are deleted without
+	// uninstalling the deployed artifacts
+	DeleteWithoutUninstallAnnotation = "landscaper.gardener.cloud/delete-without-uninstall"
+
 	// ReconcileTimestampAnnotation is used to recognize timeouts in deployitems
 	ReconcileTimestampAnnotation = "landscaper.gardener.cloud/reconcile-time"
 

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -87,3 +87,20 @@ The abort operation annotation is not removed automatically.
 
 The effect of this annotation is the same for all landscaper resources: the respective resource will not be reconciled by the landscaper, even if its spec changed or the operation annotation says otherwise. Only resources in a non-final phase are affected, to interrupt a running installation/execution/deployitem, the `landscaper.gardener.cloud/operation: abort` annotation has to be used. The phases `Succeeded`, `Failed`, and `Aborted` are considered to be final.
 Please note that as long as an update of a resource is blocked from reconciliation by this annotation, all other landscaper resources which are waiting for the update (because they depend on the resource) won't be able to be reconciled either and will be stuck.
+
+## Delete-Without-Uninstall Annotation
+
+**Annotation:** `landscaper.gardener.cloud/delete-without-uninstall`
+
+**Accepted values:**
+- `true`
+
+#### Effect on Installations/Executions/DeployItems
+
+If the annotation `landscaper.gardener.cloud/delete-without-uninstall: "true"` has been added to an installation, then
+afterwards a deletion of the installation has the following effect:
+
+- the installation, its subinstallations, executions, and deployitems will be deleted,
+- the installed artifacts on the target clusters will not be deleted.
+
+Note that you have to add the annotation **before** you delete the installation.

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -376,9 +376,14 @@ func (c *controller) reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, d
 }
 
 func (c *controller) delete(ctx context.Context, lsCtx *lsv1alpha1.Context, deployItem *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	if err := c.deployer.Delete(ctx, lsCtx, deployItem, target); err != nil {
-		return err
+	if lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(deployItem.ObjectMeta) {
+		c.log.Info("Deleting deploy item %s without uninstall", deployItem.Name)
+	} else {
+		if err := c.deployer.Delete(ctx, lsCtx, deployItem, target); err != nil {
+			return err
+		}
 	}
+
 	if controllerutil.ContainsFinalizer(deployItem, lsv1alpha1.LandscaperFinalizer) {
 		controllerutil.RemoveFinalizer(deployItem, lsv1alpha1.LandscaperFinalizer)
 		if err := c.lsClient.Update(ctx, deployItem); err != nil {

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -9,6 +9,10 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -159,6 +163,14 @@ func deleteExecution(ctx context.Context, kubeClient client.Client, inst *lsv1al
 		return true, nil
 	}
 
+	if lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(inst.ObjectMeta) {
+		metav1.SetMetaDataAnnotation(&exec.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
+		if err := kubeClient.Update(ctx, exec); err != nil {
+			return false, fmt.Errorf("unable to add delete-without-uninstall annotation to execution %s: %w",
+				exec.Name, err)
+		}
+	}
+
 	if exec.DeletionTimestamp.IsZero() {
 		if err := kubeClient.Delete(ctx, exec); err != nil {
 			return false, err
@@ -175,8 +187,8 @@ func deleteExecution(ctx context.Context, kubeClient client.Client, inst *lsv1al
 	return false, nil
 }
 
-func deleteSubInstallations(ctx context.Context, kubeClient client.Client, inst *lsv1alpha1.Installation) (bool, error) {
-	subInsts, err := installations.ListSubinstallations(ctx, kubeClient, inst)
+func deleteSubInstallations(ctx context.Context, kubeClient client.Client, parentInst *lsv1alpha1.Installation) (bool, error) {
+	subInsts, err := installations.ListSubinstallations(ctx, kubeClient, parentInst)
 	if err != nil {
 		return false, err
 	}
@@ -184,21 +196,48 @@ func deleteSubInstallations(ctx context.Context, kubeClient client.Client, inst 
 		return true, nil
 	}
 
-	for _, inst := range subInsts {
-		if inst.DeletionTimestamp.IsZero() {
-			if err := kubeClient.Delete(ctx, inst); err != nil {
+	if err := propagateDeleteWithoutUninstallAnnotation(ctx, kubeClient, parentInst, subInsts); err != nil {
+		return false, err
+	}
+
+	for _, subInst := range subInsts {
+		if subInst.DeletionTimestamp.IsZero() {
+			if err := kubeClient.Delete(ctx, subInst); err != nil {
 				return false, err
 			}
 		}
-		if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
-			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
-			if err := kubeClient.Update(ctx, inst); err != nil {
-				return false, fmt.Errorf("unable to add force reconcile annotation to subinstallation %s: %w", inst.Name, err)
+
+		if lsv1alpha1helper.HasOperation(parentInst.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
+			lsv1alpha1helper.SetOperation(&subInst.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
+			if err := kubeClient.Update(ctx, subInst); err != nil {
+				return false, fmt.Errorf("unable to add force reconcile annotation to subinstallation %s: %w", subInst.Name, err)
 			}
 		}
 	}
 
 	return false, nil
+}
+
+func propagateDeleteWithoutUninstallAnnotation(ctx context.Context, kubeClient client.Client, parentInst *lsv1alpha1.Installation, subInsts []*lsv1alpha1.Installation) error {
+	op := "PropagateDeleteWithoutUninstallAnnotationToSubInstallation"
+
+	if !lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(parentInst.ObjectMeta) {
+		return nil
+	}
+
+	for _, subInst := range subInsts {
+		metav1.SetMetaDataAnnotation(&subInst.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
+		if err := kubeClient.Update(ctx, subInst); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
+			msg := fmt.Sprintf("unable to update subinstallation %s: %s", subInst.Name, err.Error())
+			return lserrors.NewWrappedError(err, op, "Update", msg)
+		}
+	}
+
+	return nil
 }
 
 // checkIfSiblingImports checks if a sibling imports any of the installations exports.

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -168,6 +168,33 @@ var _ = Describe("Delete", func() {
 			Expect(ok).To(BeTrue())
 			Expect(ann).To(Equal(string(lsv1alpha1.ForceReconcileOperation)))
 		})
+
+		It("should propagate the delete-without-uninstall annotation to an execution", func() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, "./testdata/state/test3")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
+
+			inst := &lsv1alpha1.Installation{}
+			inst.Name = "root"
+			inst.Namespace = state.Namespace
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
+			metav1.SetMetaDataAnnotation(&inst.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
+			testutils.ExpectNoError(testenv.Client.Update(ctx, inst))
+			testutils.ExpectNoError(testenv.Client.Delete(ctx, inst))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+
+			exec := &lsv1alpha1.Execution{}
+			exec.Name = "root"
+			exec.Namespace = state.Namespace
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+			Expect(exec.DeletionTimestamp).ToNot(BeNil())
+			ann, ok := exec.Annotations[lsv1alpha1.DeleteWithoutUninstallAnnotation]
+			Expect(ok).To(BeTrue())
+			Expect(ann).To(Equal("true"))
+		})
 	})
 
 	Context("Controller", func() {

--- a/pkg/landscaper/execution/delete_test.go
+++ b/pkg/landscaper/execution/delete_test.go
@@ -7,6 +7,8 @@ package execution_test
 import (
 	"context"
 
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -152,4 +154,23 @@ var _ = Describe("Delete", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("should propagate the delete-without-uninstall annotation to deploy items", func() {
+		ctx := context.Background()
+		defer ctx.Done()
+		exec := fakeExecutions["test6/exec-1"]
+
+		eOp := execution.NewOperation(op, exec, false)
+		err := eOp.Delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		deployItemA := &lsv1alpha1.DeployItem{}
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: "di-a", Namespace: "test6"}, deployItemA)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(deployItemA.ObjectMeta)).To(BeTrue())
+
+		deployItemB := &lsv1alpha1.DeployItem{}
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: "di-b", Namespace: "test6"}, deployItemB)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(deployItemB.ObjectMeta)).To(BeTrue())
+	})
 })

--- a/pkg/landscaper/execution/helper.go
+++ b/pkg/landscaper/execution/helper.go
@@ -61,11 +61,11 @@ func (o *Operation) listManagedDeployItems(ctx context.Context) ([]lsv1alpha1.De
 func (o *Operation) getExecutionItems(items []lsv1alpha1.DeployItem) ([]executionItem, []lsv1alpha1.DeployItem) {
 	execItems := make([]executionItem, len(o.exec.Spec.DeployItems))
 	managed := sets.NewInt()
-	for i, exec := range o.exec.Spec.DeployItems {
+	for i, di := range o.exec.Spec.DeployItems {
 		execItem := executionItem{
-			Info: *exec.DeepCopy(),
+			Info: *di.DeepCopy(),
 		}
-		if j, found := getDeployItemIndexByManagedName(items, exec.Name); found {
+		if j, found := getDeployItemIndexByManagedName(items, di.Name); found {
 			managed.Insert(j)
 			execItem.DeployItem = items[j].DeepCopy()
 		}

--- a/pkg/landscaper/execution/testdata/state/test6/00-execution.yaml
+++ b/pkg/landscaper/execution/testdata/state/test6/00-execution.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: exec-1
+  namespace: test6
+  annotations:
+    landscaper.gardener.cloud/delete-without-uninstall: "true"
+  generation: 2
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  deployItems:
+  - name: a
+    type: landscaper.gardener.cloud/helm
+    config:
+      my-val: val1
+  - name: b
+    type: landscaper.gardener.cloud/container
+    dependsOn:
+    - a
+    config:
+      my-val: val1
+
+status:
+  phase: Init
+
+  observedGeneration: 0
+
+  deployItemRefs:
+  - name: a
+    ref:
+      name: di-a
+      namespace: test6
+      observedGeneration: 2
+  - name: b
+    ref:
+      name: di-b
+      namespace: test6
+      observedGeneration: 2

--- a/pkg/landscaper/execution/testdata/state/test6/10-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test6/10-deploy-item.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-a
+  namespace: test6
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 1
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: a
+spec:
+  type: landscaper.gardener.cloud/helm
+  config:
+    my-val: val1
+
+status:
+  phase: Succeeded

--- a/pkg/landscaper/execution/testdata/state/test6/20-deploy-item.yaml
+++ b/pkg/landscaper/execution/testdata/state/test6/20-deploy-item.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-b
+  namespace: test6
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 1
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: b
+spec:
+  type: landscaper.gardener.cloud/container
+  config:
+    my-val: val1
+
+status:
+  phase: Succeeded

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -25,6 +25,10 @@ const (
 	// OperationAnnotation is the annotation that specifies a operation for a component
 	OperationAnnotation = "landscaper.gardener.cloud/operation"
 
+	// DeleteWithoutUninstallAnnotation is the annotation that specifies that root installations are deleted without
+	// uninstalling the deployed artifacts
+	DeleteWithoutUninstallAnnotation = "landscaper.gardener.cloud/delete-without-uninstall"
+
 	// ReconcileTimestampAnnotation is used to recognize timeouts in deployitems
 	ReconcileTimestampAnnotation = "landscaper.gardener.cloud/reconcile-time"
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -314,3 +314,11 @@ func HasIgnoreAnnotation(obj metav1.ObjectMeta) bool {
 	v, ok := obj.GetAnnotations()[v1alpha1.IgnoreAnnotation]
 	return ok && v == "true"
 }
+
+// HasDeleteWithoutUninstallAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/delete-without-uninstall' annotation
+// and its value is 'true'.
+func HasDeleteWithoutUninstallAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.DeleteWithoutUninstallAnnotation]
+	return ok && v == "true"
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:
With this PR it is possible to delete an installation and the corresponding execution and deploy items without uninstalling resources from the target cluster.

**Which issue(s) this PR fixes**:
Related to "Landscaper resources cannot be deleted if target is not reachable (73)"

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- Support for an annotation to delete an installation without uninstalling the corresponding target artifacts.
```
