### PR TITLE
Use uncached client

### DIFF
--- a/cmd/landscaper-agent/app/options.go
+++ b/cmd/landscaper-agent/app/options.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -69,6 +71,7 @@ func (o *options) Complete() error {
 		LeaderElection:     false,
 		Port:               9443,
 		MetricsBindAddress: "0",
+		NewClient:          utils.NewUncachedClient,
 	}
 	hostRestConfig, err := ctrl.GetConfig()
 	if err != nil {

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -10,6 +10,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
@@ -83,6 +85,7 @@ func (o *Options) run(ctx context.Context) error {
 		LeaderElection:     false,
 		Port:               9443,
 		MetricsBindAddress: "0",
+		NewClient:          utils.NewUncachedClient,
 	}
 
 	if o.Config.Controllers.SyncPeriod != nil {

--- a/cmd/landscaper-controller/app/app_test.go
+++ b/cmd/landscaper-controller/app/app_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -65,6 +67,7 @@ var _ = Describe("Landscaper Controller", func() {
 			defer ctx.Done()
 			mgr, err = manager.New(testenv.Env.Config, manager.Options{
 				MetricsBindAddress: "0",
+				NewClient:          utils.NewUncachedClient,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			lsinstall.Install(mgr.GetScheme())

--- a/pkg/deployer/container/container_suite_test.go
+++ b/pkg/deployer/container/container_suite_test.go
@@ -16,11 +16,12 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/gardener/landscaper/test/utils"
+	testutils "github.com/gardener/landscaper/test/utils"
 
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	containerctlr "github.com/gardener/landscaper/pkg/deployer/container"
+	"github.com/gardener/landscaper/pkg/utils"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
@@ -73,6 +74,7 @@ var _ = Describe("Template", func() {
 		mgr, err = manager.New(testenv.Env.Config, manager.Options{
 			Scheme:             api.LandscaperScheme,
 			MetricsBindAddress: "0",
+			NewClient:          utils.NewUncachedClient,
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -80,7 +82,7 @@ var _ = Describe("Template", func() {
 
 		state, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
+		Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
 
 		go func() {
 			Expect(mgr.Start(ctx)).To(Succeed())

--- a/pkg/deployer/container/garbage_collector_test.go
+++ b/pkg/deployer/container/garbage_collector_test.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +56,7 @@ var _ = Describe("GarbageCollector", func() {
 			Scheme:             api.LandscaperScheme,
 			MetricsBindAddress: "0",
 			Logger:             logger.WithName("lsManager"),
+			NewClient:          utils.NewUncachedClient,
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -61,6 +64,7 @@ var _ = Describe("GarbageCollector", func() {
 			Scheme:             scheme.Scheme,
 			MetricsBindAddress: "0",
 			Logger:             logger.WithName("hostManager"),
+			NewClient:          utils.NewUncachedClient,
 		})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -25,7 +25,8 @@ import (
 	"github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/helper"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/pkg/deployer/helm"
-	"github.com/gardener/landscaper/test/utils"
+	"github.com/gardener/landscaper/pkg/utils"
+	testutils "github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
@@ -58,7 +59,7 @@ var _ = Describe("Template", func() {
 
 		kubeconfig, err := kutil.GenerateKubeconfigJSONBytes(testenv.Env.Config)
 		Expect(err).ToNot(HaveOccurred())
-		chartData, closer := utils.ReadChartFrom("./testdata/testchart")
+		chartData, closer := testutils.ReadChartFrom("./testdata/testchart")
 		defer closer()
 		helmConfig := &helmv1alpha1.ProviderConfiguration{}
 		helmConfig.Kubeconfig = base64.StdEncoding.EncodeToString(kubeconfig)
@@ -107,6 +108,7 @@ var _ = Describe("Template", func() {
 			mgr, err = manager.New(testenv.Env.Config, manager.Options{
 				Scheme:             api.LandscaperScheme,
 				MetricsBindAddress: "0",
+				NewClient:          utils.NewUncachedClient,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(helm.AddDeployerToManager(simplelogger.NewIOLogger(GinkgoWriter), mgr, mgr, helmv1alpha1.Configuration{})).To(Succeed())
@@ -122,12 +124,12 @@ var _ = Describe("Template", func() {
 		})
 
 		It("should create the release namespace if configured", func() {
-			Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
-			target, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
+			Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
+			target, err := testutils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(state.Create(ctx, target)).To(Succeed())
 
-			chartBytes, closer := utils.ReadChartFrom("./chartresolver/testdata/testchart")
+			chartBytes, closer := testutils.ReadChartFrom("./chartresolver/testdata/testchart")
 			defer closer()
 
 			chartAccess := helmv1alpha1.Chart{

--- a/pkg/deployer/lib/cmd/default.go
+++ b/pkg/deployer/lib/cmd/default.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -66,6 +68,7 @@ func (o *DefaultOptions) Complete() error {
 	opts := manager.Options{
 		LeaderElection:     false,
 		MetricsBindAddress: "0", // disable the metrics serving by default
+		NewClient:          utils.NewUncachedClient,
 	}
 
 	restConfig, err := ctrl.GetConfig()

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
@@ -212,6 +214,7 @@ var _ = Describe("Delete", func() {
 			mgr, err = manager.New(testenv.Env.Config, manager.Options{
 				Scheme:             api.LandscaperScheme,
 				MetricsBindAddress: "0",
+				NewClient:          utils.NewUncachedClient,
 			})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/utils/uncached_client.go
+++ b/pkg/utils/uncached_client.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewUncachedClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	c, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/test/integration/deployers/management/dm_tests.go
+++ b/test/integration/deployers/management/dm_tests.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo"
@@ -114,6 +116,7 @@ func DeployerManagementTests(f *framework.Framework) {
 				mgr, err = manager.New(f.RestConfig, manager.Options{
 					Scheme:             api.LandscaperScheme,
 					MetricsBindAddress: "0",
+					NewClient:          utils.NewUncachedClient,
 				})
 				testutil.ExpectNoError(err)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR switches the clients reading installations, executions and deploy items to uncached clients. It is not reasonable to work on outdated objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
