### PR TITLE
Fix execution reconcile

### DIFF
--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -14,6 +14,13 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 )
 
+type LsError interface {
+	error
+	LandscaperError() *lsv1alpha1.Error
+	Unwrap() error
+	UpdatedError(lastError *lsv1alpha1.Error) *lsv1alpha1.Error
+}
+
 // Error is a wrapper around the landscaper crd error
 // that implements the go error interface.
 type Error struct {
@@ -59,7 +66,7 @@ func NewError(operation, reason, message string, codes ...lsv1alpha1.ErrorCode) 
 }
 
 // NewWrappedError creates a new landscaper internal error that wraps another error
-func NewWrappedError(err error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) *Error {
+func NewWrappedError(err error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) LsError {
 	return &Error{
 		lsErr: lsv1alpha1.Error{
 			Operation:          operation,
@@ -76,7 +83,7 @@ func NewWrappedError(err error, operation, reason, message string, codes ...lsv1
 // NewErrorOrNil creates a new landscaper internal error that wraps another error.
 // if no error is set the functions return nil.
 // The error is automatically set as error message.
-func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) error {
+func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) LsError {
 	if err == nil {
 		return nil
 	}

--- a/pkg/landscaper/execution/delete_test.go
+++ b/pkg/landscaper/execution/delete_test.go
@@ -76,7 +76,8 @@ var _ = Describe("Delete", func() {
 		exec := fakeExecutions["test3/exec-1"]
 		eOp := execution.NewOperation(op, exec, false)
 
-		err := eOp.Delete(ctx)
+		var err error
+		err = eOp.Delete(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exec.Finalizers).To(HaveLen(1))
 
@@ -114,7 +115,8 @@ var _ = Describe("Delete", func() {
 		controllerutil.AddFinalizer(deployItemB, lsv1alpha1.LandscaperFinalizer)
 		Expect(eOp.Client().Update(ctx, deployItemB)).ToNot(HaveOccurred())
 
-		err := eOp.Delete(ctx)
+		var err error
+		err = eOp.Delete(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exec.Finalizers).To(HaveLen(1))
 
@@ -140,7 +142,8 @@ var _ = Describe("Delete", func() {
 		controllerutil.AddFinalizer(deployItemB, lsv1alpha1.LandscaperFinalizer)
 		Expect(eOp.Client().Update(ctx, deployItemB)).ToNot(HaveOccurred())
 
-		err := eOp.Delete(ctx)
+		var err error
+		err = eOp.Delete(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exec.Finalizers).To(HaveLen(1))
 		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
@@ -160,7 +163,8 @@ var _ = Describe("Delete", func() {
 		exec := fakeExecutions["test6/exec-1"]
 
 		eOp := execution.NewOperation(op, exec, false)
-		err := eOp.Delete(ctx)
+		var err error
+		err = eOp.Delete(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		deployItemA := &lsv1alpha1.DeployItem{}

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Reconcile", func() {
 		exec := fakeExecutions["test1/exec-1"]
 		eOp := execution.NewOperation(op, exec, false)
 
-		err := eOp.Reconcile(ctx)
+		var err error
+		err = eOp.Reconcile(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
@@ -68,7 +69,8 @@ var _ = Describe("Reconcile", func() {
 		exec := fakeExecutions["test4/exec-1"]
 		eOp := execution.NewOperation(op, exec, false)
 
-		err := eOp.Reconcile(ctx)
+		var err error
+		err = eOp.Reconcile(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
@@ -109,7 +111,8 @@ var _ = Describe("Reconcile", func() {
 		deployItemA.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
 		Expect(fakeClient.Status().Update(ctx, deployItemA)).ToNot(HaveOccurred())
 
-		err := eOp.Reconcile(ctx)
+		var err error
+		err = eOp.Reconcile(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(exec.Status.DeployItemReferences).To(HaveLen(2))

--- a/vendor/github.com/gardener/landscaper/apis/errors/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/errors/error.go
@@ -14,6 +14,13 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 )
 
+type LsError interface {
+	error
+	LandscaperError() *lsv1alpha1.Error
+	Unwrap() error
+	UpdatedError(lastError *lsv1alpha1.Error) *lsv1alpha1.Error
+}
+
 // Error is a wrapper around the landscaper crd error
 // that implements the go error interface.
 type Error struct {
@@ -59,7 +66,7 @@ func NewError(operation, reason, message string, codes ...lsv1alpha1.ErrorCode) 
 }
 
 // NewWrappedError creates a new landscaper internal error that wraps another error
-func NewWrappedError(err error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) *Error {
+func NewWrappedError(err error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) LsError {
 	return &Error{
 		lsErr: lsv1alpha1.Error{
 			Operation:          operation,
@@ -76,7 +83,7 @@ func NewWrappedError(err error, operation, reason, message string, codes ...lsv1
 // NewErrorOrNil creates a new landscaper internal error that wraps another error.
 // if no error is set the functions return nil.
 // The error is automatically set as error message.
-func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) error {
+func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) LsError {
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:
This pull request fixes issues of the reconcile logic of the execution controller:
- scenario 1 described in issue https://github.com/gardener/landscaper/issues/457

**Which issue(s) this PR fixes**:
Fixes #457 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
