### PR TITLE
Fix and refactor deployer reconciliation

### DIFF
--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -100,6 +100,35 @@ func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.Erro
 	}
 }
 
+// BuildLsError creates a new landscaper internal error if the provided error is not already of such a type or nil.
+// Otherwise the error is returned.
+func BuildLsError(err error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) LsError {
+	if err == nil {
+		return NewWrappedError(err, operation, reason, message, codes...)
+	}
+
+	switch e := err.(type) {
+	case LsError:
+		return e
+	default:
+		return NewWrappedError(err, operation, reason, message, codes...)
+	}
+}
+
+// BuildLsErrorOrNil creates a new landscaper internal error if the provided error is not already of such a type or nil.
+// Otherwise the error is returned. If the input error is nil also nil is returned.
+func BuildLsErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) LsError {
+	if err == nil {
+		return nil
+	}
+	switch e := err.(type) {
+	case LsError:
+		return e
+	default:
+		return NewErrorOrNil(err, operation, reason, codes...)
+	}
+}
+
 // IsError returns the landscaper error if the given error is one.
 // If the err does not contain a landscaper error nil is returned.
 func IsError(err error) (*Error, bool) {
@@ -135,8 +164,27 @@ func TryUpdateLsError(lastErr *lsv1alpha1.Error, err LsError) *lsv1alpha1.Error 
 		return nil
 	}
 
+	codes := CollectErrorCodes(err)
+
 	errorInfo := err.LandscaperError()
-	return UpdatedError(lastErr, errorInfo.Operation, errorInfo.Reason, errorInfo.Message, errorInfo.Codes...)
+	return UpdatedError(lastErr, errorInfo.Operation, errorInfo.Reason, errorInfo.Message, codes...)
+}
+
+func CollectErrorCodes(err error) []lsv1alpha1.ErrorCode {
+	codes := []lsv1alpha1.ErrorCode{}
+	subError := errors.Unwrap(err)
+	if subError != nil {
+		codes = CollectErrorCodes(subError)
+	}
+
+	switch e := err.(type) {
+	case LsError:
+		codes = append(codes, e.LandscaperError().Codes...)
+	default:
+		// nothing
+	}
+
+	return codes
 }
 
 // UpdatedError updates the properties of a error.

