### PR TITLE
Improve integration tests

### DIFF
--- a/.ci/new-integration-test
+++ b/.ci/new-integration-test
@@ -9,17 +9,17 @@ set -o nounset
 set -o pipefail
 
 KUBECONFIG_PATH=$1
+VERSION=$2
 SOURCE_PATH="$(dirname $0)/.."
 cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"
 
 echo "Source path ${SOURCE_PATH}"
 
-VERSION="$(./hack/get-version.sh)"
 REGISTRY_NS=clusters
 ID="12"
 
-echo "Starting integration tests for landscaper version ${VERSION}"
+echo "Starting integration tests for landscaper version ${VERSION} and kubeconfig $KUBECONFIG_PATH"
 
 TMP="${SOURCE_PATH}/tmp-int-test"
 TMP_GEN="$TMP/gen"

--- a/.ci/new-run-tests
+++ b/.ci/new-run-tests
@@ -12,6 +12,9 @@ KUBECONFIG_PATH=$1
 REGISTRY_CONFIG=$2
 VERSION=$3
 
+# to disable set on 1
+DISABLE_CLEANUP=0
+
 SOURCE_PATH="$(dirname $0)/.."
 cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"
@@ -24,7 +27,8 @@ go test -timeout=60m -mod=vendor ./test/integration \
     --registry-config=$REGISTRY_CONFIG \
     --ls-namespace=ls-system \
     --ls-version=$VERSION \
-    --ls-run-on-shoot
+    --ls-run-on-shoot \
+    --disable-cleanup=$DISABLE_CLEANUP
 
 # echo "Delete namespace with registry"
 # kubectl --kubeconfig=$KUBECONFIG_PATH delete ns $REGISTRY_NS

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,10 @@ setup-testenv:
 test: setup-testenv
 	@$(REPO_ROOT)/hack/test.sh
 
+
 .PHONY: integration-test
 integration-test:
-	@go test -timeout=1h -mod=vendor $(REPO_ROOT)/test/integration --v -ginkgo.v -ginkgo.progress \
-		--kubeconfig $(KUBECONFIG) \
-		--ls-version $(EFFECTIVE_VERSION) \
-		--registry-config=$(REGISTRY_CONFIG) \
-		--disable-cleanup=$(DISABLE_CLEANUP)
-
+	@$(REPO_ROOT)/.ci/new-integration-test $(KUBECONFIG_PATH) $(EFFECTIVE_VERSION)
 
 .PHONY: verify
 verify: check
@@ -145,14 +141,6 @@ upload-tutorial-resources:
 install-testcluster-cmd:
 	@go install $(REPO_ROOT)/hack/testcluster
 
-.PHONY: setup-local-registry
-setup-local-registry:
-	@go run $(REPO_ROOT)/hack/testcluster create --kubeconfig $(KUBECONFIG) -n default --id=local --enable-registry --enable-cluster=false --registry-auth=./tmp/local-docker.config
-	@echo "For local development add '127.0.0.1 registry-local.default' to your '/etc/hosts' and run a port-forward to the registry pod 'kubectl port-forward registry-local 5000'"
-
-.PHONY: remove-local-registry
-remove-local-registry:
-	@go run $(REPO_ROOT)/hack/testcluster delete --kubeconfig $(KUBECONFIG) -n default --id=local --enable-registry --enable-cluster=false
 
 .PHONY: start-webhooks
 start-webhooks:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -42,17 +42,13 @@ The TestMachinery itself works with
 ![TestMachinery test setup](../images/TestMachineryITSetup.png)
 
 **local execution**
-The integration tests can also be executed locally by providing a kubernetes cluster and export the kubeconfig as `export KUBECONFIG=<path to kubeconfig>`.
-Then just run the tests with `make integration-test`.
+The integration tests can also be executed locally by providing a kubernetes cluster. Then just run the tests with:
 
-By default the integration tests that require an oci registry executed with the make command are skipped. (These tests are also flagged as `Require OCI Registry` see https://github.com/gardener/landscaper/blob/master/test/integration/core/registry.go#L37)
+```
+make integration-test KUBECONFIG_PATH=<path to cluster kubeconfig file>
+```
 
-Test that require an oci registry can be executed locally by
-1. Provide an oci-registry.<br>
-   The landscaper project offers you to deploy a local registry by running `make setup-local-registry` (a running k8s cluster is needed). Please follow all instructions printed by the command.
-   > Note: The registry configuration is written to `./tmp/local-docker.config`.<br>
-   > The registry can be deleted with `make remove-local-registry`
-2. running the integration tests with the oci registry configuration as `make integration-test REGISTRY_CONFIG=<path to config>`
+The tests set up a local OCI registry, install/upgrade the landscaper and executes the integration tests.
 
 #### write tests
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -53,6 +53,12 @@ func TestConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !opts.DisableCleanupBefore {
+		if err := f.CleanupBeforeTestNamespaces(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	tutorial.RegisterTests(f)
 	webhook.RegisterTests(f)
 	core.RegisterTests(f)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority 3

**What this PR does / why we need it**:

This PR improves the execution of integration tests. Now these could be executed by a make commend and they cleanup test namespaces before the tests start.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
