### PR TITLE
Deletion status

### DIFF
--- a/apis/core/v1alpha1/helper/helpers.go
+++ b/apis/core/v1alpha1/helper/helpers.go
@@ -248,21 +248,17 @@ func CombinedInstallationPhase(phases ...v1alpha1.ComponentInstallationPhase) v1
 	var (
 		failed  bool
 		aborted bool
-		init    bool
 		empty   = true
 	)
 	for _, phase := range phases {
 		switch phase {
-		case v1alpha1.ComponentPhaseProgressing, v1alpha1.ComponentPhasePending, v1alpha1.ComponentPhaseDeleting:
+		case v1alpha1.ComponentPhaseProgressing, v1alpha1.ComponentPhasePending, v1alpha1.ComponentPhaseDeleting, v1alpha1.ComponentPhaseInit:
 			return v1alpha1.ComponentPhaseProgressing
 		case v1alpha1.ComponentPhaseFailed:
 			failed = true
 			empty = false
 		case v1alpha1.ComponentPhaseAborted:
 			aborted = true
-			empty = false
-		case v1alpha1.ComponentPhaseInit:
-			init = true
 			empty = false
 		case v1alpha1.ComponentPhaseSucceeded:
 			empty = false
@@ -275,10 +271,6 @@ func CombinedInstallationPhase(phases ...v1alpha1.ComponentInstallationPhase) v1
 
 	if failed {
 		return v1alpha1.ComponentPhaseFailed
-	}
-
-	if init {
-		return v1alpha1.ComponentPhaseInit
 	}
 
 	if empty {

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -26,6 +26,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
 	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
@@ -173,7 +174,12 @@ func handleError(ctx context.Context, err lserrors.LsError, log logr.Logger, c c
 	eventRecorder record.EventRecorder, oldExec, exec *lsv1alpha1.Execution, isDelete bool) error {
 	// if successfully deleted we could not update the object
 	if isDelete && err == nil {
-		return nil
+		exec2 := &lsv1alpha1.Execution{}
+		if err2 := read_write_layer.GetExecution(ctx, c, kutil.ObjectKey(exec.Name, exec.Namespace), exec2); err2 != nil {
+			if apierrors.IsNotFound(err2) {
+				return nil
+			}
+		}
 	}
 
 	// There are two kind of errors: err != nil and exec.Status.LastError != nil

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -33,6 +33,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	"github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/operation"
@@ -266,7 +267,12 @@ func (c *Controller) handleError(ctx context.Context, err lserrors.LsError, oldI
 	inst.Status.LastError = lserrors.TryUpdateLsError(inst.Status.LastError, err)
 	// if successfully deleted we could not update the object
 	if isDelete && err == nil {
-		return nil
+		inst2 := &lsv1alpha1.Installation{}
+		if err2 := read_write_layer.GetInstallation(ctx, c.Client(), kutil.ObjectKey(inst.Name, inst.Namespace), inst2); err2 != nil {
+			if apierrors.IsNotFound(err2) {
+				return nil
+			}
+		}
 	}
 
 	inst.Status.Phase = lserrors.GetPhaseForLastError(

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -89,7 +89,8 @@ var _ = Describe("Delete", func() {
 			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstRoot, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(installationsctl.DeleteExecutionAndSubinstallations(ctx, instOp.Writer(), instOp.Client(), instOp.Inst.Info)).To(Succeed())
+			instController := installationsctl.NewTestActuator(*instOp.Operation, nil)
+			Expect(instController.DeleteExecutionAndSubinstallations(ctx, instOp.Inst.Info)).To(Succeed())
 
 			instA := &lsv1alpha1.Installation{}
 			Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "a", Namespace: state.Namespace}, instA)).ToNot(HaveOccurred())
@@ -114,7 +115,8 @@ var _ = Describe("Delete", func() {
 			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = installationsctl.DeleteExecutionAndSubinstallations(ctx, instOp.Writer(), instOp.Client(), instOp.Inst.Info)
+			instController := installationsctl.NewTestActuator(*instOp.Operation, nil)
+			err = instController.DeleteExecutionAndSubinstallations(ctx, instOp.Inst.Info)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -132,7 +134,8 @@ var _ = Describe("Delete", func() {
 			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(installationsctl.DeleteExecutionAndSubinstallations(ctx, instOp.Writer(), instOp.Client(), instOp.Inst.Info)).To(Succeed())
+			instController := installationsctl.NewTestActuator(*instOp.Operation, nil)
+			Expect(instController.DeleteExecutionAndSubinstallations(ctx, instOp.Inst.Info)).To(Succeed())
 
 			instC := &lsv1alpha1.Installation{}
 			Expect(testenv.Client.Get(ctx, client.ObjectKey{Name: "c", Namespace: state.Namespace}, instC)).ToNot(HaveOccurred())

--- a/pkg/landscaper/execution/delete.go
+++ b/pkg/landscaper/execution/delete.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,17 +44,23 @@ func (o *Operation) Delete(ctx context.Context) lserrors.LsError {
 	executionItems, _ := o.getExecutionItems(managedItems)
 
 	allDeleted := true
+	oneDeleteFailed := false
 	for _, item := range executionItems {
 		if item.DeployItem == nil {
 			continue
 		}
 
-		gone, err := o.deleteItem(ctx, &item, executionItems)
+		gone, deleteFailed, err := o.deleteItem(ctx, &item, executionItems)
 		if err != nil {
 			return err
 		}
 
 		allDeleted = allDeleted && gone
+		oneDeleteFailed = oneDeleteFailed || deleteFailed
+	}
+
+	if oneDeleteFailed {
+		o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
 	}
 
 	if !allDeleted {
@@ -89,32 +97,104 @@ func (o *Operation) checkDeletable(item executionItem, items []executionItem) bo
 	return true
 }
 
-func (o *Operation) deleteItem(ctx context.Context, item *executionItem, executionItems []executionItem) (gone bool, err lserrors.LsError) {
+func (o *Operation) DeleteItemOld(ctx context.Context, item *executionItem, executionItems []executionItem) (gone bool,
+	deleteFailed bool, err lserrors.LsError) {
 	if item.DeployItem == nil {
-		return true, nil
+		return true, false, nil
 	}
 
 	if item.DeployItem.DeletionTimestamp.IsZero() && o.checkDeletable(*item, executionItems) {
 		if err := o.Writer().DeleteDeployItem(ctx, read_write_layer.W000065, item.DeployItem); err != nil {
 			if !apierrors.IsNotFound(err) {
-				return false, lserrors.NewWrappedError(err,
+				return false, false, lserrors.NewWrappedError(err,
 					"DeleteDeployItem",
 					fmt.Sprintf("unable to delete deploy item %s of step %s", item.DeployItem.Name, item.Info.Name),
 					err.Error(),
 				)
 			}
 
-			return true, nil
+			return true, false, nil
 		}
 
-		return false, nil
+		return false, false, nil
 	}
 
-	if !item.DeployItem.DeletionTimestamp.IsZero() && item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed {
-		o.exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+	if !item.DeployItem.DeletionTimestamp.IsZero() &&
+		item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed &&
+		item.DeployItem.Status.ObservedGeneration == item.DeployItem.Generation {
+		return false, true, nil
 	}
 
-	return false, nil
+	return false, false, nil
+}
+
+func (o *Operation) deleteItem(ctx context.Context, item *executionItem, executionItems []executionItem) (gone bool,
+	deleteFailed bool, err lserrors.LsError) {
+	if item.DeployItem == nil {
+		return true, false, nil
+	}
+
+	if o.triggerDeletionIsRequired(ctx, item, executionItems) {
+		if err := o.triggerDeletion(ctx, item); err != nil {
+			return false, false, err
+		}
+
+		if err := o.markTriggerDeletionAsDone(ctx, item); err != nil {
+			return false, false, err
+		}
+
+		return false, false, nil
+	}
+
+	if !item.DeployItem.DeletionTimestamp.IsZero() &&
+		item.DeployItem.Status.Phase == lsv1alpha1.ExecutionPhaseFailed &&
+		item.DeployItem.Status.ObservedGeneration == item.DeployItem.Generation {
+		return false, true, nil
+	}
+
+	return false, false, nil
+}
+
+func (o *Operation) triggerDeletionIsRequired(_ context.Context, item *executionItem, executionItems []executionItem) bool {
+	lastAppliedGeneration, ok := getExecutionGeneration(o.exec.Status.ExecutionGenerations, item.Info.Name)
+	if ok && lastAppliedGeneration.ObservedGeneration == o.exec.Generation {
+		return false
+	}
+
+	return o.checkDeletable(*item, executionItems)
+}
+
+func (o *Operation) triggerDeletion(ctx context.Context, item *executionItem) lserrors.LsError {
+	if item.DeployItem.DeletionTimestamp.IsZero() {
+		if err := o.Writer().DeleteDeployItem(ctx, read_write_layer.W000065, item.DeployItem); client.IgnoreNotFound(err) != nil {
+			return lserrors.NewWrappedError(err, "DeleteDeployItem",
+				fmt.Sprintf("unable to delete deploy item %s of step %s", item.DeployItem.Name, item.Info.Name),
+				err.Error(),
+			)
+		}
+	} else {
+		// if the deletionTimestamp is already set, re-trigger via reconcile annotation
+		if _, err := o.Writer().CreateOrUpdateDeployItem(ctx, read_write_layer.W000080, item.DeployItem, func() error {
+			lsv1alpha1helper.SetOperation(&item.DeployItem.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			lsv1alpha1helper.SetTimestampAnnotationNow(&item.DeployItem.ObjectMeta, lsv1alpha1helper.ReconcileTimestamp)
+			return nil
+		}); client.IgnoreNotFound(err) != nil {
+			msg := fmt.Sprintf("error while re-triggering deletion of deployitem %q", item.Info.Name)
+			return lserrors.NewWrappedError(err, "TriggerDeployItemDeletion", msg, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (o *Operation) markTriggerDeletionAsDone(ctx context.Context, item *executionItem) lserrors.LsError {
+	old := o.exec.DeepCopy()
+	o.exec.Status.ExecutionGenerations = setExecutionGeneration(o.exec.Status.ExecutionGenerations, item.Info.Name, o.exec.Generation)
+	if err := o.Writer().PatchExecutionStatus(ctx, read_write_layer.W000081, o.exec, old); err != nil {
+		msg := fmt.Sprintf("unable to patch execution status %s", o.exec.Name)
+		return lserrors.NewWrappedError(err, "MarkTriggerDeletionAsDone", msg, err.Error())
+	}
+	return nil
 }
 
 func (o *Operation) propagateDeleteWithoutUninstallAnnotation(ctx context.Context, deployItems []lsv1alpha1.DeployItem) lserrors.LsError {

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -142,7 +142,6 @@ func deployItemUpToDateAndNotForceReconcile(exec *lsv1alpha1.Execution, itemInfo
 
 func setPhaseFailedBecausePickupTimeout(exec *lsv1alpha1.Execution, cond lsv1alpha1.Condition, infoName, deployItemName string,
 	dlogger logr.Logger) {
-	exec.Status.ObservedGeneration = exec.Generation
 	exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
 	exec.Status.Conditions = lsv1alpha1helper.MergeConditions(exec.Status.Conditions,
 		lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
@@ -168,7 +167,6 @@ func setPhaseProgressingOfRunningDeployItem(exec *lsv1alpha1.Execution, itemInfo
 
 func setPhaseFailedBecauseFailedDeployItem(exec *lsv1alpha1.Execution, cond lsv1alpha1.Condition, infoName, deployItemName string,
 	dlogger logr.Logger) {
-	exec.Status.ObservedGeneration = exec.Generation
 	exec.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
 	exec.Status.Conditions = lsv1alpha1helper.MergeConditions(exec.Status.Conditions,
 		lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,

--- a/pkg/utils/read_write_layer/consts.go
+++ b/pkg/utils/read_write_layer/consts.go
@@ -82,6 +82,9 @@ const (
 	W000076 WriteID = "w000076"
 	W000077 WriteID = "w000077"
 	W000078 WriteID = "w000078"
+	W000079 WriteID = "w000079"
+	W000080 WriteID = "w000080"
+	W000081 WriteID = "w000081"
 )
 
 const (

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -248,21 +248,17 @@ func CombinedInstallationPhase(phases ...v1alpha1.ComponentInstallationPhase) v1
 	var (
 		failed  bool
 		aborted bool
-		init    bool
 		empty   = true
 	)
 	for _, phase := range phases {
 		switch phase {
-		case v1alpha1.ComponentPhaseProgressing, v1alpha1.ComponentPhasePending, v1alpha1.ComponentPhaseDeleting:
+		case v1alpha1.ComponentPhaseProgressing, v1alpha1.ComponentPhasePending, v1alpha1.ComponentPhaseDeleting, v1alpha1.ComponentPhaseInit:
 			return v1alpha1.ComponentPhaseProgressing
 		case v1alpha1.ComponentPhaseFailed:
 			failed = true
 			empty = false
 		case v1alpha1.ComponentPhaseAborted:
 			aborted = true
-			empty = false
-		case v1alpha1.ComponentPhaseInit:
-			init = true
 			empty = false
 		case v1alpha1.ComponentPhaseSucceeded:
 			empty = false
@@ -275,10 +271,6 @@ func CombinedInstallationPhase(phases ...v1alpha1.ComponentInstallationPhase) v1
 
 	if failed {
 		return v1alpha1.ComponentPhaseFailed
-	}
-
-	if init {
-		return v1alpha1.ComponentPhaseInit
 	}
 
 	if empty {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
