### PR TITLE
Full reconcile

### DIFF
--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -61,6 +61,10 @@ type ExecutionSpec struct {
 	// Note that the type information is used to determine the secret key and the type of the secret.
 	// +optional
 	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
+
+	// ReconcileID is used to update an execution even if its deploy items have not changed but their
+	// reconciliation should be triggered again.
+	ReconcileID string `json:"reconcileID,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -191,10 +191,14 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is a annotation for the landscaper to reconcile the resource
+	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
+	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
+	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
+	// (e.g. no predecessor is running).
+	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is an annotation for the landscaper to force the reconcile of  to not wait for children (executions nor subinstallations) to be completed.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -116,6 +116,10 @@ type ExecutionSpec struct {
 	// Note that the type information is used to determine the secret key and the type of the secret.
 	// +optional
 	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
+
+	// ReconcileID is used to update an execution even if its deploy items have not changed but their
+	// reconciliation should be triggered again.
+	ReconcileID string `json:"reconcileID,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -207,7 +207,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is a annotation for the landscaper to reconcile the resource
+	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
+	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
+	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
+	// (e.g. no predecessor is running).
+	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
 	ReconcileOperation Operation = "reconcile"
 
 	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2025,6 +2025,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
+	out.ReconcileID = in.ReconcileID
 	return nil
 }
 
@@ -2032,6 +2033,7 @@ func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.Execution
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
+	out.ReconcileID = in.ReconcileID
 	return nil
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4819,6 +4819,13 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 							},
 						},
 					},
+					"reconcileID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ReconcileID is used to update an execution even if its deploy items have not changed but their reconciliation should be triggered again.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -61,6 +61,10 @@ type ExecutionSpec struct {
 	// Note that the type information is used to determine the secret key and the type of the secret.
 	// +optional
 	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
+
+	// ReconcileID is used to update an execution even if its deploy items have not changed but their
+	// reconciliation should be triggered again.
+	ReconcileID string `json:"reconcileID,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -191,10 +191,14 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is a annotation for the landscaper to reconcile the resource
+	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
+	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
+	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
+	// (e.g. no predecessor is running).
+	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is an annotation for the landscaper to force the reconcile of  to not wait for children (executions nor subinstallations) to be completed.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -116,6 +116,10 @@ type ExecutionSpec struct {
 	// Note that the type information is used to determine the secret key and the type of the secret.
 	// +optional
 	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
+
+	// ReconcileID is used to update an execution even if its deploy items have not changed but their
+	// reconciliation should be triggered again.
+	ReconcileID string `json:"reconcileID,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -207,7 +207,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is a annotation for the landscaper to reconcile the resource
+	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
+	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
+	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
+	// (e.g. no predecessor is running).
+	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
 	ReconcileOperation Operation = "reconcile"
 
 	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2025,6 +2025,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
+	out.ReconcileID = in.ReconcileID
 	return nil
 }
 
@@ -2032,6 +2033,7 @@ func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.Execution
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
+	out.ReconcileID = in.ReconcileID
 	return nil
 }
 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -901,6 +901,18 @@ For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-conta
 Note that the type information is used to determine the secret key and the type of the secret.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>reconcileID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ReconcileID is used to update an execution even if its deploy items have not changed but their
+reconciliation should be triggered again.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -3221,6 +3233,18 @@ DeployItemTemplateList
 pull blueprints, component descriptors and jsonschemas from the respective registry.
 For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
 Note that the type information is used to determine the secret key and the type of the secret.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reconcileID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ReconcileID is used to update an execution even if its deploy items have not changed but their
+reconciliation should be triggered again.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/technical/installation_controller.md
+++ b/docs/technical/installation_controller.md
@@ -48,8 +48,11 @@ sub-objects with updates of their spec.
 
 ##### Update Required
 