--- a/pkg/deployer/container/container_suite_test.go
+++ b/pkg/deployer/container/container_suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	lsutils "github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
@@ -73,6 +74,7 @@ var _ = Describe("Template", func() {
 		mgr, err = manager.New(testenv.Env.Config, manager.Options{
 			Scheme:             api.LandscaperScheme,
 			MetricsBindAddress: "0",
+			NewClient:          lsutils.NewUncachedClient,
 		})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/deployer/lib/error.go
+++ b/pkg/deployer/lib/error.go
@@ -24,33 +24,37 @@ import (
 
 // HandleErrorFunc returns a error handler func for deployers.
 // The functions automatically sets the phase for long running errors and updates the status accordingly.
-func HandleErrorFunc(log logr.Logger, c client.Client, eventRecorder record.EventRecorder, deployItem *lsv1alpha1.DeployItem) func(ctx context.Context, err error) error {
-	old := deployItem.DeepCopy()
-	return func(ctx context.Context, err error) error {
-		deployItem.Status.LastError = lserrors.TryUpdateError(deployItem.Status.LastError, err)
-		deployItem.Status.Phase = lsv1alpha1.ExecutionPhase(lserrors.GetPhaseForLastError(
-			lsv1alpha1.ComponentInstallationPhase(deployItem.Status.Phase),
-			deployItem.Status.LastError,
-			5*time.Minute))
-		if deployItem.Status.LastError != nil {
-			lastErr := deployItem.Status.LastError
-			eventRecorder.Event(deployItem, corev1.EventTypeWarning, lastErr.Reason, lastErr.Message)
-		}
+func HandleErrorFunc(ctx context.Context, err lserrors.LsError, log logr.Logger, c client.Client,
+	eventRecorder record.EventRecorder, oldDeployItem, deployItem *lsv1alpha1.DeployItem, isDelete bool) error {
+	// if successfully deleted we could not update the object
+	if isDelete && err == nil {
+		return nil
+	}
 
-		if !reflect.DeepEqual(old.Status, deployItem.Status) {
-			writer := read_write_layer.NewWriter(log, c)
-			if err2 := writer.UpdateDeployItemStatus(ctx, read_write_layer.W000051, deployItem); err2 != nil {
-				if apierrors.IsConflict(err2) { // reduce logging
-					log.V(5).Info(fmt.Sprintf("unable to update status: %s", err2.Error()))
-				} else {
-					log.Error(err2, "unable to update status")
-				}
-				// retry on conflict
-				if err != nil {
-					return err2
-				}
+	deployItem.Status.LastError = lserrors.TryUpdateLsError(deployItem.Status.LastError, err)
+
+	phaseForLastError := lserrors.GetPhaseForLastError(lsv1alpha1.ComponentInstallationPhase(deployItem.Status.Phase),
+		deployItem.Status.LastError, 5*time.Minute)
+	deployItem.Status.Phase = lsv1alpha1.ExecutionPhase(phaseForLastError)
+
+	if deployItem.Status.LastError != nil {
+		lastErr := deployItem.Status.LastError
+		eventRecorder.Event(deployItem, corev1.EventTypeWarning, lastErr.Reason, lastErr.Message)
+	}
+
+	if !reflect.DeepEqual(oldDeployItem.Status, deployItem.Status) {
+		writer := read_write_layer.NewWriter(log, c)
+		if err2 := writer.UpdateDeployItemStatus(ctx, read_write_layer.W000051, deployItem); err2 != nil {
+			if apierrors.IsConflict(err2) { // reduce logging
+				log.V(5).Info(fmt.Sprintf("unable to update status: %s", err2.Error()))
+			} else {
+				log.Error(err2, "unable to update status")
+			}
+			// retry on conflict
+			if err == nil {
+				return err2
 			}
 		}
-		return err
 	}
+	return err
 }

--- a/pkg/landscaper/dataobjects/target.go
+++ b/pkg/landscaper/dataobjects/target.go
@@ -27,11 +27,6 @@ type Target struct {
 	Def        *lsv1alpha1.TargetImport
 }
 
-// NewTarget creates a new internal target.
-func NewTarget() *Target {
-	return &Target{}
-}
-
 // NewFromTarget creates a new internal target instance from a raw target.
 func NewFromTarget(target *lsv1alpha1.Target) (*Target, error) {
 	return &Target{
@@ -140,6 +135,7 @@ func (t *Target) GetInClusterObjects() []client.Object {
 }
 
 func (t *Target) ComputeConfigGeneration() string {
+
 	return strconv.FormatInt(t.GetInClusterObject().GetGeneration(), 10)
 }
 

--- a/pkg/utils/uncached_client.go
+++ b/pkg/utils/uncached_client.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewUncachedClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	c, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/vendor/github.com/gardener/landscaper/apis/errors/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/errors/error.go
@@ -100,6 +100,35 @@ func NewErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.Erro
 	}
 }
 
+// BuildLsError creates a new landscaper internal error if the provided error is not already of such a type or nil.
+// Otherwise the error is returned.
+func BuildLsError(err error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) LsError {
+	if err == nil {
+		return NewWrappedError(err, operation, reason, message, codes...)
+	}
+
+	switch e := err.(type) {
+	case LsError:
+		return e
+	default:
+		return NewWrappedError(err, operation, reason, message, codes...)
+	}
+}
+
+// BuildLsErrorOrNil creates a new landscaper internal error if the provided error is not already of such a type or nil.
+// Otherwise the error is returned. If the input error is nil also nil is returned.
+func BuildLsErrorOrNil(err error, operation, reason string, codes ...lsv1alpha1.ErrorCode) LsError {
+	if err == nil {
+		return nil
+	}
+	switch e := err.(type) {
+	case LsError:
+		return e
+	default:
+		return NewErrorOrNil(err, operation, reason, codes...)
+	}
+}
+
 // IsError returns the landscaper error if the given error is one.
 // If the err does not contain a landscaper error nil is returned.
 func IsError(err error) (*Error, bool) {
@@ -135,8 +164,27 @@ func TryUpdateLsError(lastErr *lsv1alpha1.Error, err LsError) *lsv1alpha1.Error 
 		return nil
 	}
 
+	codes := CollectErrorCodes(err)
+
 	errorInfo := err.LandscaperError()
-	return UpdatedError(lastErr, errorInfo.Operation, errorInfo.Reason, errorInfo.Message, errorInfo.Codes...)
+	return UpdatedError(lastErr, errorInfo.Operation, errorInfo.Reason, errorInfo.Message, codes...)
+}
+
+func CollectErrorCodes(err error) []lsv1alpha1.ErrorCode {
+	codes := []lsv1alpha1.ErrorCode{}
+	subError := errors.Unwrap(err)
+	if subError != nil {
+		codes = CollectErrorCodes(subError)
+	}
+
+	switch e := err.(type) {
+	case LsError:
+		codes = append(codes, e.LandscaperError().Codes...)
+	default:
+		// nothing
+	}
+
+	return codes
 }
 
 // UpdatedError updates the properties of a error.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR depends on PR https://github.com/gardener/landscaper/pull/465. It refactors the reconciliation of the deployer sich that:
- coding is better readable 
- errors which are not LsErrors are not lost
- error codes of LsErrors deeply embodied in other errors are collected

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
