### PR TITLE
New reconcile: more tests

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -163,6 +163,7 @@ func (a *Agent) EnsureHostResources(ctx context.Context, kubeClient client.Clien
 	}
 	crb := DeployerClusterRoleBinding(sa, a.config.Name)
 	if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, crb, func() error {
+		crb.Subjects = DeployerClusterRoleBindingSubjects(sa)
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("unable to create cluster role biinding %q for deployer on host cluster: %w", crb.Name, err)
@@ -316,7 +317,12 @@ func DeployerClusterRoleBinding(sa *corev1.ServiceAccount, envName string) *rbac
 		Kind:     "ClusterRole",
 		Name:     DeployerClusterRoleName,
 	}
-	crb.Subjects = []rbacv1.Subject{
+	crb.Subjects = DeployerClusterRoleBindingSubjects(sa)
+	return crb
+}
+
+func DeployerClusterRoleBindingSubjects(sa *corev1.ServiceAccount) []rbacv1.Subject {
+	return []rbacv1.Subject{
 		{
 			APIGroup:  "",
 			Kind:      "ServiceAccount",
@@ -324,5 +330,4 @@ func DeployerClusterRoleBinding(sa *corev1.ServiceAccount, envName string) *rbac
 			Namespace: sa.Namespace,
 		},
 	}
-	return crb
 }

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"time"
 
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+
 	lserrors "github.com/gardener/landscaper/apis/errors"
 
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
@@ -32,7 +34,6 @@ import (
 
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	"github.com/gardener/landscaper/apis/core/validation"
 )
 
@@ -89,7 +90,6 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 
 	_, err = dm.Writer().CreateOrUpdateCoreInstallation(ctx, read_write_layer.W000002, inst, func() error {
 		controllerutil.AddFinalizer(inst, lsv1alpha1.LandscaperDMFinalizer)
-		lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
 		inst.Spec.ComponentDescriptor = registration.Spec.InstallationTemplate.ComponentDescriptor
 		inst.Spec.Blueprint = registration.Spec.InstallationTemplate.Blueprint
 		inst.Spec.Imports = registration.Spec.InstallationTemplate.Imports
@@ -122,6 +122,9 @@ func (dm *DeployerManagement) Reconcile(ctx context.Context, registration *lsv1a
 	if err := dm.createDeployerTarget(ctx, inst, registration, env); err != nil {
 		return err
 	}
+
+	lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+	err = dm.Writer().UpdateInstallation(ctx, read_write_layer.W000106, inst)
 
 	return err
 }

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -185,10 +185,10 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logr.Logger, 
 
 		if !deployItemClassification.HasRunningItems() && deployItemClassification.HasFailedItems() {
 			err = lserrors.NewError(op, "handlePhaseDeleting", "has failed items")
-			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err)
+			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseDeleteFailed, err)
 		} else if !deployItemClassification.HasRunningItems() && !deployItemClassification.HasRunnableItems() && deployItemClassification.HasPendingItems() {
 			err = lserrors.NewError(op, "handlePhaseDeleting", "has pending items")
-			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err)
+			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseDeleteFailed, err)
 		}
 
 		// remain in deleting in all other cases,

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -2,7 +2,7 @@ package utils
 
 import lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 
-var NewReconcile = false
+var NewReconcile = true
 
 func IsNewReconcile() bool {
 	return NewReconcile

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -2,7 +2,7 @@ package utils
 
 import lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 
-var NewReconcile = true
+var NewReconcile = false
 
 func IsNewReconcile() bool {
 	return NewReconcile

--- a/test/integration/core/register.go
+++ b/test/integration/core/register.go
@@ -5,13 +5,10 @@
 package core
 
 import (
-	"github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/test/framework"
 )
 
 // RegisterTests registers all tests of the package
 func RegisterTests(f *framework.Framework) {
-	if !utils.IsNewReconcile() {
-		RegistryTest(f)
-	}
+	RegistryTest(f)
 }

--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -238,14 +238,10 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 		if commonutils.IsNewReconcile() {
 			// Set a new jobID to trigger a reconcile of the deploy item
 			utils.ExpectNoError(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di))
-			utils.ExpectNoError(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now()))
+			utils.ExpectNoError(utils.UpdateJobIdForDeployItemC(ctx, f.Client, di, metav1.Now()))
 			utils.ExpectNoError(lsutils.WaitForDeployItemToFinish(ctx, f.Client, di, lsv1alpha1.DeployItemPhaseSucceeded, 2*time.Minute))
 
-			utils.ExpectNoError(state.Client.Delete(ctx, di))
-			// Set a new jobID to trigger a reconcile of the deploy item
-			g.Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(di), di)).To(g.Succeed())
-			g.Expect(utils.UpdateJobIdForDeployItemC(ctx, state.Client, di, metav1.Now())).To(g.Succeed())
-			utils.ExpectNoError(utils.DeleteObject(ctx, f.Client, di, 2*time.Minute))
+			utils.ExpectNoError(utils.DeleteDeployItemForNewReconcile(ctx, f.Client, di, 2*time.Minute))
 			utils.ExpectNoError(utils.DeleteObject(ctx, f.Client, inst, 2*time.Minute))
 		} else {
 			utils.ExpectNoError(lsutils.WaitForDeployItemToSucceed(ctx, f.Client, di, 2*time.Minute))

--- a/test/integration/deployers/register.go
+++ b/test/integration/deployers/register.go
@@ -19,8 +19,8 @@ func RegisterTests(f *framework.Framework) {
 		ContainerDeployerTestsForNewReconcile(f)
 		ManifestDeployerTestsForNewReconcile(f)
 		helmcharts.RegisterTests(f)
-		//blueprints.RegisterTests(f)  // adapt for new reconcile
-		//management.RegisterTests(f)  // adapt for new reconcile
+		blueprints.RegisterTests(f)
+		management.RegisterTests(f)
 	} else {
 		ContainerDeployerTests(f)
 		ManifestDeployerTests(f)

--- a/test/integration/executions/generations.go
+++ b/test/integration/executions/generations.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -162,7 +163,7 @@ func GenerationHandlingTestsForNewReconcile(f *framework.Framework) {
 			utils.ExpectNoError(state.Create(ctx, exec))
 
 			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
-			Expect(utils.UpdateJobIdForExecutionC(ctx, state.Client, exec)).To(Succeed())
+			Expect(utils.UpdateJobIdForExecutionC(ctx, f.Client, exec)).To(Succeed())
 
 			By("verify that deployitem has been created")
 			di := &lsv1alpha1.DeployItem{}
@@ -245,6 +246,9 @@ func GenerationHandlingTestsForNewReconcile(f *framework.Framework) {
 			Expect(di.Generation).To(BeNumerically(">", oldDIGen))
 			Expect(exec.Status.ExecutionGenerations[0].ObservedGeneration).To(Equal(exec.Generation))
 			Expect(exec.Status.DeployItemReferences[0].Reference.ObservedGeneration).To(Equal(di.Generation))
+
+			By("delete execution")
+			utils.ExpectNoError(utils.DeleteExecutionForNewReconcile(ctx, f.Client, exec, 2*time.Minute))
 		})
 
 	})

--- a/test/integration/executions/testdata/test1/00-execution.yaml
+++ b/test/integration/executions/testdata/test1/00-execution.yaml
@@ -6,6 +6,8 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Execution
 metadata:
   name: exec-1
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
 spec:
 
   deployItems:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 3

**What this PR does / why we need it**:

The PR adjusts integration tests for the new reconcile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
