### PR TITLE
New reconcile tests

### DIFF
--- a/pkg/deployer/container/test/e2e_test.go
+++ b/pkg/deployer/container/test/e2e_test.go
@@ -72,7 +72,8 @@ var _ = Describe("Container Deployer", func() {
 	})
 
 	It("should requeue after the correct time if continuous reconciliation is configured", func() {
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
+			// continuous reconciliation currently not supported by new reconcile
 			return
 		}
 

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -125,10 +125,6 @@ var _ = Describe("Template", func() {
 		})
 
 		It("should create the release namespace if configured", func() {
-			if lsutils.NewReconcile {
-				return
-			}
-
 			Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
 			target, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 			Expect(err).ToNot(HaveOccurred())
@@ -153,9 +149,10 @@ var _ = Describe("Template", func() {
 				Key(state.Namespace, "myitem").
 				ProviderConfig(helmConfig).
 				Target(target.Namespace, target.Name).
+				GenerateJobID().
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(state.Create(ctx, item)).To(Succeed())
+			Expect(state.Create(ctx, item, envtest.UpdateStatus(true))).To(Succeed())
 
 			Eventually(func() error {
 				if err := testenv.Client.Get(ctx, kutil.ObjectKey("some-namespace", ""), &corev1.Namespace{}); err != nil {

--- a/pkg/deployer/lib/targetselector/e2e_suite_test.go
+++ b/pkg/deployer/lib/targetselector/e2e_suite_test.go
@@ -55,10 +55,6 @@ var _ = Describe("E2E", func() {
 	})
 
 	It("should reconcile a deploy item with matching annotation selector", func() {
-		if utils.NewReconcile {
-			return
-		}
-
 		ctx := context.Background()
 		defer ctx.Done()
 
@@ -81,9 +77,10 @@ var _ = Describe("E2E", func() {
 			Key(state.Namespace, "test1").
 			ProviderConfig(mockConfig).
 			TargetFromObjectKey(kutil.ObjectKeyFromObject(tgt)).
+			GenerateJobID().
 			Build()
 		testutils.ExpectNoError(err)
-		testutils.ExpectNoError(state.Create(ctx, di))
+		testutils.ExpectNoError(state.Create(ctx, di, envtest.UpdateStatus(true)))
 
 		defaultContext := &lsv1alpha1.Context{}
 		defaultContext.Name = lsv1alpha1.DefaultContextName
@@ -110,6 +107,8 @@ var _ = Describe("E2E", func() {
 		resDi := &lsv1alpha1.DeployItem{}
 		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(di), resDi))
 		Expect(resDi.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+		Expect(utils.IsDeployItemPhase(resDi, lsv1alpha1.DeployItemPhaseSucceeded)).To(BeTrue())
+		Expect(utils.IsDeployItemJobIDsIdentical(resDi)).To(BeTrue())
 	})
 
 	It("should not reconcile a deploy item if the annotation selector does not match", func() {

--- a/pkg/landscaper/controllers/deployitem/controller.go
+++ b/pkg/landscaper/controllers/deployitem/controller.go
@@ -69,7 +69,7 @@ type controller struct {
 }
 
 func (con *controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	if utils.NewReconcile {
+	if utils.IsNewReconcile() {
 		return con.reconcileNew(ctx, req)
 	} else {
 		return con.reconcileOld(ctx, req)
@@ -290,6 +290,6 @@ func (con *controller) Writer() *read_write_layer.Writer {
 	return read_write_layer.NewWriter(con.log, con.c)
 }
 
-func (con *controller) hasBeenPickedUp(di *lsv1alpha1.DeployItem) bool {
+func HasBeenPickedUp(di *lsv1alpha1.DeployItem) bool {
 	return di.Status.LastReconcileTime != nil && !di.Status.LastReconcileTime.Before(di.Status.JobIDGenerationTime)
 }

--- a/pkg/landscaper/controllers/deployitem/reconcile_new.go
+++ b/pkg/landscaper/controllers/deployitem/reconcile_new.go
@@ -41,7 +41,7 @@ func (con *controller) reconcileNew(ctx context.Context, req reconcile.Request) 
 	}
 
 	// check pickup timeout
-	if !con.hasBeenPickedUp(di) {
+	if !HasBeenPickedUp(di) {
 		if con.pickupTimeout != 0 {
 			logger.V(7).Info("check for pickup timeout")
 
@@ -52,6 +52,9 @@ func (con *controller) reconcileNew(ctx context.Context, req reconcile.Request) 
 				return reconcile.Result{}, err
 			}
 
+			if requeue == nil {
+				return reconcile.Result{}, nil
+			}
 			return reconcile.Result{RequeueAfter: *requeue}, nil
 		}
 
@@ -73,6 +76,9 @@ func (con *controller) reconcileNew(ctx context.Context, req reconcile.Request) 
 			return reconcile.Result{}, err
 		}
 
+		if requeue == nil {
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{RequeueAfter: *requeue}, nil
 	}
 
@@ -88,11 +94,13 @@ func (con *controller) reconcileNew(ctx context.Context, req reconcile.Request) 
 		}
 
 		if exceeded {
-			if err = con.writeProgressingTimeoutExceeded(ctx, logger, di); err != nil {
-				return reconcile.Result{}, err
-			}
+			err = con.writeProgressingTimeoutExceeded(ctx, logger, di)
+			return reconcile.Result{}, err
 		}
 
+		if requeue == nil {
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{RequeueAfter: *requeue}, nil
 	}
 

--- a/pkg/landscaper/controllers/execution/reconcile_test.go
+++ b/pkg/landscaper/controllers/execution/reconcile_test.go
@@ -42,10 +42,6 @@ var _ = Describe("Reconcile", func() {
 	})
 
 	It("should correctly reconcile a deleted execution when it was in failed state", func() {
-		if utils.NewReconcile {
-			return
-		}
-
 		ctx := context.Background()
 		// first deploy reconcile a simple execution with one deploy item
 		exec := &lsv1alpha1.Execution{}
@@ -65,35 +61,72 @@ var _ = Describe("Reconcile", func() {
 				},
 			},
 		}
-		testutils.ExpectNoError(state.Create(ctx, exec))
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
 
-		// expect a deploy item
-		items := &lsv1alpha1.DeployItemList{}
-		testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
-		Expect(items.Items).To(HaveLen(1))
-		di := &items.Items[0]
-		//set item to failed state
-		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+		if utils.IsNewReconcile() {
+			Expect(state.Create(ctx, exec)).To(Succeed())
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
+			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
 
-		// then reconcile the execution and delete it
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
-		testutils.ExpectNoError(testenv.Client.Delete(ctx, exec))
-		// reconcile 2 times so that the deployitem is deleted on the first
-		// and on the execution on the second reconcile
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseProgressing))
+			Expect(exec.Status.JobIDFinished).NotTo(Equal(exec.Status.JobID))
 
-		Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di))).To(BeTrue(), "expect the deploy item to be deleted")
-		Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))).To(BeTrue(), "expect the execution to be deleted")
+			// expect a deploy item
+			items := &lsv1alpha1.DeployItemList{}
+			testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
+			Expect(items.Items).To(HaveLen(1))
+
+			// set item to failed state
+			di := &items.Items[0]
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			di.Status.DeployItemPhase = lsv1alpha1.DeployItemPhaseFailed
+			di.Status.JobID = exec.Status.JobID
+			di.Status.JobIDFinished = exec.Status.JobID
+			testutils.ExpectNoError(state.Client.Status().Update(ctx, di))
+
+			// reconcile execution and check that it is failed
+			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseFailed))
+			Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
+
+			// delete execution
+			testutils.ExpectNoError(testenv.Client.Delete(ctx, exec))
+
+			// reconcile execution and check that objects are gone
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di))).To(BeTrue(), "expect the deploy item to be deleted")
+			Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))).To(BeTrue(), "expect the execution to be deleted")
+		} else {
+			testutils.ExpectNoError(state.Create(ctx, exec))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+
+			// expect a deploy item
+			items := &lsv1alpha1.DeployItemList{}
+			testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
+			Expect(items.Items).To(HaveLen(1))
+			di := &items.Items[0]
+			//set item to failed state
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+
+			// then reconcile the execution and delete it
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ExpectNoError(testenv.Client.Delete(ctx, exec))
+			// reconcile 2 times so that the deployitem is deleted on the first
+			// and on the execution on the second reconcile
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+
+			Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di))).To(BeTrue(), "expect the deploy item to be deleted")
+			Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))).To(BeTrue(), "expect the execution to be deleted")
+		}
 	})
 
 	Context("Context", func() {
 		It("should pass the context to the deploy item", func() {
-			if utils.NewReconcile {
-				return
-			}
-
 			ctx := context.Background()
 			// first deploy reconcile a simple execution with one deploy item
 			exec := &lsv1alpha1.Execution{}
@@ -114,8 +147,14 @@ var _ = Describe("Reconcile", func() {
 					},
 				},
 			}
-			testutils.ExpectNoError(state.Create(ctx, exec))
-			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(state.Create(ctx, exec)).To(Succeed())
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
+			if utils.IsNewReconcile() {
+				_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			} else {
+				testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			}
 
 			// expect a deploy item
 			items := &lsv1alpha1.DeployItemList{}
@@ -126,10 +165,6 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("should default the context of the deploy item", func() {
-			if utils.NewReconcile {
-				return
-			}
-
 			ctx := context.Background()
 			// first deploy reconcile a simple execution with one deploy item
 			exec := &lsv1alpha1.Execution{}
@@ -149,8 +184,14 @@ var _ = Describe("Reconcile", func() {
 					},
 				},
 			}
-			testutils.ExpectNoError(state.Create(ctx, exec))
-			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(state.Create(ctx, exec)).To(Succeed())
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
+			if utils.IsNewReconcile() {
+				_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			} else {
+				testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			}
 
 			// expect a deploy item
 			items := &lsv1alpha1.DeployItemList{}
@@ -162,10 +203,6 @@ var _ = Describe("Reconcile", func() {
 	})
 
 	It("should adapt the status of the execution if a deploy item changes from Failed to Succeeded and vice versa", func() {
-		if utils.NewReconcile {
-			return
-		}
-
 		ctx := context.Background()
 		// first deploy reconcile a simple execution with one deploy item
 		exec := &lsv1alpha1.Execution{}
@@ -185,37 +222,98 @@ var _ = Describe("Reconcile", func() {
 				},
 			},
 		}
-		testutils.ExpectNoError(state.Create(ctx, exec))
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		if utils.IsNewReconcile() {
+			Expect(state.Create(ctx, exec)).To(Succeed())
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
 
-		// expect a deploy item
-		items := &lsv1alpha1.DeployItemList{}
-		testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
-		Expect(items.Items).To(HaveLen(1))
-		di := &items.Items[0]
-		//set item to failed state
-		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-		di.Status.ObservedGeneration = di.Generation
-		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseProgressing))
+			Expect(exec.Status.JobIDFinished).NotTo(Equal(exec.Status.JobID))
 
-		// then reconcile the execution and expect the execution to be Failed
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
-		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
-		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+			// expect a deploy item
+			items := &lsv1alpha1.DeployItemList{}
+			testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
+			Expect(items.Items).To(HaveLen(1))
+			di := &items.Items[0]
 
-		// set deployitem phase to Succeeded and check again
-		di.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
-		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
-		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
-		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			// set item to failed state
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			di.Status.DeployItemPhase = lsv1alpha1.DeployItemPhaseFailed
+			di.Status.JobID = exec.Status.JobID
+			di.Status.JobIDFinished = exec.Status.JobID
+			testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
 
-		// verify that from Succeeded to Failed also works
-		di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
-		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
-		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
-		testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
-		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+			// then reconcile the execution and expect the execution to be Failed
+			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseFailed))
+			Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
+
+			// set deploy item phase to Succeeded and check again
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
+
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
+			di.Status.DeployItemPhase = lsv1alpha1.DeployItemPhaseSucceeded
+			di.Status.JobID = exec.Status.JobID
+			di.Status.JobIDFinished = exec.Status.JobID
+			testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseSucceeded))
+			Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
+
+			// verify that from Succeeded to Failed also works
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
+
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			di.Status.DeployItemPhase = lsv1alpha1.DeployItemPhaseFailed
+			di.Status.JobID = exec.Status.JobID
+			di.Status.JobIDFinished = exec.Status.JobID
+			testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+
+			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseFailed))
+			Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
+		} else {
+			Expect(state.Create(ctx, exec)).To(Succeed())
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+
+			// expect a deploy item
+			items := &lsv1alpha1.DeployItemList{}
+			testutils.ExpectNoError(testenv.Client.List(ctx, items, client.InNamespace(state.Namespace)))
+			Expect(items.Items).To(HaveLen(1))
+			di := &items.Items[0]
+
+			// set item to failed state
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			di.Status.ObservedGeneration = di.Generation
+			testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+
+			// then reconcile the execution and expect the execution to be Failed
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+
+			// set deployitem phase to Succeeded and check again
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseSucceeded
+			testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+
+			// verify that from Succeeded to Failed also works
+			di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
+			testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
+			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseFailed))
+		}
 	})
 
 })

