### PR TITLE
Fix trigger dependent

### DIFF
--- a/cmd/landscaper-agent/app/options.go
+++ b/cmd/landscaper-agent/app/options.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -69,6 +71,7 @@ func (o *options) Complete() error {
 		LeaderElection:     false,
 		Port:               9443,
 		MetricsBindAddress: "0",
+		NewClient:          lsutils.NewUncachedClient,
 	}
 	hostRestConfig, err := ctrl.GetConfig()
 	if err != nil {

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -10,6 +10,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
@@ -83,6 +85,7 @@ func (o *Options) run(ctx context.Context) error {
 		LeaderElection:     false,
 		Port:               9443,
 		MetricsBindAddress: "0",
+		NewClient:          lsutils.NewUncachedClient,
 	}
 
 	if o.Config.Controllers.SyncPeriod != nil {

--- a/cmd/landscaper-controller/app/app_test.go
+++ b/cmd/landscaper-controller/app/app_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -65,6 +67,7 @@ var _ = Describe("Landscaper Controller", func() {
 			defer ctx.Done()
 			mgr, err = manager.New(testenv.Env.Config, manager.Options{
 				MetricsBindAddress: "0",
+				NewClient:          lsutils.NewUncachedClient,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			lsinstall.Install(mgr.GetScheme())

--- a/pkg/deployer/container/garbage_collector_test.go
+++ b/pkg/deployer/container/garbage_collector_test.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"time"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +56,7 @@ var _ = Describe("GarbageCollector", func() {
 			Scheme:             api.LandscaperScheme,
 			MetricsBindAddress: "0",
 			Logger:             logger.WithName("lsManager"),
+			NewClient:          lsutils.NewUncachedClient,
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -61,6 +64,7 @@ var _ = Describe("GarbageCollector", func() {
 			Scheme:             scheme.Scheme,
 			MetricsBindAddress: "0",
 			Logger:             logger.WithName("hostManager"),
+			NewClient:          lsutils.NewUncachedClient,
 		})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -107,6 +109,7 @@ var _ = Describe("Template", func() {
 			mgr, err = manager.New(testenv.Env.Config, manager.Options{
 				Scheme:             api.LandscaperScheme,
 				MetricsBindAddress: "0",
+				NewClient:          lsutils.NewUncachedClient,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(helm.AddDeployerToManager(simplelogger.NewIOLogger(GinkgoWriter), mgr, mgr, helmv1alpha1.Configuration{})).To(Succeed())

--- a/pkg/deployer/lib/cmd/default.go
+++ b/pkg/deployer/lib/cmd/default.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -66,6 +68,7 @@ func (o *DefaultOptions) Complete() error {
 	opts := manager.Options{
 		LeaderElection:     false,
 		MetricsBindAddress: "0", // disable the metrics serving by default
+		NewClient:          lsutils.NewUncachedClient,
 	}
 
 	restConfig, err := ctrl.GetConfig()

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -113,9 +113,6 @@ func (c *Controller) reconcile(ctx context.Context, inst *lsv1alpha1.Installatio
 		return instOp.NewError(err, "CreateOrUpdateExports", err.Error())
 	}
 
-	// update import status
-	inst.Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
-
 	// as all exports are validated, lets trigger dependant components
 	// todo: check if this is a must, maybe track what we already successfully triggered
 	// maybe we also need to increase the generation manually to signal a new config version
@@ -123,6 +120,10 @@ func (c *Controller) reconcile(ctx context.Context, inst *lsv1alpha1.Installatio
 		err = fmt.Errorf("unable to trigger dependent installations: %w", err)
 		return instOp.NewError(err, "TriggerDependents", err.Error())
 	}
+
+	// update import status
+	inst.Status.Phase = lsv1alpha1.ComponentPhaseSucceeded
+
 	return nil
 }
 

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	lsutils "github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
@@ -212,6 +214,7 @@ var _ = Describe("Delete", func() {
 			mgr, err = manager.New(testenv.Env.Config, manager.Options{
 				Scheme:             api.LandscaperScheme,
 				MetricsBindAddress: "0",
+				NewClient:          lsutils.NewUncachedClient,
 			})
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR sets the status of an installation on success after all dependent installations are triggered. This prevents that an error in the trigger method results in phase success without triggering all dependent installations. 

Additionally all kubernetes clients where switched to uncached clients. This makes arguing about the controller interactions a little bit easier.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
