### PR TITLE
Prevent parallel updates in integration tests

### DIFF
--- a/test/integration/installations/phase-propagation.go
+++ b/test/integration/installations/phase-propagation.go
@@ -153,6 +153,7 @@ func PhasePropagationTests(f *framework.Framework) {
 			}, timeoutTime, resyncTime).Should(BeEquivalentTo(lsv1alpha1.ComponentPhaseSucceeded), "root installation should be in phase %q", string(lsv1alpha1.ComponentPhaseSucceeded))
 
 			By("set subinstallation deploy item to Failed and verify phase propagation")
+			utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKeyFromObject(subinstExecDi), subinstExecDi))
 			subinstExecDi.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
 			utils.ExpectNoError(f.Client.Status().Update(ctx, subinstExecDi))
 			Eventually(func() (lsv1alpha1.ExecutionPhase, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind test
/priority 3

**What this PR does / why we need it**:

Make integration tests more stable by refetching object just before modifying and updating it to reduce the probability of update conflicts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