--- a/pkg/landscaper/controllers/installations/reconcile_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_test.go
@@ -67,7 +67,8 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("should propagate phase changes from executions to installations", func() {
-			if utils.NewReconcile {
+			if utils.IsNewReconcile() {
+				// propagating changes upwards is currently not supported by the new reconcile
 				return
 			}
 
@@ -101,7 +102,8 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("should propagate phase changes from subinstallations to installations", func() {
-			if utils.NewReconcile {
+			if utils.IsNewReconcile() {
+				// propagating changes upwards is currently not supported by the new reconcile
 				return
 			}
 
@@ -135,7 +137,8 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("should trigger reconcile of execution", func() {
-			if utils.NewReconcile {
+			if utils.IsNewReconcile() {
+				// this test is not relevant anymore are the whole strategy has changed
 				return
 			}
 

--- a/pkg/landscaper/installations/imports/hash.go
+++ b/pkg/landscaper/installations/imports/hash.go
@@ -1,0 +1,57 @@
+package imports
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+)
+
+type importsHashes struct {
+	DataObjects              map[string]string
+	Targets                  map[string]string
+	TargetLists              map[string]string
+	ComponentDescriptors     map[string]string
+	ComponentDescriptorLists map[string]string
+}
+
+func ComputeImportsHash(imps *Imports) (string, error) {
+	impsHashes := importsHashes{}
+
+	impsHashes.DataObjects = make(map[string]string, len(imps.DataObjects))
+	for k, v := range imps.DataObjects {
+		impsHashes.DataObjects[k] = v.ComputeConfigGeneration()
+	}
+
+	impsHashes.Targets = make(map[string]string, len(imps.Targets))
+	for k, v := range imps.Targets {
+		impsHashes.DataObjects[k] = v.ComputeConfigGeneration()
+	}
+
+	impsHashes.TargetLists = make(map[string]string, len(imps.TargetLists))
+	for k, v := range imps.TargetLists {
+		impsHashes.DataObjects[k] = v.ComputeConfigGeneration()
+	}
+
+	impsHashes.ComponentDescriptors = make(map[string]string, len(imps.ComponentDescriptors))
+	for k, v := range imps.ComponentDescriptors {
+		impsHashes.DataObjects[k] = v.ComputeConfigGeneration()
+	}
+
+	impsHashes.ComponentDescriptorLists = make(map[string]string, len(imps.ComponentDescriptorLists))
+	for k, v := range imps.ComponentDescriptorLists {
+		impsHashes.DataObjects[k] = v.ComputeConfigGeneration()
+	}
+
+	impsHashesJson, err := json.Marshal(impsHashes)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha1.New()
+	_, err = h.Write(impsHashesJson)
+	if err != nil {
+		return "", err
+	}
+	result := hex.EncodeToString(h.Sum(nil))
+	return result, nil
+}

--- a/pkg/landscaper/installations/reconcilehelper/reconcilehelper.go
+++ b/pkg/landscaper/installations/reconcilehelper/reconcilehelper.go
@@ -553,7 +553,7 @@ func (rh *ReconcileHelper) checkStateForParentImport(fldPath *field.Path, import
 		return installations.NewImportNotFoundErrorf(err, "%s: import in parent not found", fldPath.String())
 	}
 
-	if utils.NewReconcile {
+	if utils.IsNewReconcile() {
 		return nil
 	}
 

--- a/pkg/landscaper/installations/reconcilehelper/validation_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/validation_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should fail if the parent provides the import but is not progressing", func() {
-			if utils.NewReconcile {
+			if utils.IsNewReconcile() {
 				return
 			}
 

--- a/pkg/utils/builders.go
+++ b/pkg/utils/builders.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,6 +28,7 @@ type DeployItemBuilder struct {
 	target                *lsv1alpha1.ObjectReference
 	annotations           map[string]string
 	Context               string
+	generateJobID         bool
 }
 
 // NewDeployItemBuilder creates a new deploy item builder
@@ -118,6 +121,11 @@ func (b *DeployItemBuilder) WithContext(name string) *DeployItemBuilder {
 	return b
 }
 
+func (b *DeployItemBuilder) GenerateJobID() *DeployItemBuilder {
+	b.generateJobID = true
+	return b
+}
+
 // Build creates the deploy items using the given options.
 func (b *DeployItemBuilder) Build() (*lsv1alpha1.DeployItem, error) {
 	b.applyDefaults()
@@ -146,6 +154,10 @@ func (b *DeployItemBuilder) Build() (*lsv1alpha1.DeployItem, error) {
 
 	if len(di.Spec.Context) == 0 {
 		di.Spec.Context = lsv1alpha1.DefaultContextName
+	}
+
+	if b.generateJobID {
+		di.Status.JobID = uuid.New().String()
 	}
 
 	return di, nil

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,3 +1,33 @@
 package utils
 
+import lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+
 var NewReconcile = false
+
+func IsNewReconcile() bool {
+	return NewReconcile
+}
+
+func IsDeployItemPhase(di *lsv1alpha1.DeployItem, phase lsv1alpha1.DeployItemPhase) bool {
+	return !IsNewReconcile() || di.Status.DeployItemPhase == phase
+}
+
+func IsInstallationPhase(inst *lsv1alpha1.Installation, phase lsv1alpha1.InstallationPhase) bool {
+	return !IsNewReconcile() || inst.Status.InstallationPhase == phase
+}
+
+func IsExecutionPhase(exec *lsv1alpha1.Execution, phase lsv1alpha1.ExecPhase) bool {
+	return !IsNewReconcile() || exec.Status.ExecutionPhase == phase
+}
+
+func IsDeployItemJobIDsIdentical(di *lsv1alpha1.DeployItem) bool {
+	return !IsNewReconcile() || di.Status.JobID == di.Status.JobIDFinished
+}
+
+func IsInstallationJobIDsIdentical(inst *lsv1alpha1.Installation) bool {
+	return !IsNewReconcile() || inst.Status.JobID == inst.Status.JobIDFinished
+}
+
+func IsExecutionJobIDsIdentical(exec *lsv1alpha1.Execution) bool {
+	return !IsNewReconcile() || exec.Status.JobID == exec.Status.JobIDFinished
+}

--- a/pkg/utils/hash/hash.go
+++ b/pkg/utils/hash/hash.go
@@ -1,0 +1,159 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"reflect"
+	"sort"
+)
+
+// EXPERIMENTAL !
+func ComputeHash(obj interface{}) (string, error) {
+	hasher := newHasher()
+
+	if err := hasher.addInterface(obj); err != nil {
+		return "", err
+	}
+
+	resultBytes := hasher.hash.Sum(nil)
+	return hex.EncodeToString(resultBytes), nil
+}
+
+func newHasher() *hasher {
+	return &hasher{
+		hash: sha256.New(),
+	}
+}
+
+type hasher struct {
+	hash hash.Hash
+}
+
+func (h *hasher) addInterface(obj interface{}) error {
+	if obj == nil {
+		_, err := fmt.Fprint(h.hash, reflect.ValueOf(nil))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	value := reflect.Indirect(reflect.ValueOf(obj))
+	return h.addAnyValue(value)
+}
+
+func (h *hasher) addAnyValue(val reflect.Value) error {
+	//val := reflect.Indirect(reflect.ValueOf(value))
+	if !val.IsValid() || val.IsZero() {
+		return nil
+	}
+
+	kind := val.Type().Kind()
+	switch kind {
+	case reflect.Struct, reflect.Ptr:
+		if err := h.addStructure(val); err != nil {
+			return err
+		}
+
+	case reflect.Slice, reflect.Array:
+		if err := h.addArray(val); err != nil {
+			return err
+		}
+
+	case reflect.Map:
+		if err := h.addMap(val); err != nil {
+			return err
+		}
+
+	default:
+		if err := h.addElementaryValue(val); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (h *hasher) addElementaryValue(value reflect.Value) error {
+	_, err := fmt.Fprint(h.hash, reflect.ValueOf(value).Interface())
+	return err
+}
+
+func (h *hasher) addStructure(value reflect.Value) error {
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+
+		ignore := value.Type().Field(i).Tag.Get("hash") == "ignore"
+		if field.IsZero() || !field.IsValid() || ignore {
+			continue
+		}
+
+		var valOf interface{}
+		// check if field of struct is unexported
+		if reflect.Indirect(field).CanInterface() {
+			valOf = reflect.Indirect(field).Interface()
+		} else {
+			return nil
+		}
+
+		if err := h.addInterface(valOf); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *hasher) addArray(value reflect.Value) error {
+	for i := 0; i < value.Len(); i++ {
+		item := reflect.Indirect(value.Index(i)).Interface()
+
+		itemHash, err := ComputeHash(item)
+		if err != nil {
+			return err
+		}
+
+		if err := h.addInterface(itemHash); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *hasher) addMap(value reflect.Value) error {
+	// sort key-value pairs based on hash string of each key
+	keyHash := make([]string, len(value.MapKeys()))
+	keyHashValue := make(map[string]reflect.Value)
+
+	for i, key := range value.MapKeys() {
+		kh, err := ComputeHash(key.Interface())
+		if err != nil {
+			return err
+		}
+		keyHash[i] = kh
+		keyHashValue[kh] = value.MapIndex(key)
+	}
+	sort.Strings(keyHash)
+
+	for _, kh := range keyHash {
+		_, err := fmt.Fprint(h.hash, kh)
+		if err != nil {
+			return err
+		}
+		vh, err := ComputeHash(keyHashValue[kh].Interface())
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(h.hash, vh)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/hash/hash_suite_test.go
+++ b/pkg/utils/hash/hash_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hash
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Test Suite")
+}

--- a/pkg/utils/hash/hash_test.go
+++ b/pkg/utils/hash/hash_test.go
@@ -1,0 +1,129 @@
+package hash
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Hash computation tests", func() {
+
+	Context("Elementary types", func() {
+
+		It("should hash strings", func() {
+			result, err := ComputeHash("test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"))
+
+			result, err = ComputeHash("hello")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"))
+		})
+
+		It("should hash booleans", func() {
+			result, err := ComputeHash(true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"))
+
+			result, err = ComputeHash(false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+		})
+
+		It("should hash integers", func() {
+			result, err := ComputeHash(1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"))
+
+			result, err = ComputeHash(42)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"))
+		})
+	})
+
+	Context("Initial values", func() {
+
+		It("should hash initial values", func() {
+			result, err := ComputeHash("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			result, err = ComputeHash(0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			result, err = ComputeHash(false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			result, err = ComputeHash([]interface{}{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			result, err = ComputeHash(map[string]interface{}{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			result, err = ComputeHash(map[string]string{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			result, err = ComputeHash(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("426b5dfece37e413f559015825ebc7c5ba251a13028e2fcd5ed36df57be00b6c"))
+		})
+
+		Context("Maps", func() {
+
+			It("should hash maps", func() {
+				m := map[string]string{"a": "1", "b": "2"}
+
+				result, err := ComputeHash(m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal("c6879d189ada98c7f4acce4fb0098741c582a53468b4387e2759c69c85845bcf"))
+
+				m = map[string]string{"b": "2", "a": "1"}
+
+				result, err = ComputeHash(m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal("c6879d189ada98c7f4acce4fb0098741c582a53468b4387e2759c69c85845bcf"))
+
+				s := []string{"b", "2", "a", "1"}
+
+				result, err = ComputeHash(s)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal("c6879d189ada98c7f4acce4fb0098741c582a53468b4387e2759c69c85845bcf"))
+			})
+		})
+
+		Context("Slices", func() {
+
+			It("should hash maps", func() {
+				s := []string{"a", "b"}
+
+				result, err := ComputeHash(s)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal("62af5c3cb8da3e4f25061e829ebeea5c7513c54949115b1acc225930a90154da"))
+
+				s = []string{"b", "a"}
+
+				result, err = ComputeHash(s)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal("ab19ec537f09499b26f0f62eed7aefad46ab9f498e06a7328ce8e8ef90da6d86"))
+
+				ha, err := ComputeHash("a")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ha).To(Equal("ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"))
+
+				hha, err := ComputeHash(ha)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hha).To(Equal("da3811154d59c4267077ddd8bb768fa9b06399c486e1fc00485116b57c9872f5"))
+
+				s = []string{"a"}
+
+				result, err = ComputeHash(s)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal("da3811154d59c4267077ddd8bb768fa9b06399c486e1fc00485116b57c9872f5"))
+			})
+		})
+	})
+})

--- a/pkg/utils/read_write_layer/consts.go
+++ b/pkg/utils/read_write_layer/consts.go
@@ -117,6 +117,9 @@ const (
 	W000111 WriteID = "w000111"
 	W000112 WriteID = "w000112"
 	W000113 WriteID = "w000113"
+	W000114 WriteID = "w000114"
+	W000115 WriteID = "w000115"
+	W000116 WriteID = "w000116"
 )
 
 const (

--- a/pkg/utils/read_write_layer/logger.go
+++ b/pkg/utils/read_write_layer/logger.go
@@ -99,7 +99,7 @@ func (w *Writer) logInstallationUpdate(writeID WriteID, msg string, installation
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(installation)
 		opNew := lsv1alpha1helper.GetOperation(installation.ObjectMeta)
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
 			w.log.V(historyLogLevel).Info(msg,
 				keyWriteID, writeID,
 				keyName, installation.Name,
@@ -128,7 +128,7 @@ func (w *Writer) logInstallationUpdate(writeID WriteID, msg string, installation
 		}
 
 	} else {
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
 			w.log.Error(err, msg,
 				keyWriteID, writeID,
 				keyName, installation.Name,
@@ -157,7 +157,7 @@ func (w *Writer) logExecutionUpdate(writeID WriteID, msg string, execution *lsv1
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(execution)
 		opNew := lsv1alpha1helper.GetOperation(execution.ObjectMeta)
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
 			w.log.V(historyLogLevel).Info(msg,
 				keyWriteID, writeID,
 				keyName, execution.Name,
@@ -185,7 +185,7 @@ func (w *Writer) logExecutionUpdate(writeID WriteID, msg string, execution *lsv1
 			)
 		}
 	} else {
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
 			w.log.Error(err, msg,
 				keyWriteID, writeID,
 				keyName, execution.Name,
@@ -214,7 +214,7 @@ func (w *Writer) logDeployItemUpdate(writeID WriteID, msg string, deployItem *ls
 	if err == nil {
 		generationNew, resourceVersionNew := getGenerationAndResourceVersion(deployItem)
 		opNew := lsv1alpha1helper.GetOperation(deployItem.ObjectMeta)
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
 			w.log.V(historyLogLevel).Info(msg,
 				keyWriteID, writeID,
 				keyName, deployItem.Name,
@@ -244,7 +244,7 @@ func (w *Writer) logDeployItemUpdate(writeID WriteID, msg string, deployItem *ls
 		}
 
 	} else {
-		if utils.NewReconcile {
+		if utils.IsNewReconcile() {
 			w.log.Error(err, msg,
 				keyWriteID, writeID,
 				keyName, deployItem.Name,

--- a/test/integration/core/register.go
+++ b/test/integration/core/register.go
@@ -4,9 +4,14 @@
 
 package core
 
-import "github.com/gardener/landscaper/test/framework"
+import (
+	"github.com/gardener/landscaper/pkg/utils"
+	"github.com/gardener/landscaper/test/framework"
+)
 
 // RegisterTests registers all tests of the package
 func RegisterTests(f *framework.Framework) {
-	RegistryTest(f)
+	if !utils.IsNewReconcile() {
+		RegistryTest(f)
+	}
 }

--- a/test/integration/deployers/container_tests.go
+++ b/test/integration/deployers/container_tests.go
@@ -9,8 +9,8 @@ import (
 	"path"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	g "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -22,7 +22,7 @@ import (
 )
 
 func ContainerDeployerTests(f *framework.Framework) {
-	ginkgo.Describe("Container Deployer", func() {
+	Describe("Container Deployer", func() {
 		var (
 			state      = f.Register()
 			exampleDir = path.Join(f.RootPath, "examples/deploy-items")
@@ -30,17 +30,17 @@ func ContainerDeployerTests(f *framework.Framework) {
 			ctx context.Context
 		)
 
-		ginkgo.BeforeEach(func() {
+		BeforeEach(func() {
 			ctx = context.Background()
 		})
 
-		ginkgo.AfterEach(func() {
+		AfterEach(func() {
 			ctx.Done()
 		})
 
-		ginkgo.It("should run a simple docker image with a sleep command", func() {
+		It("should run a simple docker image with a sleep command", func() {
 
-			ginkgo.By("Create Target for the installation")
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
@@ -58,16 +58,16 @@ func ContainerDeployerTests(f *framework.Framework) {
 				Namespace: target.Namespace,
 			}
 
-			ginkgo.By("Create container deploy item")
+			By("Create container deploy item")
 			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
-			ginkgo.By("Delete container deploy item")
+			By("Delete container deploy item")
 			utils.ExpectNoError(f.Client.Delete(ctx, di))
 		})
 
-		ginkgo.It("should detect when a image cannot be pulled and succeed when the deploy item is updated", func() {
-			ginkgo.By("Create Target for the installation")
+		It("should detect when a image cannot be pulled and succeed when the deploy item is updated", func() {
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
@@ -86,11 +86,11 @@ func ContainerDeployerTests(f *framework.Framework) {
 				Namespace: target.Namespace,
 			}
 
-			ginkgo.By("Create erroneous container deploy item")
+			By("Create erroneous container deploy item")
 			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseFailed, 2*time.Minute))
 
-			ginkgo.By("update the DeployItem and set a valid image")
+			By("update the DeployItem and set a valid image")
 			utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKey(di.Name, di.Namespace), di))
 			updatedDi := utils.BuildContainerDeployItem(&containerv1alpha1.ProviderConfiguration{
 				Image: "alpine",
@@ -100,12 +100,12 @@ func ContainerDeployerTests(f *framework.Framework) {
 
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
-			ginkgo.By("Delete container deploy item")
+			By("Delete container deploy item")
 			utils.ExpectNoError(f.Client.Delete(ctx, di))
 		})
 
-		ginkgo.It("should export data", func() {
-			ginkgo.By("Create Target for the installation")
+		It("should export data", func() {
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
@@ -123,22 +123,22 @@ func ContainerDeployerTests(f *framework.Framework) {
 				Namespace: target.Namespace,
 			}
 
-			ginkgo.By("Create container deploy item")
+			By("Create container deploy item")
 			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			// expect that the export contains a valid json with { "my-val": true }
-			g.Expect(di.Status.ExportReference).ToNot(g.BeNil())
+			Expect(di.Status.ExportReference).ToNot(BeNil())
 			exportData, err := lsutils.GetDeployItemExport(ctx, f.Client, di)
 			utils.ExpectNoError(err)
-			g.Expect(exportData).To(g.MatchJSON(`{ "my-val": true }`))
+			Expect(exportData).To(MatchJSON(`{ "my-val": true }`))
 
-			ginkgo.By("Delete container deploy item")
+			By("Delete container deploy item")
 			utils.ExpectNoError(f.Client.Delete(ctx, di))
 		})
 
-		ginkgo.It("should write and read data from the state", func() {
-			ginkgo.By("Create Target for the installation")
+		It("should write and read data from the state", func() {
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			target.Name = "my-cluster-target"
 			target.Namespace = state.Namespace
@@ -156,30 +156,219 @@ func ContainerDeployerTests(f *framework.Framework) {
 				Namespace: target.Namespace,
 			}
 
-			ginkgo.By("Create container deploy item")
+			By("Create container deploy item")
 			utils.ExpectNoError(state.Create(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 
 			// expect that the export contains a valid json with { "counter": 1 }
-			g.Expect(di.Status.ExportReference).ToNot(g.BeNil())
+			Expect(di.Status.ExportReference).ToNot(BeNil())
 			exportData, err := lsutils.GetDeployItemExport(ctx, f.Client, di)
 			utils.ExpectNoError(err)
-			g.Expect(exportData).To(g.MatchJSON(`{ "counter": 1 }`))
+			Expect(exportData).To(MatchJSON(`{ "counter": 1 }`))
 
-			ginkgo.By("Rerun the deployitem")
+			By("Rerun the deployitem")
 			metav1.SetMetaDataAnnotation(&di.ObjectMeta, lsv1alpha1.OperationAnnotation, string(lsv1alpha1.ReconcileOperation))
 			utils.ExpectNoError(f.Client.Update(ctx, di))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToBeInPhase(ctx, f.Client, di, lsv1alpha1.ExecutionPhaseSucceeded, 2*time.Minute))
 			// expect that the export contains a valid json with { "counter": 2 }
-			g.Expect(di.Status.ExportReference).ToNot(g.BeNil())
+			Expect(di.Status.ExportReference).ToNot(BeNil())
 			exportData, err = lsutils.GetDeployItemExport(ctx, f.Client, di)
 			utils.ExpectNoError(err)
-			g.Expect(exportData).To(g.MatchJSON(`{ "counter": 2 }`))
+			Expect(exportData).To(MatchJSON(`{ "counter": 2 }`))
 
-			ginkgo.By("Delete container deploy item")
+			By("Delete container deploy item")
 			utils.ExpectNoError(f.Client.Delete(ctx, di))
 		})
-
 	})
+}
 
+func ContainerDeployerTestsForNewReconcile(f *framework.Framework) {
+	Describe("Container Deployer", func() {
+		var (
+			state      = f.Register()
+			exampleDir = path.Join(f.RootPath, "examples/deploy-items")
+
+			ctx context.Context
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			ctx.Done()
+		})
+
+		It("should run a simple docker image with a sleep command", func() {
+
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			target.Name = "my-cluster-target"
+			target.Namespace = state.Namespace
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			di := &lsv1alpha1.DeployItem{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "30-DeployItem-Container-sleep.yaml")))
+			di.SetName("")
+			di.SetGenerateName("container-sleep-")
+			di.SetNamespace(state.Namespace)
+			di.Spec.Target = &lsv1alpha1.ObjectReference{
+				Name:      target.Name,
+				Namespace: target.Namespace,
+			}
+
+			By("Create container deploy item")
+			utils.ExpectNoError(state.Create(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
+
+			By("Delete container deploy item")
+			utils.ExpectNoError(f.Client.Delete(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+		})
+
+		It("should detect when a image cannot be pulled and succeed when the deploy item is updated", func() {
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			target.Name = "my-cluster-target"
+			target.Namespace = state.Namespace
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			di := utils.BuildContainerDeployItem(&containerv1alpha1.ProviderConfiguration{
+				Image: "example.com/some-invalid/image:v0.0.1",
+			})
+			di.SetName("")
+			di.SetGenerateName("container-sleep-")
+			di.SetNamespace(state.Namespace)
+			di.Spec.Target = &lsv1alpha1.ObjectReference{
+				Name:      target.Name,
+				Namespace: target.Namespace,
+			}
+
+			By("Create erroneous container deploy item")
+			utils.ExpectNoError(state.Create(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseFailed, 2*time.Minute))
+
+			By("update the DeployItem and set a valid image")
+			utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKey(di.Name, di.Namespace), di))
+			updatedDi := utils.BuildContainerDeployItem(&containerv1alpha1.ProviderConfiguration{
+				Image: "alpine",
+			})
+			di.Spec.Configuration = updatedDi.Spec.Configuration
+			utils.ExpectNoError(f.Client.Update(ctx, di))
+
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			di.Status.JobID = "2"
+			Expect(state.Client.Status().Update(ctx, di)).To(Succeed())
+
+			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
+
+			By("Delete container deploy item")
+			utils.ExpectNoError(f.Client.Delete(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+		})
+
+		It("should export data", func() {
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			target.Name = "my-cluster-target"
+			target.Namespace = state.Namespace
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			di := &lsv1alpha1.DeployItem{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "31-DeployItem-Container-export.yaml")))
+			di.SetName("")
+			di.SetGenerateName("container-export-")
+			di.SetNamespace(state.Namespace)
+			di.Spec.Target = &lsv1alpha1.ObjectReference{
+				Name:      target.Name,
+				Namespace: target.Namespace,
+			}
+
+			By("Create container deploy item")
+			utils.ExpectNoError(state.Create(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
+
+			// expect that the export contains a valid json with { "my-val": true }
+			Expect(di.Status.ExportReference).ToNot(BeNil())
+			exportData, err := lsutils.GetDeployItemExport(ctx, f.Client, di)
+			utils.ExpectNoError(err)
+			Expect(exportData).To(MatchJSON(`{ "my-val": true }`))
+
+			By("Delete container deploy item")
+			utils.ExpectNoError(f.Client.Delete(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+		})
+
+		It("should write and read data from the state", func() {
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			target.Name = "my-cluster-target"
+			target.Namespace = state.Namespace
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			di := &lsv1alpha1.DeployItem{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(di, path.Join(exampleDir, "32-DeployItem-Container-state.yaml")))
+			di.SetName("")
+			di.SetGenerateName("container-export-")
+			di.SetNamespace(state.Namespace)
+			di.Spec.Target = &lsv1alpha1.ObjectReference{
+				Name:      target.Name,
+				Namespace: target.Namespace,
+			}
+
+			By("Create container deploy item")
+			utils.ExpectNoError(state.Create(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
+
+			// expect that the export contains a valid json with { "counter": 1 }
+			Expect(di.Status.ExportReference).ToNot(BeNil())
+			exportData, err := lsutils.GetDeployItemExport(ctx, f.Client, di)
+			utils.ExpectNoError(err)
+			Expect(exportData).To(MatchJSON(`{ "counter": 1 }`))
+
+			By("Rerun the deployitem")
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+
+			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
+			// expect that the export contains a valid json with { "counter": 2 }
+			Expect(di.Status.ExportReference).ToNot(BeNil())
+			exportData, err = lsutils.GetDeployItemExport(ctx, f.Client, di)
+			utils.ExpectNoError(err)
+			Expect(exportData).To(MatchJSON(`{ "counter": 2 }`))
+
+			By("Delete container deploy item")
+			utils.ExpectNoError(f.Client.Delete(ctx, di))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+		})
+	})
 }

--- a/test/integration/deployers/helmcharts/chartstests.go
+++ b/test/integration/deployers/helmcharts/chartstests.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	utils2 "github.com/gardener/landscaper/pkg/utils"
+	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -21,7 +24,6 @@ import (
 
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/pkg/deployer/helm"
-	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
@@ -124,8 +126,16 @@ func deployDeployItemAndWaitForSuccess(
 
 	di := forgeHelmDeployItem(chartDir, valuesFile, deployerName, target, f.LsVersion)
 	utils.ExpectNoError(state.Create(ctx, di))
-	By("Waiting for the DeployItem to succeed")
-	utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
+	if utils2.IsNewReconcile() {
+		// Set a new jobID to trigger a reconcile of the deploy item
+		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+		Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+		By("Waiting for the DeployItem to succeed")
+		utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
+	} else {
+		By("Waiting for the DeployItem to succeed")
+		utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))
+	}
 	By("Waiting for the corresponding Deployment to become ready")
 	deployKey := kutil.ObjectKey(deployerName, state.Namespace)
 	utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, deployKey, 2*time.Minute))
@@ -142,6 +152,11 @@ func removeDeployItemAndWaitForSuccess(
 
 	By("Removing the DeployItem")
 	utils.ExpectNoError(f.Client.Delete(ctx, di))
+	if utils2.IsNewReconcile() {
+		// Set a new jobID to trigger a reconcile of the deploy item
+		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(Succeed())
+		Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(Succeed())
+	}
 	By("Waiting for the DeployItem to disappear")
 	utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, di, 2*time.Minute))
 

--- a/test/integration/deployers/register.go
+++ b/test/integration/deployers/register.go
@@ -5,6 +5,7 @@
 package deployers
 
 import (
+	"github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/integration/deployers/blueprints"
 	"github.com/gardener/landscaper/test/integration/deployers/continuousreconcile"
@@ -14,10 +15,18 @@ import (
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	ContainerDeployerTests(f)
-	ManifestDeployerTests(f)
-	helmcharts.RegisterTests(f)
-	blueprints.RegisterTests(f)
-	management.RegisterTests(f)
-	continuousreconcile.RegisterTests(f)
+	if utils.IsNewReconcile() {
+		ContainerDeployerTestsForNewReconcile(f)
+		ManifestDeployerTestsForNewReconcile(f)
+		helmcharts.RegisterTests(f)
+		//blueprints.RegisterTests(f)  // adapt for new reconcile
+		//management.RegisterTests(f)  // adapt for new reconcile
+	} else {
+		ContainerDeployerTests(f)
+		ManifestDeployerTests(f)
+		helmcharts.RegisterTests(f)
+		blueprints.RegisterTests(f)
+		management.RegisterTests(f)
+		continuousreconcile.RegisterTests(f)
+	}
 }

--- a/test/integration/deployitems/timeouts.go
+++ b/test/integration/deployitems/timeouts.go
@@ -10,6 +10,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/gardener/landscaper/pkg/landscaper/controllers/deployitem"
+	utils2 "github.com/gardener/landscaper/pkg/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -25,7 +28,11 @@ import (
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	TimeoutTests(f)
+	if utils2.IsNewReconcile() {
+		TimeoutTestsForNewReconcile(f)
+	} else {
+		TimeoutTests(f)
+	}
 }
 
 const (
@@ -195,6 +202,166 @@ func TimeoutTests(f *framework.Framework) {
 				return mock_di_prog.Status
 			}, waitingForReconcile, resyncTime).Should(MatchFields(IgnoreExtras, Fields{
 				"Phase": Equal(lsv1alpha1.ExecutionPhaseFailed),
+				"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
+					"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
+					"Reason": Equal(lsv1alpha1.AbortingTimeoutReason),
+				})),
+			}))
+
+		})
+
+	})
+
+}
+
+func TimeoutTestsForNewReconcile(f *framework.Framework) {
+	var (
+		testdataDir = filepath.Join(f.RootPath, "test", "integration", "deployitems", "testdata")
+	)
+
+	Describe("Deploy Item Timeouts", func() {
+
+		var (
+			state = f.Register()
+			ctx   context.Context
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			ctx.Done()
+		})
+
+		It("should detect timeouts", func() {
+			By("create test installations")
+			dummy_inst := &lsv1alpha1.Installation{}
+			mock_inst := &lsv1alpha1.Installation{}
+			mock_di_prog := &lsv1alpha1.DeployItem{}
+			// creates deploy item without responsible deployer => pickup timeout
+			utils.ExpectNoError(utils.ReadResourceFromFile(dummy_inst, path.Join(testdataDir, "00-dummy-installation.yaml")))
+			// creates valid mock deploy item => no timeout
+			utils.ExpectNoError(utils.ReadResourceFromFile(mock_inst, path.Join(testdataDir, "01-mock-installation.yaml")))
+			// creates mock deploy item in 'Progressing' phase => first progressing timeout, then aborting timeout
+			utils.ExpectNoError(utils.ReadResourceFromFile(mock_di_prog, path.Join(testdataDir, "02-progressing-mock-di.yaml")))
+			Expect(mock_di_prog.Spec.Timeout).NotTo(BeNil(), "timeout should be specified in the mock deploy item manifest")
+			deployItemProgressingTimeout := mock_di_prog.Spec.Timeout.Duration
+			dummy_inst.SetNamespace(state.Namespace)
+			mock_inst.SetNamespace(state.Namespace)
+			mock_di_prog.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&dummy_inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			lsv1alpha1helper.SetOperation(&mock_inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, dummy_inst))
+			utils.ExpectNoError(state.Create(ctx, mock_inst))
+
+			By("verify that deploy items have been created")
+			dummy_inst_di := &lsv1alpha1.DeployItem{}
+			mock_inst_di := &lsv1alpha1.DeployItem{}
+			Eventually(func() (bool, error) {
+				// fetch installations
+				err := f.Client.Get(ctx, kutil.ObjectKeyFromObject(dummy_inst), dummy_inst)
+				if err != nil || dummy_inst.Status.ExecutionReference == nil {
+					return false, err
+				}
+				err = f.Client.Get(ctx, kutil.ObjectKeyFromObject(mock_inst), mock_inst)
+				if err != nil || mock_inst.Status.ExecutionReference == nil {
+					return false, err
+				}
+				// check for executions
+				dummy_exec := &lsv1alpha1.Execution{}
+				mock_exec := &lsv1alpha1.Execution{}
+				err = f.Client.Get(ctx, dummy_inst.Status.ExecutionReference.NamespacedName(), dummy_exec)
+				if err != nil || dummy_exec.Status.DeployItemReferences == nil || len(dummy_exec.Status.DeployItemReferences) == 0 {
+					return false, err
+				}
+				err = f.Client.Get(ctx, mock_inst.Status.ExecutionReference.NamespacedName(), mock_exec)
+				if err != nil || mock_exec.Status.DeployItemReferences == nil || len(mock_exec.Status.DeployItemReferences) == 0 {
+					return false, err
+				}
+				// check executions for deploy item
+				err = f.Client.Get(ctx, dummy_exec.Status.DeployItemReferences[0].Reference.NamespacedName(), dummy_inst_di)
+				if err != nil {
+					return false, err
+				}
+				err = f.Client.Get(ctx, mock_exec.Status.DeployItemReferences[0].Reference.NamespacedName(), mock_inst_di)
+				if err != nil {
+					return false, err
+				}
+				// return true if both deploy items could be fetched
+				return true, err
+			}, waitingForDeployItems, resyncTime).Should(BeTrue(), "unable to fetch deploy items")
+			utils.ExpectNoError(state.Create(ctx, mock_di_prog))
+			// Set a new jobID to trigger a reconcile of the deploy item
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(mock_di_prog), mock_di_prog)).To(Succeed())
+			Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, mock_di_prog, metav1.Now())).To(Succeed())
+
+			By("check pickup")
+			Expect(deployitem.HasBeenPickedUp(dummy_inst_di)).To(BeFalse(), "dummy deploy item should not have been picked up")
+
+			By("wait for progressing timeout to happen")
+			time.Sleep(deployItemProgressingTimeout)
+
+			By("verify progressing timeout")
+			// expected state:
+			// - mock_di_prog should have had a progressing timeout (abort operation annotation and abort timestamp annotation, but not yet failed)
+			Eventually(func() lsv1alpha1.DeployItem { // check mock_di_prog first, because it's the only one that will change again (aborting timeout)
+				utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKeyFromObject(mock_di_prog), mock_di_prog))
+				return *mock_di_prog
+			}, waitingForReconcile, resyncTime).Should(MatchFields(IgnoreExtras, Fields{
+				"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+					"Annotations": MatchKeys(IgnoreExtras, Keys{
+						lsv1alpha1.OperationAnnotation:      BeEquivalentTo(lsv1alpha1.AbortOperation),
+						lsv1alpha1.AbortTimestampAnnotation: Not(BeNil()),
+					}),
+				}),
+				"Status": MatchFields(IgnoreExtras, Fields{
+					"DeployItemPhase": Equal(lsv1alpha1.DeployItemPhaseProgressing),
+				}),
+			}))
+
+			By("wait for pickup timeout to happen")
+			if deployItemPickupTimeout > deployItemProgressingTimeout {
+				time.Sleep(deployItemPickupTimeout - deployItemProgressingTimeout)
+			}
+
+			By("verify pickup timeout")
+			// expected state:
+			// - dummy_inst_di should have had a pickup timeout ('Failed' phase)
+			// - mock_inst_di should be succeeded and have no reconcile timestamp annotation
+			startWaitingTime := time.Now()
+
+			Eventually(func() lsv1alpha1.DeployItemStatus {
+				utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKeyFromObject(dummy_inst_di), dummy_inst_di))
+				return dummy_inst_di.Status
+			}, waitingForReconcile, resyncTime).Should(MatchFields(IgnoreExtras, Fields{
+				"DeployItemPhase": Equal(lsv1alpha1.DeployItemPhaseFailed),
+				"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
+					"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
+					"Reason": Equal(lsv1alpha1.PickupTimeoutReason),
+				})),
+			}), "deploy item of the dummy installation should have had a pickup timeout")
+
+			Eventually(func() lsv1alpha1.DeployItem {
+				utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKeyFromObject(mock_inst_di), mock_inst_di))
+				return *mock_inst_di
+			}, maxDuration(0, waitingForReconcile-time.Since(startWaitingTime)), resyncTime).Should(MatchFields(IgnoreExtras, Fields{
+				"Status": MatchFields(IgnoreExtras, Fields{
+					"DeployItemPhase": Equal(lsv1alpha1.DeployItemPhaseSucceeded),
+				}),
+			}), "deploy item of the mock installation should not have had a pickup timeout")
+
+			By("wait for aborting timeout to happen")
+			time.Sleep(maxDuration(0, deployItemAbortingTimeout-time.Since(startWaitingTime)))
+
+			By("verify aborting timeout")
+			// expected state:
+			// - mock_di_prog should have had an aborting timeout ('Failed' phase)
+			Eventually(func() lsv1alpha1.DeployItemStatus {
+				utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKeyFromObject(mock_di_prog), mock_di_prog))
+				return mock_di_prog.Status
+			}, waitingForReconcile, resyncTime).Should(MatchFields(IgnoreExtras, Fields{
+				"DeployItemPhase": Equal(lsv1alpha1.DeployItemPhaseFailed),
 				"LastError": PointTo(MatchFields(IgnoreExtras, Fields{
 					"Codes":  ContainElement(lsv1alpha1.ErrorTimeout),
 					"Reason": Equal(lsv1alpha1.AbortingTimeoutReason),

--- a/test/integration/executions/generations.go
+++ b/test/integration/executions/generations.go
@@ -133,3 +133,119 @@ func GenerationHandlingTests(f *framework.Framework) {
 
 	})
 }
+
+func GenerationHandlingTestsForNewReconcile(f *framework.Framework) {
+	var (
+		testdataDir = filepath.Join(f.RootPath, "test", "integration", "executions", "testdata", "test1")
+	)
+
+	Describe("Generation Handling", func() {
+
+		var (
+			state = f.Register()
+			ctx   context.Context
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			ctx.Done()
+		})
+
+		It("should correctly handle generations and observed generations for executions and their deployitems", func() {
+			By("Create execution")
+			exec := &lsv1alpha1.Execution{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(exec, path.Join(testdataDir, "00-execution.yaml")))
+			exec.SetNamespace(state.Namespace)
+			utils.ExpectNoError(state.Create(ctx, exec))
+
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(utils.UpdateJobIdForExecutionC(ctx, state.Client, exec)).To(Succeed())
+
+			By("verify that deployitem has been created")
+			di := &lsv1alpha1.DeployItem{}
+			Eventually(func() (bool, error) {
+				err := f.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)
+				if err != nil || len(exec.Status.DeployItemReferences) == 0 {
+					return false, err
+				}
+				err = f.Client.Get(ctx, exec.Status.DeployItemReferences[0].Reference.NamespacedName(), di)
+				if err != nil {
+					return false, err
+				}
+				return true, nil
+			}, timeoutTime, resyncTime).Should(BeTrue(), "unable to fetch deployitem")
+
+			By("verify that execution is succeeded")
+			Eventually(func() (lsv1alpha1.ExecPhase, error) {
+				err := f.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)
+				if err != nil {
+					return "", err
+				}
+				return exec.Status.ExecutionPhase, nil
+			}, timeoutTime, resyncTime).Should(BeEquivalentTo(lsv1alpha1.ExecPhaseSucceeded), "execution should be in phase '%s'", lsv1alpha1.ExecPhaseSucceeded)
+
+			oldExGen := exec.Generation
+			oldDIGen := di.Generation
+			Expect(exec.Status.DeployItemReferences[0].Reference.ObservedGeneration).To(Equal(oldDIGen))
+			Expect(exec.Status.ExecutionGenerations[0].ObservedGeneration).To(Equal(oldExGen))
+
+			mockConfig := &mockv1alpha1.ProviderConfiguration{}
+			utils.ExpectNoError(json.Unmarshal(di.Spec.Configuration.Raw, mockConfig))
+			mockStatus := map[string]interface{}{}
+			utils.ExpectNoError(json.Unmarshal(mockConfig.ProviderStatus.Raw, &mockStatus))
+			Expect(mockStatus).To(HaveKeyWithValue("key", BeEquivalentTo("foo")))
+
+			By("update execution")
+			mockStatus["key"] = "bar"
+			rawMockStatus, err := json.Marshal(mockStatus)
+			utils.ExpectNoError(err)
+			mockConfig.ProviderStatus = &runtime.RawExtension{
+				Raw: rawMockStatus,
+			}
+			rawMockConfig, err := json.Marshal(mockConfig)
+			utils.ExpectNoError(err)
+			exec.Spec.DeployItems[0].Configuration = &runtime.RawExtension{
+				Raw: rawMockConfig,
+			}
+			utils.ExpectNoError(f.Client.Update(ctx, exec))
+
+			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
+			Expect(utils.UpdateJobIdForExecutionC(ctx, state.Client, exec)).To(Succeed())
+
+			By("verify that deployitem has been changed")
+			Eventually(func() (bool, error) {
+				if err := f.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di); err != nil {
+					return false, err
+				}
+				mockConfig := &mockv1alpha1.ProviderConfiguration{}
+				if err := json.Unmarshal(di.Spec.Configuration.Raw, mockConfig); err != nil {
+					return false, err
+				}
+				mockStatus := map[string]interface{}{}
+				if err := json.Unmarshal(mockConfig.ProviderStatus.Raw, &mockStatus); err != nil {
+					return false, err
+				}
+				rawKey, ok := mockStatus["key"]
+				if !ok {
+					return false, fmt.Errorf("status does not contain 'key'")
+				}
+				key, ok := rawKey.(string)
+				if !ok {
+					return false, fmt.Errorf("value of key 'key' is not a string")
+				}
+				return key == "bar", nil
+			}, timeoutTime, resyncTime).Should(BeTrue(), "deployitem should have been updated to match new execution spec")
+			utils.ExpectNoError(f.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec))
+
+			By("verify that generations and observed generations behave as expected")
+			Expect(exec.Generation).To(BeNumerically(">", oldExGen))
+			Expect(di.Generation).To(BeNumerically(">", oldDIGen))
+			Expect(exec.Status.ExecutionGenerations[0].ObservedGeneration).To(Equal(exec.Generation))
+			Expect(exec.Status.DeployItemReferences[0].Reference.ObservedGeneration).To(Equal(di.Generation))
+		})
+
+	})
+}

--- a/test/integration/executions/register.go
+++ b/test/integration/executions/register.go
@@ -7,6 +7,8 @@ package executions
 import (
 	"time"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/gardener/landscaper/test/framework"
 )
 
@@ -17,5 +19,9 @@ var (
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	GenerationHandlingTests(f)
+	if utils.IsNewReconcile() {
+		GenerationHandlingTestsForNewReconcile(f)
+	} else {
+		GenerationHandlingTests(f)
+	}
 }

--- a/test/integration/installations/register.go
+++ b/test/integration/installations/register.go
@@ -7,6 +7,8 @@ package installations
 import (
 	"time"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/gardener/landscaper/test/framework"
 )
 
@@ -17,6 +19,10 @@ var (
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	ImportExportTests(f)
-	PhasePropagationTests(f)
+	if utils.IsNewReconcile() {
+		ImportExportTests(f)
+	} else {
+		ImportExportTests(f)
+		PhasePropagationTests(f)
+	}
 }

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gardener/landscaper/test/integration/core"
+	"github.com/gardener/landscaper/test/integration/deployers"
 	"github.com/gardener/landscaper/test/integration/deployitems"
 	"github.com/gardener/landscaper/test/integration/executions"
 	"github.com/gardener/landscaper/test/integration/installations"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/gardener/landscaper/pkg/utils/simplelogger"
 	"github.com/gardener/landscaper/test/framework"
-	"github.com/gardener/landscaper/test/integration/deployers"
 )
 
 var opts *framework.Options

--- a/test/integration/tutorial/aggregated-blueprint.go
+++ b/test/integration/tutorial/aggregated-blueprint.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	g "github.com/onsi/gomega"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -22,10 +24,10 @@ import (
 )
 
 func AggregatedBlueprint(f *framework.Framework) {
-	_ = ginkgo.Describe("AggregatedBlueprint", func() {
+	_ = Describe("AggregatedBlueprint", func() {
 		state := f.Register()
 
-		ginkgo.It("should deploy a nginx ingress controller and a echo-server together with an aggregated blueprint", func() {
+		It("should deploy a nginx ingress controller and a echo-server together with an aggregated blueprint", func() {
 			var (
 				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/aggregated")
 				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
@@ -35,23 +37,23 @@ func AggregatedBlueprint(f *framework.Framework) {
 			ctx := context.Background()
 			defer ctx.Done()
 
-			ginkgo.By("Create Target for the installation")
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, target))
 
-			ginkgo.By("Create ConfigMap with imports for the installation")
+			By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			cm.Data["namespace"] = state.Namespace
 			utils.ExpectNoError(state.Create(ctx, cm))
 
-			ginkgo.By("Create Aggregated Installation")
+			By("Create Aggregated Installation")
 			aggInst := &lsv1alpha1.Installation{}
-			g.Expect(utils.ReadResourceFromFile(aggInst, nginxInstResource)).To(g.Succeed())
+			Expect(utils.ReadResourceFromFile(aggInst, nginxInstResource)).To(Succeed())
 			aggInst.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, aggInst))
 
@@ -60,9 +62,9 @@ func AggregatedBlueprint(f *framework.Framework) {
 
 			subInstallations, err := lsutils.GetSubInstallationsOfInstallation(ctx, f.Client, aggInst)
 			utils.ExpectNoError(err)
-			g.Expect(subInstallations).To(g.HaveLen(2))
-			g.Expect(subInstallations[0].Status.Phase).To(g.Equal(lsv1alpha1.ComponentPhaseSucceeded))
-			g.Expect(subInstallations[1].Status.Phase).To(g.Equal(lsv1alpha1.ComponentPhaseSucceeded))
+			Expect(subInstallations).To(HaveLen(2))
+			Expect(subInstallations[0].Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+			Expect(subInstallations[1].Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
 
 			// expect that the nginx deployment is successfully running
 			nginxDeployment := &appsv1.Deployment{}
@@ -78,7 +80,7 @@ func AggregatedBlueprint(f *framework.Framework) {
 
 			// todo check if the echo server can be pinged
 
-			ginkgo.By("Delete aggregated installation")
+			By("Delete aggregated installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, aggInst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, aggInst, 2*time.Minute))
 
@@ -89,5 +91,77 @@ func AggregatedBlueprint(f *framework.Framework) {
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
+}
 
+func AggregatedBlueprintForNewReconcile(f *framework.Framework) {
+	_ = Describe("AggregatedBlueprint", func() {
+		state := f.Register()
+
+		It("should deploy a nginx ingress controller and a echo-server together with an aggregated blueprint", func() {
+			var (
+				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/aggregated")
+				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
+				importResource           = filepath.Join(tutorialResourcesRootDir, "configmap.yaml")
+				nginxInstResource        = filepath.Join(tutorialResourcesRootDir, "installation.yaml")
+			)
+			ctx := context.Background()
+			defer ctx.Done()
+
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			By("Create ConfigMap with imports for the installation")
+			cm := &corev1.ConfigMap{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
+			cm.SetNamespace(state.Namespace)
+			cm.Data["namespace"] = state.Namespace
+			utils.ExpectNoError(state.Create(ctx, cm))
+
+			By("Create Aggregated Installation")
+			aggInst := &lsv1alpha1.Installation{}
+			Expect(utils.ReadResourceFromFile(aggInst, nginxInstResource)).To(Succeed())
+			aggInst.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&aggInst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, aggInst))
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, aggInst, lsv1alpha1.InstallationPhaseSucceeded, 4*time.Minute))
+
+			subInstallations, err := lsutils.GetSubInstallationsOfInstallation(ctx, f.Client, aggInst)
+			utils.ExpectNoError(err)
+			Expect(subInstallations).To(HaveLen(2))
+			Expect(subInstallations[0].Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhaseSucceeded))
+			Expect(subInstallations[0].Status.JobIDFinished).To(Equal(subInstallations[0].Status.JobID))
+			Expect(subInstallations[1].Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhaseSucceeded))
+			Expect(subInstallations[1].Status.JobIDFinished).To(Equal(subInstallations[1].Status.JobID))
+
+			// expect that the nginx deployment is successfully running
+			nginxDeployment := &appsv1.Deployment{}
+			nginxDeployment.Name = "test-ingress-nginx-controller"
+			nginxDeployment.Namespace = state.Namespace
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, kutil.ObjectKeyFromObject(nginxDeployment), 4*time.Minute))
+
+			// expect that the echo server deployment is successfully running
+			echoServerDeployment := &appsv1.Deployment{}
+			echoServerDeployment.Name = "echo-server"
+			echoServerDeployment.Namespace = state.Namespace
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, kutil.ObjectKeyFromObject(echoServerDeployment), 2*time.Minute))
+
+			// todo check if the echo server can be pinged
+
+			By("Delete aggregated installation")
+			utils.ExpectNoError(f.Client.Delete(ctx, aggInst))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, aggInst, 2*time.Minute))
+
+			// expect that the echo server deployment is already deleted or has an deletion timestamp
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, echoServerDeployment, 2*time.Minute))
+
+			// expect that the nginx deployment is already deleted or has an deletion timestamp
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
+		})
+	})
 }

--- a/test/integration/tutorial/external-jsonschema.go
+++ b/test/integration/tutorial/external-jsonschema.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	g "github.com/onsi/gomega"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,10 +26,10 @@ import (
 
 // ExternalJSONSchemaTest tests the jsonschema tutorial.
 func ExternalJSONSchemaTest(f *framework.Framework) {
-	_ = ginkgo.Describe("ExternalJSONSchemaTest", func() {
+	_ = Describe("ExternalJSONSchemaTest", func() {
 		state := f.Register()
 
-		ginkgo.It("should deploy an echo server with resources defined by an external jsonschema", func() {
+		It("should deploy an echo server with resources defined by an external jsonschema", func() {
 			var (
 				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/external-jsonschema")
 				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
@@ -37,22 +39,22 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			ctx := context.Background()
 			defer ctx.Done()
 
-			ginkgo.By("Create Target for the installation")
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, target))
 
-			ginkgo.By("Create ConfigMap with imports for the installation")
+			By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, cm))
 
-			ginkgo.By("Create Installation")
+			By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
-			g.Expect(utils.ReadResourceFromFile(inst, instResource)).To(g.Succeed())
+			Expect(utils.ReadResourceFromFile(inst, instResource)).To(Succeed())
 			inst.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, inst))
 
@@ -61,8 +63,8 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 
 			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
-			g.Expect(deployItems).To(g.HaveLen(1))
-			g.Expect(deployItems[0].Status.Phase).To(g.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
 
 			// todo: make namespace configurable for deployed resources
 			// expect that the echo server deployment is successfully running
@@ -72,11 +74,11 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			// expect that the deployment has the correct resource requests and limits
 			echoServerDeploy := &appsv1.Deployment{}
 			utils.ExpectNoError(f.Client.Get(ctx, echoServerDeploymentObjectKey, echoServerDeploy))
-			g.Expect(echoServerDeploy.Spec.Template.Spec.Containers).To(g.HaveLen(1))
-			g.Expect(echoServerDeploy.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(g.Equal("50Mi"))
-			g.Expect(echoServerDeploy.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(g.Equal("100Mi"))
+			Expect(echoServerDeploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(echoServerDeploy.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("50Mi"))
+			Expect(echoServerDeploy.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("100Mi"))
 
-			ginkgo.By("Delete installation")
+			By("Delete installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
@@ -85,7 +87,78 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			if err != nil && !apierrors.IsNotFound(err) {
 				utils.ExpectNoError(err)
 			} else if err == nil {
-				g.Expect(echoServerDeploy.DeletionTimestamp.IsZero()).To(g.BeTrue())
+				Expect(echoServerDeploy.DeletionTimestamp.IsZero()).To(BeTrue())
+			}
+		})
+	})
+}
+
+// ExternalJSONSchemaTest tests the jsonschema tutorial.
+func ExternalJSONSchemaTestForNewReconcile(f *framework.Framework) {
+	_ = Describe("ExternalJSONSchemaTest", func() {
+		state := f.Register()
+
+		It("should deploy an echo server with resources defined by an external jsonschema", func() {
+			var (
+				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/external-jsonschema")
+				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
+				importResource           = filepath.Join(tutorialResourcesRootDir, "configmap.yaml")
+				instResource             = filepath.Join(tutorialResourcesRootDir, "installation.yaml")
+			)
+			ctx := context.Background()
+			defer ctx.Done()
+
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			By("Create ConfigMap with imports for the installation")
+			cm := &corev1.ConfigMap{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
+			cm.SetNamespace(state.Namespace)
+			utils.ExpectNoError(state.Create(ctx, cm))
+
+			By("Create Installation")
+			inst := &lsv1alpha1.Installation{}
+			Expect(utils.ReadResourceFromFile(inst, instResource)).To(Succeed())
+			inst.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, inst))
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))
+
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			utils.ExpectNoError(err)
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(deployItems[0].Status.JobIDFinished).To(Equal(deployItems[0].Status.JobID))
+
+			// todo: make namespace configurable for deployed resources
+			// expect that the echo server deployment is successfully running
+			echoServerDeploymentName := "echo-server"
+			echoServerDeploymentObjectKey := kutil.ObjectKey(echoServerDeploymentName, "default")
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, echoServerDeploymentObjectKey, 2*time.Minute))
+			// expect that the deployment has the correct resource requests and limits
+			echoServerDeploy := &appsv1.Deployment{}
+			utils.ExpectNoError(f.Client.Get(ctx, echoServerDeploymentObjectKey, echoServerDeploy))
+			Expect(echoServerDeploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(echoServerDeploy.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("50Mi"))
+			Expect(echoServerDeploy.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("100Mi"))
+
+			By("Delete installation")
+			utils.ExpectNoError(f.Client.Delete(ctx, inst))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
+
+			// expect that the nginx deployment is alread deleted or has an deletion timestamp
+			err = f.Client.Get(ctx, echoServerDeploymentObjectKey, echoServerDeploy)
+			if err != nil && !apierrors.IsNotFound(err) {
+				utils.ExpectNoError(err)
+			} else if err == nil {
+				Expect(echoServerDeploy.DeletionTimestamp.IsZero()).To(BeTrue())
 			}
 		})
 	})

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,10 +25,10 @@ import (
 )
 
 func NginxIngressTest(f *framework.Framework) {
-	_ = ginkgo.Describe("SimpleNginxTest", func() {
+	_ = Describe("SimpleNginxTest", func() {
 		state := f.Register()
 
-		ginkgo.It("should deploy a nginx ingress controller", func() {
+		It("should deploy a nginx ingress controller", func() {
 			var (
 				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/ingress-nginx")
 				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
@@ -36,23 +38,23 @@ func NginxIngressTest(f *framework.Framework) {
 			ctx := context.Background()
 			defer ctx.Done()
 
-			ginkgo.By("Create Target for the installation")
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, target))
 
-			ginkgo.By("Create ConfigMap with imports for the installation")
+			By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			cm.Data["namespace"] = state.Namespace
 			utils.ExpectNoError(state.Create(ctx, cm))
 
-			ginkgo.By("Create Installation")
+			By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
-			gomega.Expect(utils.ReadResourceFromFile(inst, instResource)).To(gomega.Succeed())
+			Expect(utils.ReadResourceFromFile(inst, instResource)).To(Succeed())
 			inst.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, inst))
 
@@ -61,8 +63,8 @@ func NginxIngressTest(f *framework.Framework) {
 
 			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
-			gomega.Expect(deployItems).To(gomega.HaveLen(1))
-			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
 
 			// expect that the nginx deployment is successfully running
 			nginxIngressDeploymentName := "test-ingress-nginx-controller"
@@ -71,7 +73,7 @@ func NginxIngressTest(f *framework.Framework) {
 
 			// Update the installation to use the next component descriptor version (see
 			// docs/tutorials/resources/ingress-nginx-upgrade/component-descriptor.yaml) with the next nginx version.
-			ginkgo.By("Upgrade installation")
+			By("Upgrade installation")
 			instKey := kutil.ObjectKey(inst.Name, inst.Namespace)
 			inst = &lsv1alpha1.Installation{}
 			utils.ExpectNoError(f.Client.Get(ctx, instKey, inst))
@@ -84,8 +86,8 @@ func NginxIngressTest(f *framework.Framework) {
 
 			deployItems, err = lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
-			gomega.Expect(deployItems).To(gomega.HaveLen(1))
-			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
 
 			// expect that the nginx deployment is successfully running
 			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, nginxIngressObjectKey, 2*time.Minute))
@@ -93,9 +95,9 @@ func NginxIngressTest(f *framework.Framework) {
 			// check the new chart version in label "helm.sh/chart" of the deployment
 			deploy := &appsv1.Deployment{}
 			utils.ExpectNoError(f.Client.Get(ctx, nginxIngressObjectKey, deploy))
-			gomega.Expect(deploy.GetLabels()).To(gomega.HaveKeyWithValue("helm.sh/chart", "ingress-nginx-4.0.18"))
+			Expect(deploy.GetLabels()).To(HaveKeyWithValue("helm.sh/chart", "ingress-nginx-4.0.18"))
 
-			ginkgo.By("Delete installation")
+			By("Delete installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
@@ -105,15 +107,15 @@ func NginxIngressTest(f *framework.Framework) {
 			if err != nil && !apierrors.IsNotFound(err) {
 				utils.ExpectNoError(err)
 			} else if err == nil {
-				gomega.Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
 			}
 		})
 	})
 
-	_ = ginkgo.Describe("LocalIngressNginxTest", func() {
+	_ = Describe("LocalIngressNginxTest", func() {
 		state := f.Register()
 
-		ginkgo.It("should deploy a nginx ingress controller with local artifacts", func() {
+		It("should deploy a nginx ingress controller with local artifacts", func() {
 			var (
 				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/local-ingress-nginx")
 				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
@@ -123,23 +125,23 @@ func NginxIngressTest(f *framework.Framework) {
 			ctx := context.Background()
 			defer ctx.Done()
 
-			ginkgo.By("Create Target for the installation")
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, target))
 
-			ginkgo.By("Create ConfigMap with imports for the installation")
+			By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.SetNamespace(state.Namespace)
 			cm.Data["namespace"] = state.Namespace
 			utils.ExpectNoError(state.Create(ctx, cm))
 
-			ginkgo.By("Create Installation")
+			By("Create Installation")
 			inst := &lsv1alpha1.Installation{}
-			gomega.Expect(utils.ReadResourceFromFile(inst, instResource)).To(gomega.Succeed())
+			Expect(utils.ReadResourceFromFile(inst, instResource)).To(Succeed())
 			inst.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, inst))
 
@@ -148,8 +150,8 @@ func NginxIngressTest(f *framework.Framework) {
 
 			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
-			gomega.Expect(deployItems).To(gomega.HaveLen(1))
-			gomega.Expect(deployItems[0].Status.Phase).To(gomega.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
 
 			// expect that the nginx deployment is successfully running
 			nginxIngressDeploymentName := "test-ingress-nginx-controller"
@@ -159,10 +161,10 @@ func NginxIngressTest(f *framework.Framework) {
 			// check
 			deploy := &appsv1.Deployment{}
 			utils.ExpectNoError(f.Client.Get(ctx, nginxIngressObjectKey, deploy))
-			gomega.Expect(deploy.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold == 4).To(gomega.BeTrue())
+			Expect(deploy.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold == 4).To(BeTrue())
 
 			// delete
-			ginkgo.By("Delete installation")
+			By("Delete installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
@@ -172,7 +174,169 @@ func NginxIngressTest(f *framework.Framework) {
 			if err != nil && !apierrors.IsNotFound(err) {
 				utils.ExpectNoError(err)
 			} else if err == nil {
-				gomega.Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			}
+		})
+	})
+}
+
+func NginxIngressTestForNewReconcile(f *framework.Framework) {
+	_ = Describe("SimpleNginxTest", func() {
+		state := f.Register()
+
+		It("should deploy a nginx ingress controller", func() {
+			var (
+				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/ingress-nginx")
+				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
+				importResource           = filepath.Join(tutorialResourcesRootDir, "configmap.yaml")
+				instResource             = filepath.Join(tutorialResourcesRootDir, "installation.yaml")
+			)
+			ctx := context.Background()
+			defer ctx.Done()
+
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			By("Create ConfigMap with imports for the installation")
+			cm := &corev1.ConfigMap{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
+			cm.SetNamespace(state.Namespace)
+			cm.Data["namespace"] = state.Namespace
+			utils.ExpectNoError(state.Create(ctx, cm))
+
+			By("Create Installation")
+			inst := &lsv1alpha1.Installation{}
+			Expect(utils.ReadResourceFromFile(inst, instResource)).To(Succeed())
+			inst.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, inst))
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))
+
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			utils.ExpectNoError(err)
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(deployItems[0].Status.JobIDFinished).To(Equal(deployItems[0].Status.JobID))
+
+			// expect that the nginx deployment is successfully running
+			nginxIngressDeploymentName := "test-ingress-nginx-controller"
+			nginxIngressObjectKey := kutil.ObjectKey(nginxIngressDeploymentName, state.Namespace)
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, nginxIngressObjectKey, 2*time.Minute))
+
+			// Update the installation to use the next component descriptor version (see
+			// docs/tutorials/resources/ingress-nginx-upgrade/component-descriptor.yaml) with the next nginx version.
+			By("Upgrade installation")
+			instKey := kutil.ObjectKey(inst.Name, inst.Namespace)
+			inst = &lsv1alpha1.Installation{}
+			utils.ExpectNoError(f.Client.Get(ctx, instKey, inst))
+			inst.Spec.ComponentDescriptor.Reference.Version = "v0.3.3"
+			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			err = f.Client.Update(ctx, inst)
+			utils.ExpectNoError(err)
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))
+
+			deployItems, err = lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			utils.ExpectNoError(err)
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(deployItems[0].Status.JobIDFinished).To(Equal(deployItems[0].Status.JobID))
+
+			// expect that the nginx deployment is successfully running
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, nginxIngressObjectKey, 2*time.Minute))
+
+			// check the new chart version in label "helm.sh/chart" of the deployment
+			deploy := &appsv1.Deployment{}
+			utils.ExpectNoError(f.Client.Get(ctx, nginxIngressObjectKey, deploy))
+			Expect(deploy.GetLabels()).To(HaveKeyWithValue("helm.sh/chart", "ingress-nginx-4.0.18"))
+
+			By("Delete installation")
+			utils.ExpectNoError(f.Client.Delete(ctx, inst))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
+
+			// expect that the nginx deployment is already deleted or has an deletion timestamp
+			nginxDeployment := &appsv1.Deployment{}
+			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
+			if err != nil && !apierrors.IsNotFound(err) {
+				utils.ExpectNoError(err)
+			} else if err == nil {
+				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			}
+		})
+	})
+
+	_ = Describe("LocalIngressNginxTest", func() {
+		state := f.Register()
+
+		It("should deploy a nginx ingress controller with local artifacts", func() {
+			var (
+				tutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/local-ingress-nginx")
+				targetResource           = filepath.Join(tutorialResourcesRootDir, "my-target.yaml")
+				importResource           = filepath.Join(tutorialResourcesRootDir, "configmap.yaml")
+				instResource             = filepath.Join(tutorialResourcesRootDir, "installation.yaml")
+			)
+			ctx := context.Background()
+			defer ctx.Done()
+
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			By("Create ConfigMap with imports for the installation")
+			cm := &corev1.ConfigMap{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
+			cm.SetNamespace(state.Namespace)
+			cm.Data["namespace"] = state.Namespace
+			utils.ExpectNoError(state.Create(ctx, cm))
+
+			By("Create Installation")
+			inst := &lsv1alpha1.Installation{}
+			Expect(utils.ReadResourceFromFile(inst, instResource)).To(Succeed())
+			inst.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, inst))
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))
+
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			utils.ExpectNoError(err)
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(deployItems[0].Status.JobIDFinished).To(Equal(deployItems[0].Status.JobID))
+
+			// expect that the nginx deployment is successfully running
+			nginxIngressDeploymentName := "test-ingress-nginx-controller"
+			nginxIngressObjectKey := kutil.ObjectKey(nginxIngressDeploymentName, state.Namespace)
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, nginxIngressObjectKey, 2*time.Minute))
+
+			// check
+			deploy := &appsv1.Deployment{}
+			utils.ExpectNoError(f.Client.Get(ctx, nginxIngressObjectKey, deploy))
+			Expect(deploy.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold == 4).To(BeTrue())
+
+			// delete
+			By("Delete installation")
+			utils.ExpectNoError(f.Client.Delete(ctx, inst))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
+
+			// expect that the nginx deployment is already deleted or has an deletion timestamp
+			nginxDeployment := &appsv1.Deployment{}
+			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
+			if err != nil && !apierrors.IsNotFound(err) {
+				utils.ExpectNoError(err)
+			} else if err == nil {
+				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
 			}
 		})
 	})

--- a/test/integration/tutorial/register.go
+++ b/test/integration/tutorial/register.go
@@ -4,12 +4,22 @@
 
 package tutorial
 
-import "github.com/gardener/landscaper/test/framework"
+import (
+	"github.com/gardener/landscaper/pkg/utils"
+	"github.com/gardener/landscaper/test/framework"
+)
 
 // RegisterTests registers all tests of the package
 func RegisterTests(f *framework.Framework) {
-	NginxIngressTest(f)
-	SimpleImport(f)
-	AggregatedBlueprint(f)
-	ExternalJSONSchemaTest(f)
+	if utils.IsNewReconcile() {
+		NginxIngressTestForNewReconcile(f)
+		SimpleImportForNewReconcile(f)
+		AggregatedBlueprintForNewReconcile(f)
+		ExternalJSONSchemaTestForNewReconcile(f)
+	} else {
+		NginxIngressTest(f)
+		SimpleImport(f)
+		AggregatedBlueprint(f)
+		ExternalJSONSchemaTest(f)
+	}
 }

--- a/test/integration/tutorial/simple-import.go
+++ b/test/integration/tutorial/simple-import.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	g "github.com/onsi/gomega"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,10 +25,10 @@ import (
 )
 
 func SimpleImport(f *framework.Framework) {
-	_ = ginkgo.Describe("SimpleImport", func() {
+	_ = Describe("SimpleImport", func() {
 		state := f.Register()
 
-		ginkgo.It("should deploy a nginx ingress controller and a echo-server", func() {
+		It("should deploy a nginx ingress controller and a echo-server", func() {
 			var (
 				nginxTutorialResourcesRootDir      = filepath.Join(f.RootPath, "/docs/tutorials/resources/local-ingress-nginx")
 				echoServerTutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/echo-server")
@@ -38,32 +40,32 @@ func SimpleImport(f *framework.Framework) {
 			ctx := context.Background()
 			defer ctx.Done()
 
-			ginkgo.By("Create Target for the installation")
+			By("Create Target for the installation")
 			target := &lsv1alpha1.Target{}
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
 			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
 			utils.ExpectNoError(err)
 			utils.ExpectNoError(state.Create(ctx, target))
 
-			ginkgo.By("Create ConfigMap with imports for the installation")
+			By("Create ConfigMap with imports for the installation")
 			cm := &corev1.ConfigMap{}
 			cm.SetNamespace(state.Namespace)
 			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
 			cm.Data["namespace"] = state.Namespace
 			utils.ExpectNoError(state.Create(ctx, cm))
 
-			ginkgo.By("Create Nginx Ingress Installation")
+			By("Create Nginx Ingress Installation")
 			nginxInst := &lsv1alpha1.Installation{}
-			g.Expect(utils.ReadResourceFromFile(nginxInst, nginxInstResource)).To(g.Succeed())
+			Expect(utils.ReadResourceFromFile(nginxInst, nginxInstResource)).To(Succeed())
 			nginxInst.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, nginxInst))
 
 			// wait for installation to finish
 			utils.ExpectNoError(lsutils.WaitForInstallationToBeHealthy(ctx, f.Client, nginxInst, 2*time.Minute))
 
-			ginkgo.By("Create echo server Installation")
+			By("Create echo server Installation")
 			inst := &lsv1alpha1.Installation{}
-			g.Expect(utils.ReadResourceFromFile(inst, echoServerInstResource)).To(g.Succeed())
+			Expect(utils.ReadResourceFromFile(inst, echoServerInstResource)).To(Succeed())
 			inst.SetNamespace(state.Namespace)
 			utils.ExpectNoError(state.Create(ctx, inst))
 
@@ -72,8 +74,8 @@ func SimpleImport(f *framework.Framework) {
 
 			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
 			utils.ExpectNoError(err)
-			g.Expect(deployItems).To(g.HaveLen(1))
-			g.Expect(deployItems[0].Status.Phase).To(g.Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
 
 			// expect that the echo server deployment is successfully running
 			echoServerDeploymentName := "echo-server"
@@ -82,7 +84,7 @@ func SimpleImport(f *framework.Framework) {
 
 			// todo check if the echo server can be pinged
 
-			ginkgo.By("Delete echo server installation")
+			By("Delete echo server installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
@@ -92,10 +94,94 @@ func SimpleImport(f *framework.Framework) {
 			if err != nil && !apierrors.IsNotFound(err) {
 				utils.ExpectNoError(err)
 			} else if err == nil {
-				g.Expect(echoServerDeployment.DeletionTimestamp.IsZero()).To(g.BeTrue())
+				Expect(echoServerDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
 			}
 
-			ginkgo.By("Delete nginx installation")
+			By("Delete nginx installation")
+			utils.ExpectNoError(f.Client.Delete(ctx, nginxInst))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxInst, 2*time.Minute))
+		})
+	})
+
+}
+
+func SimpleImportForNewReconcile(f *framework.Framework) {
+	_ = Describe("SimpleImport", func() {
+		state := f.Register()
+
+		It("should deploy a nginx ingress controller and a echo-server", func() {
+			var (
+				nginxTutorialResourcesRootDir      = filepath.Join(f.RootPath, "/docs/tutorials/resources/local-ingress-nginx")
+				echoServerTutorialResourcesRootDir = filepath.Join(f.RootPath, "/docs/tutorials/resources/echo-server")
+				targetResource                     = filepath.Join(nginxTutorialResourcesRootDir, "my-target.yaml")
+				importResource                     = filepath.Join(nginxTutorialResourcesRootDir, "configmap.yaml")
+				nginxInstResource                  = filepath.Join(nginxTutorialResourcesRootDir, "installation.yaml")
+				echoServerInstResource             = filepath.Join(echoServerTutorialResourcesRootDir, "installation.yaml")
+			)
+			ctx := context.Background()
+			defer ctx.Done()
+
+			By("Create Target for the installation")
+			target := &lsv1alpha1.Target{}
+			utils.ExpectNoError(utils.ReadResourceFromFile(target, targetResource))
+			target, err := utils.BuildInternalKubernetesTarget(ctx, f.Client, state.Namespace, target.Name, f.RestConfig, true)
+			utils.ExpectNoError(err)
+			utils.ExpectNoError(state.Create(ctx, target))
+
+			By("Create ConfigMap with imports for the installation")
+			cm := &corev1.ConfigMap{}
+			cm.SetNamespace(state.Namespace)
+			utils.ExpectNoError(utils.ReadResourceFromFile(cm, importResource))
+			cm.Data["namespace"] = state.Namespace
+			utils.ExpectNoError(state.Create(ctx, cm))
+
+			By("Create Nginx Ingress Installation")
+			nginxInst := &lsv1alpha1.Installation{}
+			Expect(utils.ReadResourceFromFile(nginxInst, nginxInstResource)).To(Succeed())
+			nginxInst.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&nginxInst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, nginxInst))
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, nginxInst, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))
+
+			By("Create echo server Installation")
+			inst := &lsv1alpha1.Installation{}
+			Expect(utils.ReadResourceFromFile(inst, echoServerInstResource)).To(Succeed())
+			inst.SetNamespace(state.Namespace)
+			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+			utils.ExpectNoError(state.Create(ctx, inst))
+
+			// wait for installation to finish
+			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))
+
+			deployItems, err := lsutils.GetDeployItemsOfInstallation(ctx, f.Client, inst)
+			utils.ExpectNoError(err)
+			Expect(deployItems).To(HaveLen(1))
+			Expect(deployItems[0].Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(deployItems[0].Status.JobIDFinished).To(Equal(deployItems[0].Status.JobID))
+
+			// expect that the echo server deployment is successfully running
+			echoServerDeploymentName := "echo-server"
+			echoServerObjectKey := kutil.ObjectKey(echoServerDeploymentName, state.Namespace)
+			utils.ExpectNoError(utils.WaitForDeploymentToBeReady(ctx, f.TestLog(), f.Client, echoServerObjectKey, 2*time.Minute))
+
+			// todo check if the echo server can be pinged
+
+			By("Delete echo server installation")
+			utils.ExpectNoError(f.Client.Delete(ctx, inst))
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
+
+			// expect that the echo server deployment is already deleted or has an deletion timestamp
+			echoServerDeployment := &appsv1.Deployment{}
+			err = f.Client.Get(ctx, echoServerObjectKey, echoServerDeployment)
+			if err != nil && !apierrors.IsNotFound(err) {
+				utils.ExpectNoError(err)
+			} else if err == nil {
+				Expect(echoServerDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			}
+
+			By("Delete nginx installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, nginxInst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxInst, 2*time.Minute))
 		})

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -71,108 +71,238 @@ var _ = Describe("Simple", func() {
 	})
 
 	It("Should successfully reconcile SimpleTest", func() {
-		if utils.NewReconcile {
-			return
+		if utils.IsNewReconcile() {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, filepath.Join(projectRoot, "examples", "01-simple", "cluster"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
+
+			// first the installation controller should run and set the finalizer
+			// afterwards it should again reconcile and deploy the execution
+			instReq := testutils.Request("root-1", state.Namespace)
+			inst := &lsv1alpha1.Installation{}
+			Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
+			Expect(testutils.AddReconcileAnnotation(ctx, testenv, inst)).To(Succeed())
+			testutils.ShouldReconcile(ctx, instActuator, instReq)        // add finalizer
+			testutils.ShouldReconcile(ctx, instActuator, instReq)        // remove reconcile annotation and generate jobID
+			_ = testutils.ShouldNotReconcile(ctx, instActuator, instReq) // create execution; returns error because execution is unfinished
+
+			Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
+			Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhaseProgressing))
+			Expect(inst.Status.JobID).NotTo(BeEmpty())
+			Expect(inst.Status.JobIDFinished).To(BeEmpty())
+			Expect(inst.Status.ExecutionReference).ToNot(BeNil())
+			Expect(inst.Status.Imports).To(HaveLen(1))
+			Expect(inst.Status.Imports[0]).To(MatchFields(IgnoreExtras, Fields{
+				"Name": Equal("imp-a"),
+				"Type": Equal(lsv1alpha1.DataImportStatusType),
+			}))
+
+			jobID := inst.Status.JobID
+
+			execReq := testutils.Request(inst.Status.ExecutionReference.Name, inst.Status.ExecutionReference.Namespace)
+			exec := &lsv1alpha1.Execution{}
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(BeEmpty())
+			Expect(exec.Status.JobID).To(Equal(jobID))
+			Expect(exec.Status.JobIDFinished).To(BeEmpty())
+
+			// reconcile execution
+			_ = testutils.ShouldNotReconcile(ctx, execActuator, execReq) // not finished
+
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseProgressing))
+			Expect(exec.Status.JobID).To(Equal(jobID))
+			Expect(exec.Status.JobIDFinished).To(BeEmpty())
+			Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
+
+			diList := &lsv1alpha1.DeployItemList{}
+			Expect(testenv.Client.List(ctx, diList)).ToNot(HaveOccurred())
+			Expect(diList.Items).To(HaveLen(1))
+			diReq := testutils.Request(exec.Status.DeployItemReferences[0].Reference.Name, exec.Status.DeployItemReferences[0].Reference.Namespace)
+			di := &lsv1alpha1.DeployItem{}
+			Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).To(Succeed())
+			Expect(di.Status.DeployItemPhase).To(BeEmpty())
+			Expect(di.Status.JobID).To(Equal(jobID))
+			Expect(di.Status.JobIDFinished).To(BeEmpty())
+
+			// reconcile deploy item
+			testutils.ShouldReconcile(ctx, mockActuator, diReq)
+			testutils.ShouldReconcile(ctx, mockActuator, diReq)
+
+			Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).To(Succeed())
+			Expect(di.Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(di.Status.JobID).To(Equal(jobID))
+			Expect(di.Status.JobIDFinished).To(Equal(jobID))
+
+			// as the deploy item is now successfully reconciled, we have to trigger the execution
+			// and check if the states are correctly propagated
+			testutils.ShouldReconcile(ctx, execActuator, execReq)
+
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).To(Succeed())
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseSucceeded))
+			Expect(exec.Status.JobID).To(Equal(jobID))
+			Expect(exec.Status.JobIDFinished).To(Equal(jobID))
+			Expect(exec.Status.ExportReference).ToNot(BeNil())
+
+			// as the execution is now successfully reconciled, we have to trigger the installation
+			// and check if the state is propagated
+			testutils.ShouldReconcile(ctx, instActuator, instReq)
+
+			Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
+			Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhaseSucceeded))
+			Expect(inst.Status.JobID).To(Equal(jobID))
+			Expect(inst.Status.JobIDFinished).To(Equal(jobID))
+
+			By("delete resource")
+			Expect(testenv.Client.Delete(ctx, inst)).To(Succeed())
+
+			// the installation controller should propagate the deletion to the execution
+			testutils.ShouldReconcile(ctx, instActuator, instReq)        // generate jobID for deletion
+			_ = testutils.ShouldNotReconcile(ctx, instActuator, instReq) // delete execution
+
+			Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
+			Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhaseDeleting))
+			Expect(inst.Status.JobID).NotTo(Equal(jobID))
+			Expect(inst.Status.JobIDFinished).To(Equal(jobID))
+
+			deletionJobID := inst.Status.JobID
+
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).To(Succeed())
+			Expect(exec.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")
+			Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecPhaseSucceeded))
+			Expect(exec.Status.JobID).To(Equal(deletionJobID))
+			Expect(exec.Status.JobIDFinished).To(Equal(jobID))
+
+			// the execution controller should propagate the deletion to its deploy item
+			testutils.ShouldReconcile(ctx, execActuator, execReq)
+
+			Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).To(Succeed())
+			Expect(di.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")
+			Expect(di.Status.DeployItemPhase).To(Equal(lsv1alpha1.DeployItemPhaseSucceeded))
+			Expect(di.Status.JobID).To(Equal(deletionJobID))
+			Expect(di.Status.JobIDFinished).To(Equal(jobID))
+
+			// deployer should remove finalizer
+			testutils.ShouldReconcile(ctx, mockActuator, diReq)
+			err = testenv.Client.Get(ctx, diReq.NamespacedName, di)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "deploy item should be deleted")
+
+			// execution controller should remove finalizer
+			testutils.ShouldReconcile(ctx, execActuator, execReq)
+			err = testenv.Client.Get(ctx, execReq.NamespacedName, exec)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "execution should be deleted")
+
+			// installation controller should remove finalizer
+			testutils.ShouldReconcile(ctx, instActuator, instReq)
+			err = testenv.Client.Get(ctx, instReq.NamespacedName, inst)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "installation should be deleted")
+
+		} else {
+			ctx := context.Background()
+
+			var err error
+			state, err = testenv.InitResources(ctx, filepath.Join(projectRoot, "examples", "01-simple", "cluster"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
+
+			// first the installation controller should run and set the finalizer
+			// afterwards it should again reconcile and deploy the execution
+			instReq := testutils.Request("root-1", state.Namespace)
+			testutils.ShouldReconcile(ctx, instActuator, instReq)
+			testutils.ShouldReconcile(ctx, instActuator, instReq)
+
+			inst := &lsv1alpha1.Installation{}
+			Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).ToNot(HaveOccurred())
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseProgressing))
+			Expect(inst.Status.ExecutionReference).ToNot(BeNil())
+			Expect(inst.Status.Imports).To(HaveLen(1))
+			Expect(inst.Status.Imports[0]).To(MatchFields(IgnoreExtras, Fields{
+				"Name": Equal("imp-a"),
+				"Type": Equal(lsv1alpha1.DataImportStatusType),
+			}))
+
+			execReq := testutils.Request(inst.Status.ExecutionReference.Name, inst.Status.ExecutionReference.Namespace)
+			exec := &lsv1alpha1.Execution{}
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
+
+			// after the execution was created by the installation, we need to run the execution controller
+			// on first reconcile it should add the finalizer
+			// and int he second reconcile it should create the deploy item
+			testutils.ShouldReconcile(ctx, execActuator, execReq)
+			testutils.ShouldReconcile(ctx, execActuator, execReq)
+
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseProgressing))
+			Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
+
+			diList := &lsv1alpha1.DeployItemList{}
+			Expect(testenv.Client.List(ctx, diList)).ToNot(HaveOccurred())
+			Expect(diList.Items).To(HaveLen(1))
+
+			diReq := testutils.Request(exec.Status.DeployItemReferences[0].Reference.Name, exec.Status.DeployItemReferences[0].Reference.Namespace)
+			di := &lsv1alpha1.DeployItem{}
+			Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).ToNot(HaveOccurred())
+
+			testutils.ShouldReconcile(ctx, mockActuator, diReq)
+			testutils.ShouldReconcile(ctx, mockActuator, diReq)
+
+			// as the deploy item is now successfully reconciled, we have to trigger the execution
+			// and check if the states are correctly propagated
+			_, err = execActuator.Reconcile(ctx, execReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
+			Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
+			Expect(exec.Status.ExportReference).ToNot(BeNil())
+
+			// as the execution is now successfully reconciled, we have to trigger the installation
+			// and check if the state is propagated
+			_, err = instActuator.Reconcile(ctx, testutils.Request("root-1", state.Namespace))
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).ToNot(HaveOccurred())
+			Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+
+			By("delete resource")
+			Expect(testenv.Client.Delete(ctx, inst)).ToNot(HaveOccurred())
+
+			// the installation controller should propagate the deletion to its subcharts
+			_, err = instActuator.Reconcile(ctx, instReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
+			Expect(exec.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")
+
+			// the execution controller should propagate the deletion to its deploy item
+			_, err = execActuator.Reconcile(ctx, execReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).ToNot(HaveOccurred())
+			Expect(di.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")
+
+			_, err = mockActuator.Reconcile(ctx, diReq)
+			Expect(err).ToNot(HaveOccurred())
+			err = testenv.Client.Get(ctx, diReq.NamespacedName, di)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "deploy item should be deleted")
+
+			// execution controller should remove the finalizer
+			testutils.ShouldReconcile(ctx, execActuator, execReq)
+			err = testenv.Client.Get(ctx, execReq.NamespacedName, exec)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "execution should be deleted")
+
+			// installation controller should remove its own finalizer
+			testutils.ShouldReconcile(ctx, instActuator, instReq)
+			err = testenv.Client.Get(ctx, instReq.NamespacedName, inst)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "installation should be deleted")
 		}
-
-		ctx := context.Background()
-
-		var err error
-		state, err = testenv.InitResources(ctx, filepath.Join(projectRoot, "examples", "01-simple", "cluster"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
-
-		// first the installation controller should run and set the finalizer
-		// afterwards it should again reconcile and deploy the execution
-		instReq := testutils.Request("root-1", state.Namespace)
-		testutils.ShouldReconcile(ctx, instActuator, instReq)
-		testutils.ShouldReconcile(ctx, instActuator, instReq)
-
-		inst := &lsv1alpha1.Installation{}
-		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).ToNot(HaveOccurred())
-		Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseProgressing))
-		Expect(inst.Status.ExecutionReference).ToNot(BeNil())
-		Expect(inst.Status.Imports).To(HaveLen(1))
-		Expect(inst.Status.Imports[0]).To(MatchFields(IgnoreExtras, Fields{
-			"Name": Equal("imp-a"),
-			"Type": Equal(lsv1alpha1.DataImportStatusType),
-		}))
-
-		execReq := testutils.Request(inst.Status.ExecutionReference.Name, inst.Status.ExecutionReference.Namespace)
-		exec := &lsv1alpha1.Execution{}
-		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
-
-		// after the execution was created by the installation, we need to run the execution controller
-		// on first reconcile it should add the finalizer
-		// and int he second reconcile it should create the deploy item
-		testutils.ShouldReconcile(ctx, execActuator, execReq)
-		testutils.ShouldReconcile(ctx, execActuator, execReq)
-
-		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
-		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseProgressing))
-		Expect(exec.Status.DeployItemReferences).To(HaveLen(1))
-
-		diList := &lsv1alpha1.DeployItemList{}
-		Expect(testenv.Client.List(ctx, diList)).ToNot(HaveOccurred())
-		Expect(diList.Items).To(HaveLen(1))
-
-		diReq := testutils.Request(exec.Status.DeployItemReferences[0].Reference.Name, exec.Status.DeployItemReferences[0].Reference.Namespace)
-		di := &lsv1alpha1.DeployItem{}
-		Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).ToNot(HaveOccurred())
-
-		testutils.ShouldReconcile(ctx, mockActuator, diReq)
-		testutils.ShouldReconcile(ctx, mockActuator, diReq)
-
-		// as the deploy item is now successfully reconciled, we have to trigger the execution
-		// and check if the states are correctly propagated
-		_, err = execActuator.Reconcile(ctx, execReq)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
-		Expect(exec.Status.Phase).To(Equal(lsv1alpha1.ExecutionPhaseSucceeded))
-		Expect(exec.Status.ExportReference).ToNot(BeNil())
-
-		// as the execution is now successfully reconciled, we have to trigger the installation
-		// and check if the state is propagated
-		_, err = instActuator.Reconcile(ctx, testutils.Request("root-1", state.Namespace))
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).ToNot(HaveOccurred())
-		Expect(inst.Status.Phase).To(Equal(lsv1alpha1.ComponentPhaseSucceeded))
-
-		By("delete resource")
-		Expect(testenv.Client.Delete(ctx, inst)).ToNot(HaveOccurred())
-
-		// the installation controller should propagate the deletion to its subcharts
-		_, err = instActuator.Reconcile(ctx, instReq)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).ToNot(HaveOccurred())
-		Expect(exec.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")
-
-		// the execution controller should propagate the deletion to its deploy item
-		_, err = execActuator.Reconcile(ctx, execReq)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(testenv.Client.Get(ctx, diReq.NamespacedName, di)).ToNot(HaveOccurred())
-		Expect(di.DeletionTimestamp.IsZero()).To(BeFalse(), "deletion timestamp should be set")
-
-		_, err = mockActuator.Reconcile(ctx, diReq)
-		Expect(err).ToNot(HaveOccurred())
-		err = testenv.Client.Get(ctx, diReq.NamespacedName, di)
-		Expect(err).To(HaveOccurred())
-		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "deploy item should be deleted")
-
-		// execution controller should remove the finalizer
-		testutils.ShouldReconcile(ctx, execActuator, execReq)
-		err = testenv.Client.Get(ctx, execReq.NamespacedName, exec)
-		Expect(err).To(HaveOccurred())
-		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "execution should be deleted")
-
-		// installation controller should remove its own finalizer
-		testutils.ShouldReconcile(ctx, instActuator, instReq)
-		err = testenv.Client.Get(ctx, instReq.NamespacedName, inst)
-		Expect(err).To(HaveOccurred())
-		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "installation should be deleted")
 	})
 })

