### PR TITLE
update virtual-garden to v0.5.0

### DIFF
--- a/.landscaper/landscaper-service/blueprint/installation/landscaper-rbac-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/landscaper-rbac-subinst.yaml
@@ -9,7 +9,7 @@ blueprint:
 imports:
   targets:
     - name: virtualCluster
-      target: virtualGardenKubeconfig
+      target: virtualGardenCluster
   data:
     - name: virtualClusterNamespace
       dataRef: virtualClusterNamespace

--- a/.landscaper/landscaper-service/blueprint/installation/virtual-garden-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/virtual-garden-subinst.yaml
@@ -8,7 +8,7 @@ blueprint:
 
 imports:
   targets:
-    - name: cluster
+    - name: runtimeCluster
       target: hostingCluster
   data:
     - name: importHostingClusterNamespace
@@ -21,7 +21,7 @@ imports:
       dataRef: dnsAccessDomain
 
 importDataMappings:
-  hostingCluster:
+  runtimeClusterSettings:
     namespace: (( importHostingClusterNamespace ))
     infrastructureProvider: (( importProviderType ))
 
@@ -42,5 +42,5 @@ exports:
     - name: virtualGardenEndpoint
       dataRef: virtualGardenEndpoint
   targets:
-    - name: virtualGardenKubeconfig
-      target: virtualGardenKubeconfig
+    - name: virtualGardenCluster
+      target: virtualGardenCluster

--- a/.landscaper/landscaper-service/component-references.yaml
+++ b/.landscaper/landscaper-service/component-references.yaml
@@ -6,5 +6,5 @@ version: ${VERSION}
 ---
 componentName: github.com/gardener/virtual-garden
 name: virtual-garden
-version: v0.1.0-dev-8ca2fc6eb9521ca2522763090d97e728899b6069
+version: v0.5.0
 ...


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Update component reference virtual-garden to the latest released version v0.5.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
