### PR TITLE
fix missing rebasing

### DIFF
--- a/pkg/landscaper/installations/executions/executions_test.go
+++ b/pkg/landscaper/installations/executions/executions_test.go
@@ -43,7 +43,8 @@ var _ = Describe("DeployItemExecutions", func() {
 		op.Inst = inInstRoot
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
-		rh := reconcilehelper.NewReconcileHelper(ctx, op)
+		rh, err := reconcilehelper.NewReconcileHelper(ctx, op)
+		Expect(err).ToNot(HaveOccurred())
 		imps, err := rh.GetImports()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rh.ImportsSatisfied()).To(Succeed())

--- a/pkg/landscaper/installations/imports/importexec_test.go
+++ b/pkg/landscaper/installations/imports/importexec_test.go
@@ -41,7 +41,8 @@ var _ = Describe("ImportExecutions", func() {
 		op.Inst = inInstRoot
 		Expect(op.SetInstallationContext(ctx)).To(Succeed())
 
-		rh := reconcilehelper.NewReconcileHelper(ctx, op)
+		rh, err := reconcilehelper.NewReconcileHelper(ctx, op)
+		Expect(err).ToNot(HaveOccurred())
 		imps, err := rh.GetImports()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rh.ImportsSatisfied()).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind technical-debt
/priority 1

**What this PR does / why we need it**:
When merging #414, I forgot to rebase the changes from #483 into it before. The result is an error during build, as the `NewReconcileHelper` method has gotten a second return value in #483 which is not reflected in the files added with #414 yet.

**Special notes for your reviewer**:
See failing pipeline https://concourse.ci.gardener.cloud/teams/gardener/pipelines/landscaper-master/jobs/master-head-update-job/builds/86

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
