### PR TITLE
Remove reconcile timestamp annotation earlier

### DIFF
--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -41,7 +41,6 @@ func HandleAnnotationsAndGeneration(ctx context.Context,
 	kubeClient client.Client,
 	di *lsv1alpha1.DeployItem,
 	deployerInfo lsv1alpha1.DeployerInformation) error {
-	changedMeta := false
 	hasReconcileAnnotation := lsv1alpha1helper.HasOperation(di.ObjectMeta, lsv1alpha1.ReconcileOperation)
 	hasForceReconcileAnnotation := lsv1alpha1helper.HasOperation(di.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
 	if hasReconcileAnnotation || hasForceReconcileAnnotation || di.Status.ObservedGeneration != di.Generation {
@@ -55,18 +54,10 @@ func HandleAnnotationsAndGeneration(ctx context.Context,
 			return err
 		}
 	}
+
 	if hasReconcileAnnotation {
 		log.V(5).Info("removing reconcile annotation")
-		changedMeta = true
 		delete(di.ObjectMeta.Annotations, lsv1alpha1.OperationAnnotation)
-	}
-	if metav1.HasAnnotation(di.ObjectMeta, string(lsv1alpha1helper.ReconcileTimestamp)) {
-		log.V(5).Info("removing timestamp annotation")
-		changedMeta = true
-		delete(di.ObjectMeta.Annotations, lsv1alpha1.ReconcileTimestampAnnotation)
-	}
-
-	if changedMeta {
 		log.V(7).Info("updating metadata")
 		writer := read_write_layer.NewWriter(log, kubeClient)
 		if err := writer.UpdateDeployItem(ctx, read_write_layer.W000046, di); err != nil {

--- a/pkg/utils/read_write_layer/consts.go
+++ b/pkg/utils/read_write_layer/consts.go
@@ -79,6 +79,7 @@ const (
 	W000073 WriteID = "w000073"
 	W000074 WriteID = "w000074"
 	W000075 WriteID = "w000075"
+	W000076 WriteID = "w000076"
 )
 
 const (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:
This pull requests prevents endless reconciles of a deploy item. 




**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