-An update is required if the status of the installation is not up-to-date (`generation != observedGeneration`) or if
-one of the imports has been modified, see [Standard Reconciliation](./reconciliation_flow.md#standard-reconciliation).
+An update is required in the following cases:
+
+- if the status of the installation is not up-to-date (`generation != observedGeneration`) 
+- or if one of the imports has been modified, see [Standard Reconciliation](./reconciliation_flow.md#standard-reconciliation),
+- or if the installation is failed and has the reconcile annotation. 
 
 
 ## Force Reconcile

--- a/docs/technical/reconciliation_flow.md
+++ b/docs/technical/reconciliation_flow.md
@@ -62,9 +62,18 @@ This is the default reconciliation logic.
 
 4. Check if an update is required ❔🚪
 
-    If neither the installation itself nor any of its imports has been modified, there is no need to trigger the nested installations and executions. This is checked by comparing generation values with stored 'observed' generation values, the latter of which are updated when a new generation is observed. For imports which are exported by another installation, the generation is read from the exporting installation's status. For imports which are not owned by an installation, it is usually a hash over their respective spec, although the implementations slightly differ, depending on the type of import.
+    The nested installations and executions need to be triggered in the following cases:
+    - if the installation itself was changed
+    - or any of its imports has been modified,
+    - or if the installation has phase `Failed` and has the reconcile annotation.
+   
+    This is checked by comparing generation values with stored 'observed' generation values, 
+    the latter of which are updated when a new generation is observed. For imports which are exported by another 
+    installation, the generation is read from the exporting installation's status. For imports which are not owned by an 
+    installation, it is usually a hash over their respective spec, although the implementations slightly differ, 
+    depending on the type of import.
  
-   If an update is required, the installation's phase is set to `PendingDependencies` and it is checked whether the installation can be updated now.
+    If an update is required, the installation's phase is set to `PendingDependencies` and it is checked whether the installation can be updated now.
     
     1. Check if updating is possible ❔✔️🚪
 
@@ -82,18 +91,21 @@ This is the default reconciliation logic.
         
         Otherwise, the installation will be stuck in `PendingDependencies` and log a corresponding error message. 🚪
 
-5. Export generation
+6. Export generation
 
     The exports are generated.
 
-6. Trigger depending installations
+7. Trigger depending installations
 
     All sibling installations which depend on this one are triggered by having the reconcile operation annotation added.
 
 
 ### Force Reconciliation
 
-A force reconciliation only happens if the corresponding operation annotation has been added to the installation. Since it is clear in this case that an update is desired, most of the checks of the standard reconciliation are skipped in this flow. Most noticable, it is possible to update an installation despite installations the current one depends on being `Failed` or `Progressing`.
+A force reconciliation only happens if the corresponding operation annotation has been added to the installation. 
+Since it is clear in this case that an update is desired, most of the checks of the standard reconciliation are skipped 
+in this flow. Most noticable, it is possible to update an installation despite installations the current one depends on 
+being `Failed` or `Progressing`.
 
 1. Check if imports are satisfied ❔🚪
 

--- a/pkg/landscaper/controllers/installations/testdata/registry/blobs/root3/blueprint.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/blobs/root3/blueprint.yaml
@@ -1,0 +1,26 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+annotations:
+  local/name: root3
+  local/version: 1.0.0
+
+deployExecutions:
+- type: Spiff
+  template:
+    deployItems:
+    - name: subexec
+      type: landscaper.gardener.cloud/mock
+      config:
+        apiVersion: mock.deployer.landscaper.gardener.cloud/v1alpha1
+        kind: ProviderConfiguration
+
+subinstallations:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    kind: InstallationTemplate
+    name: subinst
+    blueprint:
+      filesystem:
+        blueprint.yaml: |
+          apiVersion: landscaper.gardener.cloud/v1alpha1
+          kind: Blueprint

--- a/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/registry/component-descriptor.yaml
@@ -75,3 +75,11 @@ component:
       type: localFilesystemBlob
       mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: root2
+  - name: root3
+    type: blueprint
+    version: 1.0.0
+    relation: local
+    access:
+      type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
+      filename: root3

--- a/pkg/landscaper/controllers/installations/testdata/state/test5/00-root.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test5/00-root.yaml
@@ -1,0 +1,35 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root
+  namespace: {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: root3
+
+status:
+  configGeneration: ""
+  executionRef:
+    name: root
+    namespace: {{ .Namespace }}
+  installationRefs:
+    - name: subinst
+      ref:
+        name: subinst
+        namespace: {{ .Namespace }}
+  observedGeneration: 1
+  phase: Failed

--- a/pkg/landscaper/controllers/installations/testdata/state/test5/10-exec.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test5/10-exec.yaml
@@ -1,0 +1,30 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: root
+  namespace: {{ .Namespace }}
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+  ownerReferences:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Installation
+    name: root
+    uid: abc-def-root
+spec:
+  deployItems:
+  - config:
+      apiVersion: mock.deployer.landscaper.gardener.cloud/v1alpha1
+      kind: ProviderConfiguration
+    name: subexec
+    type: landscaper.gardener.cloud/mock
+status:
+  deployItemRefs:
+  - name: subexec
+    ref:
+      name: root-subexec-abcde
+      namespace: {{ .Namespace }}
+      observedGeneration: 1
+  observedGeneration: 1
+  phase: Failed

--- a/pkg/landscaper/controllers/installations/testdata/state/test5/10-subinst.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test5/10-subinst.yaml
@@ -1,0 +1,38 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  annotations:
+    landscaper.gardener.cloud/subinstallation-name: subinst
+  labels:
+    landscaper.gardener.cloud/encompassed-by: root
+  name: subinst
+  namespace: {{ .Namespace }}
+  ownerReferences:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Installation
+    name: root
+    uid: abc-def-root
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    inline:
+      filesystem:
+        blueprint.yaml: |
+          apiVersion: landscaper.gardener.cloud/v1alpha1
+          kind: Blueprint
+
+status:
+  configGeneration: ""
+  observedGeneration: 1
+  phase: Failed

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -85,6 +85,11 @@ spec:
                   - config
                   type: object
                 type: array
+              reconcileID:
+                description: ReconcileID is used to update an execution even if its
+                  deploy items have not changed but their reconciliation should be
+                  triggered again.
+                type: string
               registryPullSecrets:
                 description: 'RegistryPullSecrets defines a list of registry credentials
                   that are used to pull blueprints, component descriptors and jsonschemas

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -70,7 +70,7 @@ func (o *Operation) Reconcile(ctx context.Context) lserrors.LsError {
 				// the deployitem is: up-to-date, in a final state, not failed => deployItem.spec.phase == succeeded => nothing to do with the deployitem
 				dlogger.V(7).Info("deployitem not triggered because up-to-date", "deployItemPhase", string(item.DeployItem.Status.Phase))
 			}
-		} else {
+		} else { // deploy item not up to date or force reconcile
 			allSucceeded = false
 
 			runnable, err := o.checkRunnable(ctx, item, executionItems)

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -28,14 +28,14 @@ import (
 )
 
 // TriggerSubInstallations triggers a reconcile for all sub installation of the component.
-func (o *Operation) TriggerSubInstallations(ctx context.Context, inst *lsv1alpha1.Installation, operation lsv1alpha1.Operation) error {
+func (o *Operation) TriggerSubInstallations(ctx context.Context, inst *lsv1alpha1.Installation) error {
 	for _, instRef := range inst.Status.InstallationReferences {
 		subInst := &lsv1alpha1.Installation{}
 		if err := read_write_layer.GetInstallation(ctx, o.Client(), instRef.Reference.NamespacedName(), subInst); err != nil {
 			return errors.Wrapf(err, "unable to get sub installation %s", instRef.Reference.NamespacedName().String())
 		}
 
-		metav1.SetMetaDataAnnotation(&subInst.ObjectMeta, lsv1alpha1.OperationAnnotation, string(operation))
+		metav1.SetMetaDataAnnotation(&subInst.ObjectMeta, lsv1alpha1.OperationAnnotation, string(lsv1alpha1.ReconcileOperation))
 		if err := o.Writer().UpdateInstallation(ctx, read_write_layer.W000007, subInst); err != nil {
 			return errors.Wrapf(err, "unable to update sub installation %s", instRef.Reference.NamespacedName().String())
 		}

--- a/pkg/utils/read_write_layer/consts.go
+++ b/pkg/utils/read_write_layer/consts.go
@@ -81,6 +81,7 @@ const (
 	W000075 WriteID = "w000075"
 	W000076 WriteID = "w000076"
 	W000077 WriteID = "w000077"
+	W000078 WriteID = "w000078"
 )
 
 const (

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -61,6 +61,10 @@ type ExecutionSpec struct {
 	// Note that the type information is used to determine the secret key and the type of the secret.
 	// +optional
 	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
+
+	// ReconcileID is used to update an execution even if its deploy items have not changed but their
+	// reconciliation should be triggered again.
+	ReconcileID string `json:"reconcileID,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -191,10 +191,14 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is a annotation for the landscaper to reconcile the resource
+	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
+	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
+	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
+	// (e.g. no predecessor is running).
+	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is an annotation for the landscaper to force the reconcile of  to not wait for children (executions nor subinstallations) to be completed.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -116,6 +116,10 @@ type ExecutionSpec struct {
 	// Note that the type information is used to determine the secret key and the type of the secret.
 	// +optional
 	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
+
+	// ReconcileID is used to update an execution even if its deploy items have not changed but their
+	// reconciliation should be triggered again.
+	ReconcileID string `json:"reconcileID,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -207,7 +207,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is a annotation for the landscaper to reconcile the resource
+	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
+	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
+	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
+	// (e.g. no predecessor is running).
+	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
 	ReconcileOperation Operation = "reconcile"
 
 	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2025,6 +2025,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
+	out.ReconcileID = in.ReconcileID
 	return nil
 }
 
@@ -2032,6 +2033,7 @@ func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.Execution
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
+	out.ReconcileID = in.ReconcileID
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

If an installation has phase `Failed`, a manual action is necessary to trigger a new reconciliation that might solve the problem.

A force-reconcile annotation might be too brutal, because it skips some checks, so that the order of sub-installations / deploy items might not be guaranteed. 

The normal reconcile annotation on the other hand, is currently too weak. The reconciliation return quite early, because `Failed` is considered as a "completed" phase. The present pull request changes how the controllers handle objects with a reconcile annotation.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
