### PR TITLE
Script running all integration tests in a script against a shoot cluster

### DIFF
--- a/.ci/new-integration-test
+++ b/.ci/new-integration-test
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBECONFIG_PATH=$1
+SOURCE_PATH="$(dirname $0)/.."
+cd "${SOURCE_PATH}"
+SOURCE_PATH="$(pwd)"
+
+echo "Source path ${SOURCE_PATH}"
+
+VERSION="$(./hack/get-version.sh)"
+REGISTRY_NS=clusters
+ID="12"
+
+echo "Starting integration tests for landscaper version ${VERSION}"
+
+TMP="${SOURCE_PATH}/tmp-int-test"
+TMP_GEN="$TMP/gen"
+
+rm -f -r $TMP
+mkdir -p $TMP_GEN
+
+echo "Create registry namespace"
+
+kubectl --kubeconfig=$KUBECONFIG_PATH apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $REGISTRY_NS
+EOF
+
+echo "Cleanup registry"
+go run -mod=vendor ./hack/testcluster registry delete \
+    --kubeconfig=$KUBECONFIG_PATH \
+    --namespace=$REGISTRY_NS \
+    --id=$ID \
+    --timeout=10m
+
+echo "Create registry"
+go run -mod=vendor ./hack/testcluster registry create \
+    --kubeconfig=$KUBECONFIG_PATH \
+    --namespace=$REGISTRY_NS \
+    --id=$ID \
+    --registry-auth=$TMP/docker.config \
+    --address-format=ip \
+    --timeout=10m \
+    --ls-run-on-shoot
+
+# install bash for the get version command
+if ! which bash 1>/dev/null; then
+  echo "Installing bash... "
+  apk add --no-cache bash
+fi
+
+if ! which openssl 1>/dev/null; then
+  echo "Installing openssl... "
+  apk add openssl
+fi
+
+if ! which curl 1>/dev/null; then
+  echo "Installing curl... "
+  apk add curl
+fi
+
+if ! which git 1>/dev/null; then
+  echo "Installing git... "
+  apk add --no-cache git
+fi
+
+if ! which kubectl 1>/dev/null; then
+  echo "Kubectl is not installed, trying to install it..."
+  curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
+  mv ./kubectl /usr/local/bin/kubectl
+  chmod +x /usr/local/bin/kubectl
+fi
+
+if ! which helm 1>/dev/null; then
+  echo "Helm 3 is not installed, trying to install it..."
+  export DESIRED_VERSION=v3.7.0
+  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+fi
+
+echo "> Installing Landscaper version ${VERSION}"
+
+printf "
+landscaper:
+  landscaper:
+    deployers:
+    - container
+    - helm
+    - manifest
+    - mock
+    deployItemTimeouts:
+      pickup: 10s
+      abort: 10s
+" > $TMP/values.yaml
+
+touch $TMP/registry-values.yaml
+if [[ -f "$TMP/docker.config" ]]; then
+  printf "
+landscaper:
+  landscaper:
+    registryConfig:
+      allowPlainHttpRegistries: false
+      insecureSkipVerify: true
+      secrets:
+        default: $(cat "$TMP/docker.config")
+  " > $TMP/registry-values.yaml
+fi
+
+echo "Pull landscaper helm chart"
+helm pull oci://eu.gcr.io/gardener-project/landscaper/charts/landscaper --version $VERSION --untar --destination $TMP_GEN
+
+echo "Upgrade landscaper"
+helm upgrade --kubeconfig=$KUBECONFIG_PATH --install --wait --create-namespace -n ls-system \
+  -f $TMP/values.yaml -f $TMP/registry-values.yaml landscaper $TMP_GEN/landscaper
+
+./.ci/new-run-tests $KUBECONFIG_PATH $TMP/docker.config $VERSION
+
+# echo "Delete namespace with registry"
+# kubectl --kubeconfig=$KUBECONFIG_PATH delete ns $REGISTRY_NS
+# rm -r $TMP

--- a/.ci/new-run-tests
+++ b/.ci/new-run-tests
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBECONFIG_PATH=$1
+REGISTRY_CONFIG=$2
+VERSION=$3
+
+SOURCE_PATH="$(dirname $0)/.."
+cd "${SOURCE_PATH}"
+SOURCE_PATH="$(pwd)"
+
+
+echo "Run tests"
+go test -timeout=60m -mod=vendor ./test/integration \
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
+    --kubeconfig $KUBECONFIG_PATH \
+    --registry-config=$REGISTRY_CONFIG \
+    --ls-namespace=ls-system \
+    --ls-version=$VERSION \
+    --ls-run-on-shoot
+
+# echo "Delete namespace with registry"
+# kubectl --kubeconfig=$KUBECONFIG_PATH delete ns $REGISTRY_NS
+# rm -r $TMP

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tmp
+tmp-int-test
 
 /dev
 /gen

