### PR TITLE
fix inheritance of context in subinstallations

### DIFF
--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -328,7 +328,6 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 	}
 
 	_, err = o.Writer().CreateOrUpdateInstallation(ctx, read_write_layer.W000001, subInst, func() error {
-		subInst.Spec.Context = inst.Spec.Context
 		subInst.Labels = map[string]string{
 			lsv1alpha1.EncompassedByLabel: inst.Name,
 		}
@@ -339,6 +338,7 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 			return errors.Wrapf(err, "unable to set owner reference")
 		}
 		subInst.Spec = lsv1alpha1.InstallationSpec{
+			Context:             inst.Spec.Context,
 			RegistryPullSecrets: inst.Spec.RegistryPullSecrets,
 			ComponentDescriptor: subCdDef,
 			Blueprint:           *subBlueprint,

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -117,7 +117,7 @@ var _ = Describe("SubInstallation", func() {
 		fakeClient = testenv.Client
 		fakeInstallations = state.Installations
 
-		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8", "test9", "test10", "test11")).To(Succeed())
+		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8", "test9", "test10", "test11", "test12")).To(Succeed())
 
 		fakeCompRepo, err = componentsregistry.NewLocalClient(logr.Discard(), "./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
@@ -276,6 +276,20 @@ var _ = Describe("SubInstallation", func() {
 			defer ctx.Done()
 
 			_ = expectSubInstallationsFail(ctx, "test9", "root")
+		})
+
+		It("should inherit context definition", func() {
+			ctx := context.Background()
+			defer ctx.Done()
+
+			_, subinsts := expectSubInstallationsSucceed(ctx, "test12", "root", lsv1alpha1.NamedObjectReference{
+				Name: "def-1",
+				Reference: lsv1alpha1.ObjectReference{
+					Name:      "def-1",
+					Namespace: "test12"},
+			})
+
+			Expect(subinsts[0].Spec.Context).To(Equal("custom"))
 		})
 
 		Context("Cleanup", func() {

--- a/pkg/landscaper/installations/subinstallations/testdata/state/test12/00-root.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/state/test12/00-root.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root
+  namespace: test12
+spec:
+
+  context: "custom"
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      componentName: example.com/root
+      version: 1.0.0
+
+  blueprint:
+    ref:
+      resourceName: root-1

--- a/pkg/landscaper/installations/subinstallations/testdata/state/test12/01-context.yaml
+++ b/pkg/landscaper/installations/subinstallations/testdata/state/test12/01-context.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Context
+metadata:
+  name: custom
+  namespace: test12


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

The context of the parent installation was not correctly passed to its subinstallations.
This PR fixes this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed the inheritance of the landscaper context of a parent installation to its subinstallations.
```
