### PR TITLE
container deployer service account token handling

### DIFF
--- a/apis/.schemes/container-v1alpha1-Configuration.json
+++ b/apis/.schemes/container-v1alpha1-Configuration.json
@@ -126,13 +126,20 @@
       "type": "object",
       "required": [
         "disable",
-        "worker"
+        "worker",
+        "requeueTimeSeconds"
       ],
       "properties": {
         "disable": {
           "description": "Disable disables the garbage collector and the resources clean-up.",
           "type": "boolean",
           "default": false
+        },
+        "requeueTimeSeconds": {
+          "description": "RequeueTime specifies the duration after which the object, which is not yet ready to be garbage collected, is requeued. Defaults to 60.",
+          "type": "integer",
+          "format": "int32",
+          "default": 0
         },
         "worker": {
           "description": "Worker defines the number of parallel garbage collection routines. Defaults to 5.",

--- a/apis/deployer/container/types_config.go
+++ b/apis/deployer/container/types_config.go
@@ -99,6 +99,9 @@ type GarbageCollection struct {
 	// Worker defines the number of parallel garbage collection routines.
 	// Defaults to 5.
 	Worker int `json:"worker"`
+	// RequeueTime specifies the duration after which the object, which is not yet ready to be garbage collected, is requeued.
+	// Defaults to 60.
+	RequeueTimeSeconds int `json:"requeueTimeSeconds"`
 }
 
 // DebugOptions defines optional debug options.

--- a/apis/deployer/container/v1alpha1/defaults.go
+++ b/apis/deployer/container/v1alpha1/defaults.go
@@ -29,4 +29,7 @@ func SetDefaults_GarbageCollection(obj *GarbageCollection) {
 	if obj.Worker <= 0 {
 		obj.Worker = 5
 	}
+	if obj.RequeueTimeSeconds <= 0 {
+		obj.RequeueTimeSeconds = 60
+	}
 }

--- a/apis/deployer/container/v1alpha1/types_config.go
+++ b/apis/deployer/container/v1alpha1/types_config.go
@@ -101,6 +101,9 @@ type GarbageCollection struct {
 	// Worker defines the number of parallel garbage collection routines.
 	// Defaults to 5.
 	Worker int `json:"worker"`
+	// RequeueTime specifies the duration after which the object, which is not yet ready to be garbage collected, is requeued.
+	// Defaults to 60.
+	RequeueTimeSeconds int `json:"requeueTimeSeconds"`
 }
 
 // DebugOptions defines optional debug options.

--- a/apis/deployer/container/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/container/v1alpha1/zz_generated.conversion.go
@@ -282,6 +282,7 @@ func Convert_container_DebugOptions_To_v1alpha1_DebugOptions(in *container.Debug
 func autoConvert_v1alpha1_GarbageCollection_To_container_GarbageCollection(in *GarbageCollection, out *container.GarbageCollection, s conversion.Scope) error {
 	out.Disable = in.Disable
 	out.Worker = in.Worker
+	out.RequeueTimeSeconds = in.RequeueTimeSeconds
 	return nil
 }
 
@@ -293,6 +294,7 @@ func Convert_v1alpha1_GarbageCollection_To_container_GarbageCollection(in *Garba
 func autoConvert_container_GarbageCollection_To_v1alpha1_GarbageCollection(in *container.GarbageCollection, out *GarbageCollection, s conversion.Scope) error {
 	out.Disable = in.Disable
 	out.Worker = in.Worker
+	out.RequeueTimeSeconds = in.RequeueTimeSeconds
 	return nil
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -7305,8 +7305,16 @@ func schema_apis_deployer_container_v1alpha1_GarbageCollection(ref common.Refere
 							Format:      "int32",
 						},
 					},
+					"requeueTimeSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequeueTime specifies the duration after which the object, which is not yet ready to be garbage collected, is requeued. Defaults to 60.",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
-				Required: []string{"disable", "worker"},
+				Required: []string{"disable", "worker", "requeueTimeSeconds"},
 			},
 		},
 	}

--- a/charts/container-deployer/templates/rbac.yaml
+++ b/charts/container-deployer/templates/rbac.yaml
@@ -86,4 +86,5 @@ rules:
   - create
   - update
   - delete
+  - watch
 {{- end }}

--- a/test/utils/controller.go
+++ b/test/utils/controller.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -220,6 +221,77 @@ func (c *MimicKCMServiceAccountController) Reconcile(ctx context.Context, req re
 // AddMimicKCMServiceAccountControllerToManager adds the mock kcm controller to a manager.
 func AddMimicKCMServiceAccountControllerToManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).For(&corev1.ServiceAccount{}).Complete(&MimicKCMServiceAccountController{
+		client: mgr.GetClient(),
+	})
+}
+
+// MimicKCMSecretController is a controller that mimics the service account token secret handling of the KCM.
+type MimicKCMSecretController struct {
+	client client.Client
+}
+
+func (c *MimicKCMSecretController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	secret := &corev1.Secret{}
+	if err := c.client.Get(ctx, req.NamespacedName, secret); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if secret.Type != corev1.SecretTypeServiceAccountToken {
+		return reconcile.Result{}, nil
+	}
+
+	saName, ok := secret.Annotations[corev1.ServiceAccountNameKey]
+	if !ok {
+		return reconcile.Result{}, fmt.Errorf("annotation %s missing for secret %s", corev1.ServiceAccountNameKey, client.ObjectKeyFromObject(secret).String())
+	}
+
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := c.client.Get(ctx, types.NamespacedName{Name: saName, Namespace: secret.Namespace}, serviceAccount); err != nil {
+		return reconcile.Result{}, fmt.Errorf("service account %s not found for secret %s", saName, client.ObjectKeyFromObject(secret).String())
+	}
+
+	secretInSARefs := false
+	for _, ref := range serviceAccount.Secrets {
+		if ref.Name == secret.Name {
+			secretInSARefs = true
+			break
+		}
+	}
+
+	if !secretInSARefs {
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: secret.Name, Namespace: secret.Namespace})
+		if err := c.client.Update(ctx, serviceAccount); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to update service account %s", client.ObjectKeyFromObject(serviceAccount).String())
+		}
+	}
+
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+
+	rootCa, ok := secret.Data[corev1.ServiceAccountRootCAKey]
+	if !ok {
+		rootCa = []byte("my-test-rootca")
+		secret.Data[corev1.ServiceAccountRootCAKey] = rootCa
+
+	}
+
+	token, ok := secret.Data[corev1.ServiceAccountTokenKey]
+	if !ok {
+		token = []byte("my-test-token")
+		secret.Data[corev1.ServiceAccountTokenKey] = token
+	}
+
+	if err := c.client.Update(ctx, secret); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// AddMimicKCMSecretControllerToManager adds the mock kcm controller to a manager.
+func AddMimicKCMSecretControllerToManager(mgr manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(mgr).For(&corev1.Secret{}).Complete(&MimicKCMSecretController{
 		client: mgr.GetClient(),
 	})
 }

