### PR TITLE
Handle prefix of docker image reference

### DIFF
--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	lserrors "github.com/gardener/landscaper/apis/errors"
-
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -196,13 +194,6 @@ func (o *ExecutionOperation) Ensure(ctx context.Context, inst *installations.Ins
 		ExecutionDeployedReason, "Deployed execution item")
 	if err := o.UpdateInstallationStatus(ctx, inst.Info, inst.Info.Status.Phase, cond); err != nil {
 		return err
-	}
-
-	if lsv1alpha1helper.HasOperation(inst.Info.ObjectMeta, lsv1alpha1.ReconcileOperation) {
-		delete(inst.Info.Annotations, lsv1alpha1.OperationAnnotation)
-		if err := o.Writer().UpdateInstallation(ctx, read_write_layer.W000009, inst.Info); err != nil {
-			return lserrors.NewWrappedError(err, "Ensure", "DeleteOperationAnnotation", err.Error())
-		}
 	}
 
 	return nil

--- a/pkg/landscaper/installations/executions/template/helper.go
+++ b/pkg/landscaper/installations/executions/template/helper.go
@@ -140,13 +140,19 @@ func ParseOCIReference(ref string) [2]string {
 	if err != nil {
 		panic(err)
 	}
+
 	splitRef := strings.Split(ref, ":")
 	if len(splitRef) < 2 {
 		panic("invalid reference")
 	}
 
 	// todo: remove workaround with new component-cli version
-	repository := strings.TrimPrefix(refspec.Name(), "index.docker.io/library/")
+	repository := refspec.Name()
+	if strings.HasPrefix(repository, "index.docker.io/library/") {
+		repository = strings.TrimPrefix(refspec.Name(), "index.docker.io/library/")
+	} else if strings.HasPrefix(repository, "index.docker.io/") {
+		repository = strings.TrimPrefix(refspec.Name(), "index.docker.io/")
+	}
 
 	if refspec.Tag != nil {
 		return [2]string{

--- a/pkg/utils/read_write_layer/logger.go
+++ b/pkg/utils/read_write_layer/logger.go
@@ -2,6 +2,7 @@ package read_write_layer
 
 import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 )
 
 const (
@@ -10,17 +11,18 @@ const (
 	keyNamespace          = "namespace"
 	keyPhase              = "phase"
 	keyWriteID            = "write-id"
-	keyGenerationOld      = "generation-old"
-	keyGenerationNew      = "generation-new"
-	keyResourceVersionOld = "resource-version-old"
-	keyResourceVersionNew = "resource-version-new"
+	keyGenerationOld      = "gen-old"
+	keyGenerationNew      = "gen-new"
+	keyOperation          = "op"
+	keyResourceVersionOld = "rv-old"
+	keyResourceVersionNew = "rv-new"
 )
 
-func (w *Writer) logContextUpdate(writeID WriteID, op string, context *lsv1alpha1.Context,
+func (w *Writer) logContextUpdate(writeID WriteID, msg string, context *lsv1alpha1.Context,
 	generationOld int64, resourceVersionOld string, err error) {
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(context)
-		w.log.V(historyLogLevel).Info(op,
+		w.log.V(historyLogLevel).Info(msg,
 			keyWriteID, writeID,
 			keyName, context.Name,
 			keyNamespace, context.Namespace,
@@ -30,7 +32,7 @@ func (w *Writer) logContextUpdate(writeID WriteID, op string, context *lsv1alpha
 			keyResourceVersionNew, resourceVersionNew,
 		)
 	} else {
-		w.log.Error(err, op,
+		w.log.Error(err, msg,
 			keyWriteID, writeID,
 			keyName, context.Name,
 			keyNamespace, context.Namespace,
@@ -40,11 +42,11 @@ func (w *Writer) logContextUpdate(writeID WriteID, op string, context *lsv1alpha
 	}
 }
 
-func (w *Writer) logTargetUpdate(writeID WriteID, op string, target *lsv1alpha1.Target,
+func (w *Writer) logTargetUpdate(writeID WriteID, msg string, target *lsv1alpha1.Target,
 	generationOld int64, resourceVersionOld string, err error) {
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(target)
-		w.log.V(historyLogLevel).Info(op,
+		w.log.V(historyLogLevel).Info(msg,
 			keyWriteID, writeID,
 			keyName, target.Name,
 			keyNamespace, target.Namespace,
@@ -54,7 +56,7 @@ func (w *Writer) logTargetUpdate(writeID WriteID, op string, target *lsv1alpha1.
 			keyResourceVersionNew, resourceVersionNew,
 		)
 	} else {
-		w.log.Error(err, op,
+		w.log.Error(err, msg,
 			keyWriteID, writeID,
 			keyName, target.Name,
 			keyNamespace, target.Namespace,
@@ -64,11 +66,11 @@ func (w *Writer) logTargetUpdate(writeID WriteID, op string, target *lsv1alpha1.
 	}
 }
 
-func (w *Writer) logDataObjectUpdate(writeID WriteID, op string, do *lsv1alpha1.DataObject,
+func (w *Writer) logDataObjectUpdate(writeID WriteID, msg string, do *lsv1alpha1.DataObject,
 	generationOld int64, resourceVersionOld string, err error) {
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(do)
-		w.log.V(historyLogLevel).Info(op,
+		w.log.V(historyLogLevel).Info(msg,
 			keyWriteID, writeID,
 			keyName, do.Name,
 			keyNamespace, do.Namespace,
@@ -78,7 +80,7 @@ func (w *Writer) logDataObjectUpdate(writeID WriteID, op string, do *lsv1alpha1.
 			keyResourceVersionNew, resourceVersionNew,
 		)
 	} else {
-		w.log.Error(err, op,
+		w.log.Error(err, msg,
 			keyWriteID, writeID,
 			keyName, do.Name,
 			keyNamespace, do.Namespace,
@@ -88,22 +90,24 @@ func (w *Writer) logDataObjectUpdate(writeID WriteID, op string, do *lsv1alpha1.
 	}
 }
 
-func (w *Writer) logInstallationUpdate(writeID WriteID, op string, installation *lsv1alpha1.Installation,
+func (w *Writer) logInstallationUpdate(writeID WriteID, msg string, installation *lsv1alpha1.Installation,
 	generationOld int64, resourceVersionOld string, err error) {
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(installation)
-		w.log.V(historyLogLevel).Info(op,
+		opNew := lsv1alpha1helper.GetOperation(installation.ObjectMeta)
+		w.log.V(historyLogLevel).Info(msg,
 			keyWriteID, writeID,
 			keyName, installation.Name,
 			keyNamespace, installation.Namespace,
 			keyPhase, installation.Status.Phase,
 			keyGenerationOld, generationOld,
 			keyGenerationNew, generationNew,
+			keyOperation, opNew,
 			keyResourceVersionOld, resourceVersionOld,
 			keyResourceVersionNew, resourceVersionNew,
 		)
 	} else {
-		w.log.Error(err, op,
+		w.log.Error(err, msg,
 			keyWriteID, writeID,
 			keyName, installation.Name,
 			keyNamespace, installation.Namespace,
@@ -114,22 +118,24 @@ func (w *Writer) logInstallationUpdate(writeID WriteID, op string, installation 
 	}
 }
 
-func (w *Writer) logExecutionUpdate(writeID WriteID, op string, execution *lsv1alpha1.Execution,
+func (w *Writer) logExecutionUpdate(writeID WriteID, msg string, execution *lsv1alpha1.Execution,
 	generationOld int64, resourceVersionOld string, err error) {
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(execution)
-		w.log.V(historyLogLevel).Info(op,
+		opNew := lsv1alpha1helper.GetOperation(execution.ObjectMeta)
+		w.log.V(historyLogLevel).Info(msg,
 			keyWriteID, writeID,
 			keyName, execution.Name,
 			keyNamespace, execution.Namespace,
 			keyPhase, execution.Status.Phase,
 			keyGenerationOld, generationOld,
 			keyGenerationNew, generationNew,
+			keyOperation, opNew,
 			keyResourceVersionOld, resourceVersionOld,
 			keyResourceVersionNew, resourceVersionNew,
 		)
 	} else {
-		w.log.Error(err, op,
+		w.log.Error(err, msg,
 			keyWriteID, writeID,
 			keyName, execution.Name,
 			keyNamespace, execution.Namespace,
@@ -140,22 +146,24 @@ func (w *Writer) logExecutionUpdate(writeID WriteID, op string, execution *lsv1a
 	}
 }
 
-func (w *Writer) logDeployItemUpdate(writeID WriteID, op string, deployItem *lsv1alpha1.DeployItem,
+func (w *Writer) logDeployItemUpdate(writeID WriteID, msg string, deployItem *lsv1alpha1.DeployItem,
 	generationOld int64, resourceVersionOld string, err error) {
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(deployItem)
-		w.log.V(historyLogLevel).Info(op,
+		opNew := lsv1alpha1helper.GetOperation(deployItem.ObjectMeta)
+		w.log.V(historyLogLevel).Info(msg,
 			keyWriteID, writeID,
 			keyName, deployItem.Name,
 			keyNamespace, deployItem.Namespace,
 			keyPhase, deployItem.Status.Phase,
 			keyGenerationOld, generationOld,
 			keyGenerationNew, generationNew,
+			keyOperation, opNew,
 			keyResourceVersionOld, resourceVersionOld,
 			keyResourceVersionNew, resourceVersionNew,
 		)
 	} else {
-		w.log.Error(err, op,
+		w.log.Error(err, msg,
 			keyWriteID, writeID,
 			keyName, deployItem.Name,
 			keyNamespace, deployItem.Namespace,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area oci
/kind bug
/priority 3

**What this PR does / why we need it**:
Suppose a component descriptor contains a resource referencing a container image on docker.io as follows:

```yaml
  resources:
    - name: nginx-image
      type: ociImage
      version: 1.21.6-debian-10-r105
      relation: external
      access:
        type: ociRegistry
        imageReference: bitnami/nginx:1.21.6-debian-10-r105
```

Further suppose an execution template in the blueprint uses the templating function `ociRefRepo` to obtain the image repository:

```yaml
      values:
        image:
          {{- $imageResource := getResource .cd "name" "nginx-image" }}
          repository: {{ ociRefRepo $imageResource.access.imageReference }}
          tag: {{ ociRefVersion $imageResource.access.imageReference }}
```

The result of the templating inside the execution will look as follows:

```yaml
      values:
        image:
          repository: index.docker.io/bitnami/nginx
          tag: 1.21.6-debian-10-r105
``` 

The `ociRefRepo` templating function has added the prefix `index.docker.io/` to the repository. 

The helm chart used in the current example creates a deployment and a pod with the following image: 

```yaml
      containers:
      - image: docker.io/index.docker.io/bitnami/nginx:1.21.6-debian-10-r105
```

The chart has added another prefix, `docker.io/`. 

Pulling the image of the deployed nginx pod fails:

```text
        message: Back-off pulling image "docker.io/index.docker.io/bitnami/nginx:1.21.6-debian-10-r105"
        reason: ImagePullBackOff
```

The problem is the first prefix that was added by the templating function. The present pull request fixes this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