--- a/hack/testcluster/pkg/cluster.go
+++ b/hack/testcluster/pkg/cluster.go
@@ -172,7 +172,7 @@ func CreateCluster(ctx context.Context, logger simplelogger.Logger, args CreateC
 	if err := kubeClient.Create(ctx, pod); err != nil {
 		return fmt.Errorf("unable to create cluster pod: %w", err)
 	}
-	logger.Logfln("Created cluster %q", pod.Name)
+	logger.Logfln("Created cluster %q from image %q running kubernetes version %q", pod.Name, pod.Spec.Containers[0].Image, kubernetesVersion)
 
 	// register cleanup to delete the cluster if something fails
 	defer func() {

--- a/hack/testcluster/registry_create.go
+++ b/hack/testcluster/registry_create.go
@@ -47,6 +47,8 @@ type CreateRegistryOptions struct {
 	// OutputAddressFormat is the format of the output address for the registry
 	// Can be either hostname or ip
 	OutputAddressFormat string
+
+	RunOnShoot bool
 }
 
 // AddFlags adds flags for the options to a flagset
@@ -58,6 +60,8 @@ func (o *CreateRegistryOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Password, "registry-password", "", "set the registry password")
 	fs.StringVar(&o.ExportRegistryCreds, "registry-auth", "", "path where the docker auth config is written to")
 	fs.StringVar(&o.OutputAddressFormat, "address-format", "hostname", "the format of the addresses in the generated output. Can be hostname or ip.")
+	fs.BoolVar(&o.RunOnShoot, "ls-run-on-shoot", false, "runs on a shoot and not a k3s cluster")
+
 }
 
 func (o *CreateRegistryOptions) Complete() error {
@@ -94,5 +98,6 @@ func (o *CreateRegistryOptions) Run(ctx context.Context) error {
 		o.Password,
 		o.OutputAddressFormat,
 		o.ExportRegistryCreds,
-		o.Timeout)
+		o.Timeout,
+		o.RunOnShoot)
 }

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -50,6 +50,7 @@ type Options struct {
 	LsVersion        string
 	DockerConfigPath string
 	DisableCleanup   bool
+	RunOnShoot       bool
 }
 
 // AddFlags registers the framework related flags
@@ -64,6 +65,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.LsVersion, "ls-version", "", "the version to use in integration tests")
 	fs.StringVar(&o.DockerConfigPath, "registry-config", "", "path to the docker config file")
 	fs.BoolVar(&o.DisableCleanup, "disable-cleanup", false, "skips the cleanup of resources.")
+	fs.BoolVar(&o.RunOnShoot, "ls-run-on-shoot", false, "runs on a shoot and not a k3s cluster")
 	o.fs = fs
 }
 
@@ -100,6 +102,8 @@ type Framework struct {
 	LsVersion string
 	// DisableCleanup skips the state cleanup step
 	DisableCleanup bool
+	// RunOnShoot tests are executed on shoot and not a k3s cluster (only for compatibility with old setup)
+	RunOnShoot bool
 
 	// RegistryConfig defines the oci registry config file.
 	// It is expected that the configfile contains exactly one server.
@@ -124,6 +128,7 @@ func New(logger simplelogger.Logger, cfg *Options) (*Framework, error) {
 		LsVersion:      cfg.LsVersion,
 		Cleanup:        &Cleanup{},
 		DisableCleanup: cfg.DisableCleanup,
+		RunOnShoot:     cfg.RunOnShoot,
 	}
 
 	var err error

--- a/test/integration/core/registry.go
+++ b/test/integration/core/registry.go
@@ -192,7 +192,9 @@ func buildAndUploadComponentDescriptorWithArtifacts(ctx context.Context, f *fram
 
 	ref, err := cdoci.OCIRef(repoCtx, cd.Name, cd.Version)
 	utils.ExpectNoError(err)
-	utils.ExpectNoError(f.OCIClient.PushManifest(ctx, ref, manifest))
+
+	err = f.OCIClient.PushManifest(ctx, ref, manifest)
+	utils.ExpectNoError(err)
 	return cd
 }
 

--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -94,6 +94,10 @@ func DeployerBlueprintTests(f *framework.Framework) {
 			ComponentDescriptorName: "github.com/gardener/landscaper/helm-deployer",
 			BlueprintResourceName:   "helm-deployer-blueprint",
 			DeployItem: func(state *envtest.State, target *lsv1alpha1.Target) (*lsv1alpha1.DeployItem, error) {
+				ref := "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18"
+				if !f.RunOnShoot {
+					ref = "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0"
+				}
 				return helm.NewDeployItemBuilder().
 					Key(state.Namespace, "my-di").
 					Target(target.Namespace, target.Name).
@@ -101,7 +105,7 @@ func DeployerBlueprintTests(f *framework.Framework) {
 						Name:      "my-chart",
 						Namespace: state.Namespace,
 						Chart: helmv1alpha1.Chart{
-							Ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0",
+							Ref: ref,
 						},
 					}).Build()
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority 3

**What this PR does / why we need it**:

This PR adds a script with which all integration tests could be run locally whereby the landscaper and the registry are installed on the shoot cluster for which the kubeconfig is provided. Also the tests are executed on that cluster. In subsequent PRs we should integrate this test into our pipelines. To guarantee a stable behaviour we need to add cleanup for hanging test namespaces as well as the deinstallation of the landscaper and the registry itself.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
