### PR TITLE
retrigger failed deployer

### DIFF
--- a/pkg/deployermanagement/config/deployment.go
+++ b/pkg/deployermanagement/config/deployment.go
@@ -89,14 +89,14 @@ func (o *Options) DeployInternalDeployers(ctx context.Context, log logr.Logger, 
 	}
 
 	for _, deployerName := range o.EnabledDeployers {
-		if err := o.deployInternalDeployer(ctx, log, deployerName, kubeClient, apply); err != nil {
+		if err := o.deployDeployerRegistrations(ctx, log, deployerName, kubeClient, apply); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (o *Options) deployInternalDeployer(ctx context.Context, log logr.Logger, deployerName string, kubeClient client.Client, apply DeployerApplyFunc) error {
+func (o *Options) deployDeployerRegistrations(ctx context.Context, log logr.Logger, deployerName string, kubeClient client.Client, apply DeployerApplyFunc) error {
 	log.Info("Enable Deployer", "name", deployerName)
 
 	deployerConfig, _ := o.GetDeployerConfigForDeployer(deployerName)

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -32,7 +32,8 @@ import (
 
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	validation "github.com/gardener/landscaper/apis/core/validation"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	"github.com/gardener/landscaper/apis/core/validation"
 )
 
 // DeployerClusterRoleName is the name of the deployer cluster role.
@@ -88,6 +89,7 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 
 	_, err = dm.Writer().CreateOrUpdateCoreInstallation(ctx, read_write_layer.W000002, inst, func() error {
 		controllerutil.AddFinalizer(inst, lsv1alpha1.LandscaperDMFinalizer)
+		lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
 		inst.Spec.ComponentDescriptor = registration.Spec.InstallationTemplate.ComponentDescriptor
 		inst.Spec.Blueprint = registration.Spec.InstallationTemplate.Blueprint
 		inst.Spec.Imports = registration.Spec.InstallationTemplate.Imports


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Failed deployer are reconciled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
