### PR TITLE
capture test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp-int-test
 **/sha256
 
 **/gomock_reflect_*
+
+coverage.*

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
@@ -22,10 +20,18 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   P_FLAG="-p=1"
 fi
 
-go test -mod=vendor -race ${P_FLAG} ${PROJECT_ROOT}/cmd/... \
+go test -mod=vendor -race -coverprofile=${PROJECT_ROOT}/coverage.main.out -covermode=atomic ${P_FLAG} \
+                    ${PROJECT_ROOT}/cmd/... \
                     ${PROJECT_ROOT}/pkg/... \
                     ${PROJECT_ROOT}/test/framework/... \
                     ${PROJECT_ROOT}/test/utils/... \
                     ${PROJECT_ROOT}/test/landscaper/...
+EXIT_STATUS_MAIN_TEST=$?
 
-cd ${PROJECT_ROOT}/apis && GO111MODULE=on go test ./...
+cd ${PROJECT_ROOT}/apis && GO111MODULE=on go test -coverprofile=${PROJECT_ROOT}/coverage.api.out -covermode=atomic ./...
+EXIT_STATUS_API_TEST=$?
+
+cd ${PROJECT_ROOT}/controller-utils && GO111MODULE=on go test -coverprofile=${PROJECT_ROOT}/coverage.controller-utils.out -covermode=atomic ./...
+EXIT_STATUS_CONTROLLER_UTILS_TEST=$?
+
+! (( EXIT_STATUS_MAIN_TEST || EXIT_STATUS_API_TEST || EXIT_STATUS_CONTROLLER_UTILS_TEST ))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Capture the test coverage of the unit-test which is then visible in the concourse pipeline.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Capture the test coverage of unit-tests.
```