--- a/test/utils/resources.go
+++ b/test/utils/resources.go
@@ -12,6 +12,10 @@ import (
 	"net/url"
 	"path/filepath"
 
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/mandelsoft/vfs/pkg/osfs"
@@ -283,6 +287,44 @@ func BuildContainerDeployItem(configuration *containerv1alpha1.ProviderConfigura
 		Build()
 	ExpectNoErrorWithOffset(1, err)
 	return di
+}
+
+func AddAnnotationForDeployItem(ctx context.Context, testenv *envtest.Environment, di *lsv1alpha1.DeployItem,
+	annotation, value string) error {
+	metav1.SetMetaDataAnnotation(&di.ObjectMeta, annotation, value)
+	return testenv.Client.Update(ctx, di)
+}
+
+func AddReconcileAnnotation(ctx context.Context, testenv *envtest.Environment, inst *lsv1alpha1.Installation) error {
+	lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+	return testenv.Client.Update(ctx, inst)
+}
+
+func UpdateJobIdForDeployItem(ctx context.Context, testenv *envtest.Environment, di *lsv1alpha1.DeployItem, time metav1.Time) error {
+	di.Status.JobID = di.Status.JobID + "-1"
+	di.Status.JobIDGenerationTime = &time
+	return testenv.Client.Status().Update(ctx, di)
+}
+
+func UpdateJobIdForDeployItemC(ctx context.Context, cl client.Client, di *lsv1alpha1.DeployItem, time metav1.Time) error {
+	di.Status.JobID = di.Status.JobID + "-1"
+	di.Status.JobIDGenerationTime = &time
+	return cl.Status().Update(ctx, di)
+}
+
+func UpdateJobIdForExecution(ctx context.Context, testenv *envtest.Environment, exec *lsv1alpha1.Execution) error {
+	exec.Status.JobID = exec.Status.JobID + "-1"
+	return testenv.Client.Status().Update(ctx, exec)
+}
+
+func UpdateJobIdForExecutionC(ctx context.Context, cl client.Client, exec *lsv1alpha1.Execution) error {
+	exec.Status.JobID = exec.Status.JobID + "-1"
+	return cl.Status().Update(ctx, exec)
+}
+
+func UpdateJobIdForInstallation(ctx context.Context, testenv *envtest.Environment, inst *lsv1alpha1.Installation) error {
+	inst.Status.JobID = inst.Status.JobID + "-1"
+	return testenv.Client.Status().Update(ctx, inst)
 }
 
 // ReadAndCreateOrUpdateDeployItem reads a deploy item from the given file and creates or updated the deploy item


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR adapts the unit and integration tests for the new reconcile (see also PR #497). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