--- a/test/utils/controller.go
+++ b/test/utils/controller.go
@@ -269,17 +269,12 @@ func (c *MimicKCMSecretController) Reconcile(ctx context.Context, req reconcile.
 		secret.Data = make(map[string][]byte)
 	}
 
-	rootCa, ok := secret.Data[corev1.ServiceAccountRootCAKey]
-	if !ok {
-		rootCa = []byte("my-test-rootca")
-		secret.Data[corev1.ServiceAccountRootCAKey] = rootCa
-
+	if _, ok := secret.Data[corev1.ServiceAccountRootCAKey]; !ok {
+		secret.Data[corev1.ServiceAccountRootCAKey] = []byte("my-test-rootca")
 	}
 
-	token, ok := secret.Data[corev1.ServiceAccountTokenKey]
-	if !ok {
-		token = []byte("my-test-token")
-		secret.Data[corev1.ServiceAccountTokenKey] = token
+	if _, ok := secret.Data[corev1.ServiceAccountTokenKey]; !ok {
+		secret.Data[corev1.ServiceAccountTokenKey] = []byte("my-test-token")
 	}
 
 	if err := c.client.Update(ctx, secret); err != nil {

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/types_config.go
@@ -99,6 +99,9 @@ type GarbageCollection struct {
 	// Worker defines the number of parallel garbage collection routines.
 	// Defaults to 5.
 	Worker int `json:"worker"`
+	// RequeueTime specifies the duration after which the object, which is not yet ready to be garbage collected, is requeued.
+	// Defaults to 60.
+	RequeueTimeSeconds int `json:"requeueTimeSeconds"`
 }
 
 // DebugOptions defines optional debug options.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/types_config.go
@@ -101,6 +101,9 @@ type GarbageCollection struct {
 	// Worker defines the number of parallel garbage collection routines.
 	// Defaults to 5.
 	Worker int `json:"worker"`
+	// RequeueTime specifies the duration after which the object, which is not yet ready to be garbage collected, is requeued.
+	// Defaults to 60.
+	RequeueTimeSeconds int `json:"requeueTimeSeconds"`
 }
 
 // DebugOptions defines optional debug options.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/zz_generated.conversion.go
@@ -282,6 +282,7 @@ func Convert_container_DebugOptions_To_v1alpha1_DebugOptions(in *container.Debug
 func autoConvert_v1alpha1_GarbageCollection_To_container_GarbageCollection(in *GarbageCollection, out *container.GarbageCollection, s conversion.Scope) error {
 	out.Disable = in.Disable
 	out.Worker = in.Worker
+	out.RequeueTimeSeconds = in.RequeueTimeSeconds
 	return nil
 }
 
@@ -293,6 +294,7 @@ func Convert_v1alpha1_GarbageCollection_To_container_GarbageCollection(in *Garba
 func autoConvert_container_GarbageCollection_To_v1alpha1_GarbageCollection(in *container.GarbageCollection, out *GarbageCollection, s conversion.Scope) error {
 	out.Disable = in.Disable
 	out.Worker = in.Worker
+	out.RequeueTimeSeconds = in.RequeueTimeSeconds
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/serviceaccounts.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/serviceaccounts.go
@@ -11,6 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// GetSecretsForServiceAccount returns the list of secrets of type "kubernetes.io/service-account-token"
+// which belong to the given service account. The result list is sorted decreasingly by creation timestamp,
+// so that it starts with the newest secret.
 func GetSecretsForServiceAccount(ctx context.Context, kubeClient client.Client, serviceAccountKey client.ObjectKey) ([]*corev1.Secret, error) {
 	secretList := &corev1.SecretList{}
 	if err := kubeClient.List(ctx, secretList, client.InNamespace(serviceAccountKey.Namespace)); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:
With this change, the container deployer creates the service account token secret manually, which is required for Kubernetes v1.24.x.
This PR also adds a requeue time for the container deployer garbage collector.
Previously objects (Service Accounts, Roles, Rolebindings etc.) created by the container deployer were not requed for reconciliation when the deploy item is still existing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
For Kubernetes versions 1.24 and later, create the service account token secret manually in the container deployer.
Add container deployer garbage collector automatic requeuing.
```
