### PR TITLE
create html coverage reports

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -27,11 +27,14 @@ go test -mod=vendor -race -coverprofile=${PROJECT_ROOT}/coverage.main.out -cover
                     ${PROJECT_ROOT}/test/utils/... \
                     ${PROJECT_ROOT}/test/landscaper/...
 EXIT_STATUS_MAIN_TEST=$?
+go tool cover -html=${PROJECT_ROOT}/coverage.main.out -o ${PROJECT_ROOT}/coverage.main.html
 
 cd ${PROJECT_ROOT}/apis && GO111MODULE=on go test -coverprofile=${PROJECT_ROOT}/coverage.api.out -covermode=atomic ./...
 EXIT_STATUS_API_TEST=$?
+go tool cover -html=${PROJECT_ROOT}/coverage.api.out -o ${PROJECT_ROOT}/coverage.api.html
 
 cd ${PROJECT_ROOT}/controller-utils && GO111MODULE=on go test -coverprofile=${PROJECT_ROOT}/coverage.controller-utils.out -covermode=atomic ./...
 EXIT_STATUS_CONTROLLER_UTILS_TEST=$?
+go tool cover -html=${PROJECT_ROOT}/coverage.controller-utils.out -o ${PROJECT_ROOT}/coverage.controller-utils.html
 
 ! (( EXIT_STATUS_MAIN_TEST || EXIT_STATUS_API_TEST || EXIT_STATUS_CONTROLLER_UTILS_TEST ))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Automatically create html code coverage reports for unit tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Automatically create html code coverage reports for unit tests.
```
