### PR TITLE
Landscaper deployment on kubernetes 1.24

### DIFF
--- a/controller-utils/pkg/kubernetes/serviceaccounts.go
+++ b/controller-utils/pkg/kubernetes/serviceaccounts.go
@@ -1,0 +1,73 @@
+package kubernetes
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetSecretsForServiceAccount returns the list of secrets of type "kubernetes.io/service-account-token"
+// which belong to the given service account. The result list is sorted decreasingly by creation timestamp,
+// so that it starts with the newest secret.
+func GetSecretsForServiceAccount(ctx context.Context, kubeClient client.Client, serviceAccountKey client.ObjectKey) ([]*corev1.Secret, error) {
+	secretList := &corev1.SecretList{}
+	if err := kubeClient.List(ctx, secretList, client.InNamespace(serviceAccountKey.Namespace)); err != nil {
+		return nil, err
+	}
+
+	result := []*corev1.Secret{}
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		if s.Type == corev1.SecretTypeServiceAccountToken {
+			serviceAccountName, ok := s.Annotations[corev1.ServiceAccountNameKey]
+			if ok && serviceAccountName == serviceAccountKey.Name {
+				result = append(result, s)
+			}
+		}
+	}
+
+	// Sort the result list so that it starts with the newest secret
+	sort.Slice(result, func(i, j int) bool {
+		return result[j].ObjectMeta.CreationTimestamp.Before(&result[i].ObjectMeta.CreationTimestamp)
+	})
+
+	return result, nil
+}
+
+func CreateSecretForServiceAccount(ctx context.Context, kubeClient client.Client, serviceAccount *corev1.ServiceAccount) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:  map[string]string{corev1.ServiceAccountNameKey: serviceAccount.Name},
+			GenerateName: serviceAccount.Name + "-token-",
+			Namespace:    serviceAccount.Namespace,
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	if err := kubeClient.Create(ctx, secret); err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+func WaitForServiceAccountToken(ctx context.Context, kubeClient client.Client, secretKey client.ObjectKey) error {
+	return wait.PollImmediate(10*time.Second, 5*time.Minute, func() (done bool, err error) {
+		secret := &corev1.Secret{}
+		if err := kubeClient.Get(ctx, secretKey, secret); err != nil {
+			return false, nil
+		}
+
+		if len(secret.Data) == 0 {
+			return false, nil
+		}
+
+		token, ok := secret.Data[corev1.ServiceAccountTokenKey]
+		return ok && len(token) > 0, nil
+	})
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -169,7 +169,8 @@ func (a *Agent) EnsureHostResources(ctx context.Context, kubeClient client.Clien
 	}
 
 	hostRestConfig := rest.CopyConfig(a.hostRestConfig)
-	if err := kutil.AddServiceAccountAuth(ctx, kubeClient, sa, hostRestConfig); err != nil {
+	if err := kutil.AddServiceAccountToken(ctx, kubeClient, sa, hostRestConfig); err != nil {
+		a.log.Error(err, "unable to add a service account token", "service-account", sa.Name)
 		return nil, err
 	}
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Agent", func() {
 		})
 
 		It("should ensure all host resources", func() {
-			testutils.MimicKCMServiceAccount(ctx, testenv.Client, testutils.MimicKCMServiceAccountArgs{
+			testutils.MimicKCMServiceAccountTokenGeneration(ctx, testenv.Client, testutils.MimicKCMServiceAccountArgs{
 				Name:      "deployer-testenv",
 				Namespace: state.Namespace,
 				Token:     "test-token",

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -199,7 +199,8 @@ func (dm *DeployerManagement) createDeployerTarget(ctx context.Context,
 	restConfig.TLSClientConfig.ServerName = env.Spec.LandscaperClusterRestConfig.TLSClientConfig.ServerName
 	restConfig.TLSClientConfig.CAData = env.Spec.LandscaperClusterRestConfig.TLSClientConfig.CAData
 
-	if err := kutil.AddServiceAccountAuth(ctx, dm.client, sa, restConfig); err != nil {
+	if err := kutil.AddServiceAccountToken(ctx, dm.client, sa, restConfig); err != nil {
+		dm.log.Error(err, "unable to add service account token", "service-account", sa.Name)
 		return err
 	}
 

--- a/pkg/deployermanagement/controller/deployer_management_test.go
+++ b/pkg/deployermanagement/controller/deployer_management_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Deployer Management Test", func() {
 			reg.Spec.DeployItemTypes = []lsv1alpha1.DeployItemType{"test"}
 			testutils.ExpectNoError(state.Create(ctx, reg))
 
-			testutils.MimicKCMServiceAccount(ctx, testenv.Client, testutils.MimicKCMServiceAccountArgs{
+			testutils.MimicKCMServiceAccountTokenGeneration(ctx, testenv.Client, testutils.MimicKCMServiceAccountArgs{
 				Name:      deployers.FQName(reg, env),
 				Namespace: state.Namespace,
 				Token:     "my-service-account-token",

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/serviceaccounts.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/serviceaccounts.go
@@ -1,0 +1,70 @@
+package kubernetes
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetSecretsForServiceAccount(ctx context.Context, kubeClient client.Client, serviceAccountKey client.ObjectKey) ([]*corev1.Secret, error) {
+	secretList := &corev1.SecretList{}
+	if err := kubeClient.List(ctx, secretList, client.InNamespace(serviceAccountKey.Namespace)); err != nil {
+		return nil, err
+	}
+
+	result := []*corev1.Secret{}
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		if s.Type == corev1.SecretTypeServiceAccountToken {
+			serviceAccountName, ok := s.Annotations[corev1.ServiceAccountNameKey]
+			if ok && serviceAccountName == serviceAccountKey.Name {
+				result = append(result, s)
+			}
+		}
+	}
+
+	// Sort the result list so that it starts with the newest secret
+	sort.Slice(result, func(i, j int) bool {
+		return result[j].ObjectMeta.CreationTimestamp.Before(&result[i].ObjectMeta.CreationTimestamp)
+	})
+
+	return result, nil
+}
+
+func CreateSecretForServiceAccount(ctx context.Context, kubeClient client.Client, serviceAccount *corev1.ServiceAccount) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:  map[string]string{corev1.ServiceAccountNameKey: serviceAccount.Name},
+			GenerateName: serviceAccount.Name + "-token-",
+			Namespace:    serviceAccount.Namespace,
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	if err := kubeClient.Create(ctx, secret); err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+func WaitForServiceAccountToken(ctx context.Context, kubeClient client.Client, secretKey client.ObjectKey) error {
+	return wait.PollImmediate(10*time.Second, 5*time.Minute, func() (done bool, err error) {
+		secret := &corev1.Secret{}
+		if err := kubeClient.Get(ctx, secretKey, secret); err != nil {
+			return false, nil
+		}
+
+		if len(secret.Data) == 0 {
+			return false, nil
+		}
+
+		token, ok := secret.Data[corev1.ServiceAccountTokenKey]
+		return ok && len(token) > 0, nil
+	})
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request fixes the issue "Landscaper deployment does not install deployers #116"

In kubernetes version 1.24, no secret with a service account token is automatically generated for a service account. This has an impact on the generation of target objects that are used for the installation of deployers, because each of the targets contains a kubeconfig with a token originating from a service account. Affected service accounts: `container-default`, `helm-default`, `manifest-default`, `deployer-default`. The landscaper agent has corresponding service accounts per environment.  

This PR creates the secrets for the service accounts and waits until they are filled with a token. (The old behaviour was to wait for the secrets.)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
