### PR TITLE
Fix flakey test

### DIFF
--- a/pkg/landscaper/installations/subinstallations/helper_test.go
+++ b/pkg/landscaper/installations/subinstallations/helper_test.go
@@ -201,7 +201,7 @@ func (d *dependencyProvider) nextMode() string {
 		case 2:
 			mode = mappingDependency
 		}
-		d.count++
+		d.count = (d.count + 1) % 3
 	}
 	return string(mode)
 }
@@ -213,7 +213,14 @@ func (d *dependencyProvider) nextMode() string {
 // data export, target export, or something exported in the exportDataMappings, respectively.
 func generateSubinstallationTemplates(deps map[string][]string, dProv dependencyProvider) []*lsv1alpha1.InstallationTemplate {
 	res := []*lsv1alpha1.InstallationTemplate{}
-	for k, v := range deps {
+	// sort map keys to make iteration order deterministic
+	keys := []string{}
+	for k := range deps {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := deps[k]
 		tmpl := &lsv1alpha1.InstallationTemplate{
 			Name: k,
 			Imports: lsv1alpha1.InstallationImports{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority 3

**What this PR does / why we need it**:
One of the tests for the cyclic dependency checking was flakey. The reason was that the error message, which is checked for, depended on the order in which elements of a map were processed. Iterating over the map in a deterministic manner solved the problem.

**Special notes for your reviewer**:
Merge #510 first.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A flakey test has been fixed.
```
