### PR TITLE
improve context docu

### DIFF
--- a/docs/usage/Context.md
+++ b/docs/usage/Context.md
@@ -1,23 +1,32 @@
 # Context
 
-The context is a configuration resource containing shared configuration for installations.
-This config can contain the repository context, registry pull secrets, or even deployer specific context.
+A context is a configuration resource which could be referenced and used by different installations. It contains shared 
+configuration data for installations. This information includes the location of the component descriptors as well as 
+access data like credentials for the component descriptors and other (OCI) artifacts like images, blueprints etc. 
 
-A context can be referenced by installations in the same namespace.
+As you already know, an installation references a blueprint and a component descriptor. The component descriptor itself 
+might reference further artifacts like OCI images, other component descriptors etc. With the information in the context,
+the Landscapes knows the location of the components descriptors and possesses the required credentials to all OCI 
+artefacts (including the component descriptors).
+
+Remark: Be aware that all components descriptors must be located in the same repository context, e.g. if they are stored
+in an OCI registry in a repository context `example.com/somePath`, it is assumed that all component descriptors are located
+under `example.com/somePath/component-descriptors/`
+
+A context can only be referenced by installations in the same namespace.
 
 ## Basic structure
 
-A context object contains the repository context and an optional list of registry pull secrets.
-These registry pull secrets are references to secrets in the same namespace as the context.
-It is expected that the secrets contain oci registry access credentials.
-These credentials can be used to access component descriptors, blueprints or even deployable artifacts like helm charts or oci images.
+A context object has the following structure.  It contains the repository context, registry pull secrets for accessing
+resources stored in OCI registries, and additional information in the configurations section.
+
 
 ```yaml
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Context
 metadata:
-  name: default
-  namespace: default
+  name: example-context
+  namespace: example-namespace
 
 repositoryContext:
   type: ociRegistry
@@ -25,18 +34,90 @@ repositoryContext:
 
 registryPullSecrets: # additional pull secrets to access component descriptors and blueprints
 - name: my-pullsecret
+
+configurations: 
+  yourKey: yourInfo
 ```
 
-## Default Context
+The repository context is usually the location where the component descriptors are stored in an OCI registry. For the 
+example above it is expected that the component descriptors are stored under `example.com/component-descriptors/`.
 
-Just like kubernetes creates a default service account in every namespace, a default context is created in every namespace.
-The default context can be configured in the landscaper configuration `.controllers.context.config.default` as described in the [example](../../examples/00-Landscaper-Configuration.yaml).
+These registry pull secrets are references to secrets in the same namespace as the context. It is expected that the 
+secrets contain oci registry access credentials. These credentials are used by the Landscaper to access component 
+descriptors, blueprints, images or even deployable artifacts like helm charts stored in an OCI registry.
 
-The default context object can also be manually modified as the landscaper controller only reconciles configured defaults.
+How to create registry pull secrets is described
+[here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). They typically look as
+follows:
 
-## Configuration
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-pullsecret
+  namespace: example-namespace
+data:
+  .dockerconfigjson: authenticationData
+type: kubernetes.io/dockerconfigjson
+```
 
-The context controller can be configured in the landscaper config `.controllers.context`.
+**Example**:
+
+This example describes how to create a secret with access data to the  Google Container Registry. First, you need a 
+service account with read permissions for your registry. Then you create a service account key and download the 
+corresponding service account key file ([see](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)). 
+
+Finally, you create the authentication data for the secret according to the following example. 
+
+```
+{
+  "auths":{
+    "eu.gcr.io/somePath":{"auth":"base64 encoded content of the service account key file"}
+  }
+}
+```
+
+`eu.gcr.io/somePath` defines that all OCI artefacts stored at a location starting with this URL are fetched using the 
+specified access data of the `auth` entry. Of course, you need to use your URL here. If your resources are located
+in different OCI registries, you could add several URLs together with the appropriate access data. 
+
+## Installation with Context Reference
+
+An installation could reference a context object as outlined here:
+
+```
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: example-name
+  namespace: example-namespace
+
+spec:
+  blueprint:
+    ref:
+      resourceName: someBlueprint
+
+  context: example-context
+
+  componentDescriptor:
+    ref:
+      componentName: yourDomain/your/component/name
+      version: v0.1.0
+```
+
+When this installation is deployed, the Landscaper locates the component descriptor by the repository context in the
+context object concatenated with `component-descriptors` and the name of the component descriptor:
+
+    `example.com/component-descriptors/yourDomain/your/component/name`
+
+For all referenced component descriptors the location is computed the same way. For all resources stored in protected
+OCI registries, the Landscaper uses the registry pull secrets provided by the context object to get access to them.
+
+## Default Context in the Landscaper Configuration
+
+Just like kubernetes creates a default service account in every namespace, the Landscaper creates a default context object
+in every namespace during startup. The default context can be configured in the landscaper configuration 
+`.controllers.context.config.default` as described in this [example](../../examples/00-Landscaper-Configuration.yaml):
 
 ```yaml
 apiVersion: config.landscaper.gardener.cloud/v1alpha1
@@ -54,3 +135,10 @@ controllers:
           type: ociRegistry
           baseUrl: "myregistry.com/components"
 ```
+
+If nothing is configured for the default context in the LandscaperConfiguration, empty default contexts are still 
+created. In this situation you could modify these context objects manually. This is not possible if you have configured 
+something in the LandscaperConfiguration because the responsible context controller replaces your manual 
+modifications always with these settings.
+
+If an installation has no context configured, the default context is used. 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR improves the documentation of context objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Improved documentation of context objects
```
