### PR TITLE
Adapt docu for new reconcile

### DIFF
--- a/docs/deployer/README.md
+++ b/docs/deployer/README.md
@@ -5,6 +5,8 @@ These deployers are meant to have specific deploy, install and update logic.
 
 ## List of Deployers
 
+The following deployers are available out of the box with the Landscaper. Further deployer could be implemented and registered.
+
 - [Mock](mock.md)
 - [Helm](helm.md)
 - [Kubernetes Manifest](manifest.md)
@@ -16,17 +18,21 @@ These deployers are meant to have specific deploy, install and update logic.
 ### Target Selector
 
 If multiple instances of a deployer are used (e.g. when dealing with different environment) by default all instances will concurrently reconcile the deploy items.
-Therefore a mechanism is needed that defines the responsibility for the different deploy items and deployer instances.
+Therefore, a mechanism is needed that defines the responsibility for the different deploy items and deployer instances.
 
 There are different possible options for how this can be achieved, which could also be very deployer/target specific (e.g. the url or aws region).
 The Landscaper deployer library currently offers some standardized default options by using targets to determine responsibility.
 
 **Annotations/Labels**
 
-A simple mechanism is to annotate the targets (either using annotations or labels) and configure each deployer instance with a different target selector that matches these annotations (or labels). This is comparable to how Kubernetes Ingress objects are selected.
+A simple mechanism is to annotate the targets (either using annotations or labels) and configure each deployer instance 
+with a different target selector that matches these annotations (or labels). This is comparable to how Kubernetes Ingress 
+objects are selected.
 
 The landscaper offers a default implementation to use label selector to either select targets based on annotations or labels. 
-(See the official Kubernetes doucmentation for detailed documentation on how the selectors work: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
+(See the official Kubernetes documentation for detailed documentation on how the selectors work: 
+https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
+
 ```yaml
 --- # target
 apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/docs/deployer/container.md
+++ b/docs/deployer/container.md
@@ -58,9 +58,6 @@ spec:
     command: ["my command"]
     args:  ["--flag1", "my arg"]
 
-#    continuousReconcile: # configure continuous reconciliation
-#      every: "1h"
-#      cron: cron: "* */1 * * *"
 ```
 
 ### Contract
@@ -108,8 +105,6 @@ When the image with your program is executed, it gets access to particular infor
 Again you will find a more detailed explanation of these env variables
 [here](https://github.com/gardener/landscapercli/blob/master/docs/commands/container_deployer/add_container_di.md).
 
-##### Continuous Reconciliation
-For information on the continuous reconciliation configuration, see [here](../development/deployer-extensions##continuous-reconcile-extension) under 'usage'.
 
 ### Status
 
@@ -135,8 +130,7 @@ status:
 
 ### Operations
 
-In addition to the annotations that are specified in the DeployItem contract (operation reconcile and force-reconcile), 
-the container deployer implements specific annotations that can be set to instruct the container deployer to 
+The container deployer reacts on specific annotations that can be set to instruct the container deployer to 
 perform specific actions.
 
 - _container.deployer.landscaper.gardener.cloud/force-cleanup=true_ : triggers the force deletion of the deploy item. 
@@ -148,7 +142,9 @@ When deploying the container deployer controller it can be configured using the 
 
 The structure of the provided configuration file is defined as follows.
 
-:warning: Keep in mind that when deploying with the helm chart the configuration is abstracted using the helm values. See the [helm values file](../../charts/container-deployer/values.yaml) for details when deploying with the helm chart.
+:warning: Keep in mind that when deploying with the helm chart the configuration is abstracted using the helm values. 
+See the [helm values file](../../charts/container-deployer/values.yaml) for details when deploying with the helm chart.
+
 ```yaml
 apiVersion: container.deployer.landscaper.gardener.cloud/v1alpha1
 kind: Configuration
@@ -215,7 +211,7 @@ When a Container DeployItem is reconciled basically the following steps are perf
 2. When the DeployItem is ready to be executed (configuration has changed), the container deployer schedules a Pod.
 3. That pod contains a InitContainer that fetches the targets, import values, blueprint and the resolved component descriptor. The data is stored in a shared local volume.
 4. The actual application code is executed in a main container as soon as the initContainer has finished. The main container has access to the shared volume which make it possible for the application to access runtime data and configuration.
-5. When the main container has successfully finished, optionally data is exported. See [Container Eexport](#export) for detailed export architecture.
+5. When the main container has successfully finished, optionally data is exported. See [Container Export](#export) for detailed export architecture.
 
 ![Container Deployer Reconcile](../images/container-deployer_reconcile.png)
 

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -62,10 +62,6 @@ spec:
 
     updateStrategy: update | patch # optional; defaults to update
 
-#    continuousReconcile: # configure continuous reconciliation
-#      every: "1h"
-#      cron: cron: "* */1 * * *"
-
     # Configuration of the readiness checks for the resources.
     # optional
     readinessChecks:
@@ -74,7 +70,7 @@ spec:
       disableDefault: true
       # Defines the time to wait before giving up on a resource
       # to be ready. Should be changed with long startup time pods.
-      # optional; default to 180 seconds/3 minutes.
+      # optional; defaults to 180 seconds/3 minutes.
       timeout: 3m
       # Configuration of custom readiness checks which are used
       # to check on custom fields and their values
@@ -121,7 +117,7 @@ spec:
           - value: 3
 
     # Defines the time to wait before giving up on a resource to be deleted,
-    # for instance when deleting resources that are not anymore managed from this DeployItem.
+    # for instance when deleting resources that are not managed by this DeployItem anymore.
     # optional; default to 180 seconds/3 minutes.
     deleteTimeout: 2m
 
@@ -209,9 +205,6 @@ spec:
     helmDeployment: false
 ```
 
-##### Continuous Reconciliation
-For information on the continuous reconciliation configuration, see [here](../development/deployer-extensions##continuous-reconcile-extension) under 'usage'.
-
 ### Status
 
 This section describes the provider specific status of the resource.
@@ -234,7 +227,9 @@ When deploying the helm deployer controller it can be configured using the `--co
 
 The structure of the provided configuration file is defined as follows.
 
-:warning: Keep in mind that when deploying with the helm chart the configuration is abstracted using the helm values. See the [helm values file](../../charts/helm-deployer/values.yaml) for details when deploying with the helm chart.
+:warning: Keep in mind that when deploying with the helm chart the configuration is abstracted using the helm values. 
+See the [helm values file](../../charts/helm-deployer/values.yaml) for details when deploying with the helm chart.
+
 ```yaml
 apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1
 kind: Configuration

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -32,10 +32,6 @@ spec:
 
     updateStrategy: update | patch # optional; defaults to update
 
-#    continuousReconcile: # configure continuous reconciliation
-#      every: "1h"
-#      cron: cron: "* */1 * * *"
-
     # Configuration of the readiness checks for the resources.
     # optional
     readinessChecks:
@@ -147,9 +143,6 @@ __Policy__:
 - `fallback`: create, update and delete (only if not already managed by someone else: check for annotation with landscaper identity, deployitem name + namespace)
 - `keep`: create, update
 - `ignore`: forget
-
-##### Continuous Reconciliation
-For information on the continuous reconciliation configuration, see [here](../development/deployer-extensions##continuous-reconcile-extension) under 'usage'.
 
 ### Status
 

--- a/docs/deployer/mock.md
+++ b/docs/deployer/mock.md
@@ -2,7 +2,8 @@
 
 The mock deployer is a controller that reconciles DeployItems of type `landscaper.gardener.cloud/mock`. 
 
-This deployer is only ment for testing and demo purposes to simluate specific behavior of deploy item. Therefore, the Configuration part configures the state that should be reconciled by the mock.
+This deployer is only meant for testing and demo purposes to simulate specific behavior of deploy items. Therefore, the 
+configuration part configures the state that should be reconciled by the mock.
 
 **Index**:
 - [Provider Configuration](#provider-configuration)
@@ -34,14 +35,8 @@ spec:
     # Specifies the exported data that will be reconciled into the exportRef.
     export:
       key2: val2
-#    continuousReconcile: # configure continuous reconciliation
-#      every: "1h"
-#      cron: cron: "* */1 * * *"
 
 ```
-
-##### Continuous Reconciliation
-For information on the continuous reconciliation configuration, see [here](../development/deployer-extensions##continuous-reconcile-extension) under 'usage'.
 
 ### Status
 
@@ -53,7 +48,9 @@ When deploying the mock deployer controller it can be configured using the `--co
 
 The structure of the provided configuration file is defined as follows.
 
-:warning: Keep in mind that when deploying with the helm chart the configuration is abstracted using the helm values. See the [helm values file](../../charts/mock-deployer/values.yaml) for details when deploying with the helm chart.
+:warning: Keep in mind that when deploying with the helm chart the configuration is abstracted using the helm values. 
+See the [helm values file](../../charts/mock-deployer/values.yaml) for details when deploying with the helm chart.
+
 ```yaml
 apiVersion: mock.deployer.landscaper.gardener.cloud/v1alpha1
 kind: Configuration

--- a/docs/development/dep-lib-extension-hooks.md
+++ b/docs/development/dep-lib-extension-hooks.md
@@ -1,5 +1,8 @@
 # Deployer Library Extension Hooks
 
+After switching to the new reconcile logic the extension hooks are currently deactivated. It is open if and when they
+are activated again.
+
 No matter what exactly a deployer is meant to do, the landscaper has some expectations regarding the handling of deploy items - the deployer is expected to remove certain annotations and react on them, reconcile only deploy items which it is responsible for, [and so on](../technical/deployer_contract.md). To avoid lots of duplicate code and reduce the risk of errors in the implementation of this contract, there is a deployer library which implements most of the boilerplate code and basically simplifies the process of writing a deployer to a little more than implementing an interface.
 
 However, in some cases, the default reconciliation flow implemented by the deployer library is too restrictive for what a deployer wants to do.

--- a/docs/development/deployer-extensions.md
+++ b/docs/development/deployer-extensions.md
@@ -1,5 +1,8 @@
 # Deployer Extensions
 
+After switching to the new reconcile logic the continuous reconcile extension is currently deactivated. It is open if, how and
+when it is activated again.
+
 This article is meant to list already implemented extensions which can be integrated in deployers. For more information on how deployer extensions work, read about the [Deployer Library Extension Hooks](./dep-lib-extension-hooks.md).
 
 #### Index

--- a/docs/gettingstarted/install-landscaper-service.md
+++ b/docs/gettingstarted/install-landscaper-service.md
@@ -57,6 +57,10 @@ The following example shows the configuration of the landscaper service installa
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
   name: landscaper-service
 spec:
   componentDescriptor:

--- a/docs/level_0/basic_concepts.md
+++ b/docs/level_0/basic_concepts.md
@@ -50,8 +50,8 @@ Custom Resources (CR) defined by Landscaper. An installation references the Blue
 corresponding Component Descriptor. It specifies the import data and how to handle the export data. 
 
 An Installation is deployed to the cluster where Landscaper watches these CRs. If Landscaper recognizes an installation
-with all input data available, it starts the setup specified in the Blueprint. This executes the installation tasks 
-defined in the DeployItems.
+with the annotation `landscaper.gardener.cloud/operation: reconcile` with all input data available, it starts the setup 
+specified in the Blueprint. This executes the installation tasks defined in the DeployItems. 
 
 ## Aggregated Blueprint
 

--- a/docs/level_0/first_example_installation.md
+++ b/docs/level_0/first_example_installation.md
@@ -1,6 +1,8 @@
 # First Example Installation
 
-In this example we describe how to deploy your first component with Landscaper. The component defines an nginx helm chart deployment. Note that this example uses an already existing Component Descriptor and its Blueprint, so it is meant to give you a way to quickly deploy something with the Landscaper and look at the deployed resources in your cluster.
+In this example we describe how to deploy your first component with Landscaper. The component defines an nginx helm chart 
+deployment. Note that this example uses an already existing Component Descriptor and its Blueprint, so it is meant to 
+give you a way to quickly deploy something with the Landscaper and look at the deployed resources in your cluster.
 
 To try out this example by yourself, you need to install Landscaper (see [here](../gettingstarted/install-landscaper-controller.md)) in a cluster.
 
@@ -51,12 +53,18 @@ kubectl create namespace first-example
 
 ## Step 3 - Create and apply the Installation custom resource
 
-To install the nginx ingress-controller with the Landscaper, we have to finally create a custom resource of kind `Installation`. Such Ìnstallation`custom resources are watched by the Landscaper controller and triggers the installation as described by the Blueprint, which is located within the specified Component Descriptor.
+To install the nginx ingress-controller with the Landscaper, we have to finally create a custom resource of kind `Installation`. 
+Such `Installation` custom resources are watched by the Landscaper controller and triggers the installation as described 
+by the Blueprint, which is located within the specified Component Descriptor. To be processed by the Landscaper, the 
+installation requires an annotation `landscaper.gardener.cloud/operation: reconcile` which is automatically removed when 
+the processing starts. This annotation has to be set by the operator/user.
 
 ```yaml
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
   name: demo
   namespace: demo
 spec:

--- a/docs/level_0/resources/installation.yaml
+++ b/docs/level_0/resources/installation.yaml
@@ -1,6 +1,8 @@
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
   name: demo
   namespace: demo
 spec:

--- a/docs/technical/deployer_contract.md
+++ b/docs/technical/deployer_contract.md
@@ -1,7 +1,9 @@
 
 # Deployer Contract
 
-Deployers need to follow some rules in order to work together with the landscaper. The purpose of this documentation is to define the contract between deployers and the landscaper so that developers who want to create their own deployer know which requirements they have to fulfill.
+Deployers need to follow some rules in order to work together with the landscaper. The purpose of this documentation is 
+to define the contract between deployers and the landscaper so that developers who want to create their own deployer 
+know which requirements they have to fulfill.
 
 **Index**
 - [What is a Deployer](#what-is-a-deployer)
@@ -12,8 +14,13 @@ Deployers need to follow some rules in order to work together with the landscape
 
 ## What is a Deployer?
 
-A 'deployer' is basically a kubernetes controller that watches resources of the type `deployitems.landscaper.gardener.cloud`. _Deploy Items_ have a unique type (`.spec.type`) that describes the supported deployment or installation method and is also the identifier for the corresponding deployer.
-For example: Among the basic deployers that come with the landscaper is a `helm` deployer, which reacts on deploy items of type `landscaper.gardener.cloud/helm` and is able to deploy, update, and delete helm charts. Another one would be the `manifest` deployer, which manages basic kubernetes manifests which are contained in the corresponding deploy items.
+A 'deployer' is basically a kubernetes controller that watches resources of the type `deployitems.landscaper.gardener.cloud`. 
+_Deploy Items_ have a unique type (`.spec.type`) that describes the supported deployment or installation method and is 
+also the identifier for the corresponding deployer.
+
+For example: Among the basic deployers that come with the landscaper is a `helm` deployer, which reacts on deploy items 
+of type `landscaper.gardener.cloud/helm` and is able to deploy, update, and delete helm charts. Another one would be 
+the `manifest` deployer, which manages basic kubernetes manifests which are contained in the corresponding deploy items.
 
 
 ## Structure of a Deploy Item
@@ -42,14 +49,21 @@ spec:
         name: foo
 
 ```
-This example shows a manifest deploy item that will create a namespace called `foo` when applied. Check out the [example deploy items](../../examples/deploy-items) for more examples of deploy items.
+This example shows a manifest deploy item that will create a namespace called `foo` when applied. Check out the 
+[example deploy items](../../examples/deploy-items) for more examples of deploy items.
 
-The type of the deploy item is defined in `spec.type`. It determines which deployer is responsible for this deploy item. The manifest deployer will only handle deploy items of type `landscaper.gardener.cloud/kubernetes-manifest` and it should be the only deployer that watches for this type.
+The type of the deploy item is defined in `spec.type`. It determines which deployer is responsible for this deploy item. 
+The manifest deployer will only handle deploy items of type `landscaper.gardener.cloud/kubernetes-manifest` and it 
+should be the only deployer that watches for this type.
 
-Deployers may reference a target in `spec.target`. Targets usually contain credentials for accessing the environment that is targeted by this type of deploy item.
-The manifest deployer targets kubernetes clusters, so this target will contain a kubeconfig pointing to the cluster where the namespace should be created. 
-Not all deploy items target kubernetes clusters though, for example the `terraform` deployer can also target IAAS accounts.
-There might be cases in which multiple deployers of the same type exists, e.g. if there is a fenced environment that is not accessible from the outside. In this case, the landscaper and a manifest deployer could run outside of it and another manifest deployer could run within the fenced environment to deploy manifests there. The target then determines which deployer handles which deploy item.
+Deployers may reference a target in `spec.target`. Targets usually contain credentials for accessing the environment 
+that is targeted by this type of deploy item. The manifest deployer targets kubernetes clusters, so this target will 
+contain a kubeconfig pointing to the cluster where the namespace should be created. Not all deploy items target 
+kubernetes clusters though, for example the `terraform` deployer can also target IAAS accounts. There might be cases in 
+which multiple deployers of the same type exists, e.g. if there is a fenced environment that is not accessible from the 
+outside. In this case, the landscaper and a manifest deployer could run outside of it and another manifest deployer 
+could run within the fenced environment to deploy manifests there. The target then determines which deployer handles 
+which deploy item.
 
 The content of `spec.config` depends on its type. It is only read and evaluated by the corresponding deployer. 
 In this example the configuration for a manifest deploy item consists of a list of kubernetes manifests.
@@ -57,8 +71,12 @@ In this example the configuration for a manifest deploy item consists of a list 
 ### Status
 
 Once handled by its deployer, a status similar to this one will be attached to the deploy item:
+
 ```yaml
 status:
+  deployItemPhase: Succeeded
+  jobID: "fgkjjdfd..."
+  jobIDFinished: "fgkjjdfd..."
   observedGeneration: 1
   phase: Succeeded
   lastReconcileTime: "2021-04-15T12:10:51Z"
@@ -79,9 +97,13 @@ status:
 ```
 
 If errors occurred while handling the deploy item, the status will contain an error message:
+
 ```yaml
 status:
-  observedGeneration: 0
+  deployItemPhase: Failed
+  jobID: "fgkjjdfd..."
+  jobIDFinished: "fgkjjdfd..."
+  observedGeneration: 1
   phase: Failed
   lastError:
     codes:
@@ -93,69 +115,95 @@ status:
     reason: PickupTimeout
 ```
 
-The most interesting part of the status is the `phase`. There are five different phases for deploy items:
+The most interesting part of the status is the `deployItemPhase`, the `jobId`, the `jobIdFinished` and `lastReconcileTime`. 
+The Landscaper interacts with the deployer using these fields. A deployer is only allowed to process a deploy item if 
+`jobId` is not equal to `jobIdFinished`. This way the Landscaper informs the deployer about processing a deploy item. 
+
+If `jobId` is not equal to `jobIdFinished` and `deployItemPhase` is either empty, or has the value `Succeeded` or `Failed`, 
+the deployer is allowed to process the deploy item. Then it must set `deployItemPhase` on `Processing` or `Deleting` 
+depending on if the item should be just reconciled or deleted/uninstalled. This signals the Landscaper that the deployer 
+has picked up the deploy item. Furthermore, the deployer must set `lastReconcileTime` on the current time. The Landscaper 
+checks a deploy item regularly and if `lastReconcileTime` is to old, it sees that the responsible deployer does not 
+finish within the specified timeframe and sets the deploy item on failed ([see](../usage/DeployItemTimeouts.md)). 
+
+When the reconcile or the deletion of the deploy item succeeded or failed, the deployer is required to set 
+`deployItemPhase` on `Succeeded` or `Failed` and `jobIdFinished` on the value of `jobId`. This must be done in one 
+atomic update operation because it is required that if `jobId` and `jobIdFinished` are equal, the `deployItemPhase` must 
+be `Succeeded` or `Failed`. This informs the Landscaper, that the deployer has finished processing the deploy item and 
+only then the Landscaper is allowed to trigger a new operation by updating the `jobId` again. 
+
+The deletion of deploy items is triggered by the Landscaper. The deployers are only responsible to uninstall the deployed
+artefacts and remove the finalizers of the deploy item if the uninstallation was successful.  
+
+When the deployer starts working on a deploy item, it could use the status field `phase` to report its internal 
+processing state, whereby the following values are allowed:
+
 - `Init`: This is more of a transition phase that shows that the deploy item is about to be handled by a deployer.
 - `Progressing`: The deploy item is currently being processed by its deployer.
 - `Deleting`: Similar to `Processing`, but instead of being applied, the deploy item is being deleted.
-- `Succeeded`: The deploy item successfully finished processing. When this phase is set, landscaper expects all effects of the deploy item to have been applied.
-- `Failed`: The deployer finished processing the deploy item, but it was not successful. Whenever this state is set, there should be further information on what went wrong in the `status.lastError` field.
-
-`Succeeded` and `Failed` are treated as 'final states', because the corresponding deployer won't do anything with the deploy item unless being triggered, while `Init`, `Progressing`, and `Deleting` indicate that the deployer is still working on this deploy item.
-
+- `Succeeded`: The deploy item successfully finished processing. 
+- `Failed`: The deployer finished processing the deploy item, but it was not successful. Whenever this state is set, 
+  there should be further information on what went wrong in the `status.lastError` field.
 
 ## How is a Deployer expected to act?
 
-Not only a deployer, but also the landscaper interacts with deploy items. To avoid conflicts between deployers and the landscaper, the deployer is expected to follow these steps in the given order:
+Not only a deployer, but also the landscaper interacts with deploy items. To avoid conflicts between deployers and the 
+landscaper, the deployer is expected to follow these steps in the given order:
 
 #### 1. Check the Type of the Deploy Item
-A deployer's reconcile loop will be triggered for changes to any deploy item, not only the ones that are handled by this deployer. The deployer has to make sure that it only handles deploy items of its own type. A deployer must never modify a deploy item of another type in any way!
+A deployer's reconcile loop will be triggered for changes to any deploy item, not only the ones that are handled by 
+this deployer. The deployer has to make sure that it only handles deploy items of its own type. A deployer must never 
+modify a deploy item of another type in any way!
 
 #### 2. Verify Target
-As explained above, even if the type is correct, the deployer might still not be responsible for the deploy item, so the target has to be checked too, if any.
+As explained above, even if the type is correct, the deployer might still not be responsible for the deploy item, so the 
+target has to be checked too, if any.
 
-#### 3. Handle Annotations
-There are two important annotations that need to be handled by the deployer: 
-The operation annotation `landscaper.gardener.cloud/operation` indicates that either a human operator or the landscaper wants a specific operation to be fulfilled on this deploy item. The value of the annotation specifies the expected operation:
-- `reconcile`: This deploy item needs to be reconciled. The deployer has to remove this annotation. In addition, it should set the deploy item's phase to `Init` to show the beginning of a new reconciliation and avoid loss of information in case the deployer dies immediately after removing the annotation. In the status, `lastReconcileTime` has to be set to the current timestamp (this value is used to recognize when a deployer is 'stuck' processing a deploy item).
-- `force-reconcile`: This is similar to `reconcile`, but the reconciliation should be 'enforced'. The meaning of this depends on the implementation of the deployer. For the provided deployers, a 'normal' reconcile usually checks the state of the deployitem and only acts if something has changed, while a 'forced' reconcile skips these checks and acts in every case.
-- `abort`: This annotation is usually attached to deploy items in the `Progressing` phase and means that the deployer should stop processing it. The main purpose of this annotation is to give the deployer time to gracefully stop processing the deploy item and clean up any already created resources before setting the phase to `Failed`. What 'aborting gracefully' means is highly specific to the corresponding deployer logic.
+#### 3. Check for Need for Action
+A deployer is only allowed to process a deploy item if `jobId` is not equal to `jobIdFinished`. The detailed protocol
+between the landscaper and the deployer was described above.
 
-The operation annotations are described in more detail [here](../usage/Annotations.md).
+#### 4. Deployer Logic and Status
+Now the deployer should do its magic. First it must set the status field `lastReconcileTime` on the current time thereby
+signaling the Landscaper that a deployer has picked up the deploy item.
 
-The second important annotation is `landscaper.gardener.cloud/reconcile-time`. The landscaper adds this annotation - with the current time as value - whenever it expands an `execution` into its deploy items. If this annotation is still present after a defined time, this is interpreted as no deployer having picked up this deploy item and the landscaper will set its phase to `Failed`. Deployers are expected to remove this annotation whenever they start reconciling a deploy item they are responsible for.
+As long as the deployer is actually doing something - or waiting for something - `deployItemPhase` must be set on 
+`Processing` or `Deleting` and `jobId` remains different from `jobIdFinished`. 
 
-For a detailed description of the different timeouts, please have a look at [DeployItem Timeouts](../usage/DeployItemTimeouts.md).
-
-#### 4. Handle Generation
-Another indicator that something needs to be done is when `status.observedGeneration` differs from `metadata.generation`. The latter one changes every time the `spec` is modified and a difference in both shows that the deployer has not yet reacted on the latest changes to this deploy item. For this logic to work, the deployer has to set `status.observedGeneration` to the deploy item's generation at the beginning of the reconcile loop. Similarly to the reconcile annotation, the deployer should set the phase of the deploy item to `Init` if it updated the observed generation.
-
-> There is an auxiliary method `HandleAnnotationsAndGeneration` that handles steps 3 and 4 [defined here](../../pkg/deployer/lib/utils.go).
-
-#### 5. Check for Need for Action
-For most deployers, there probably isn't anything to do now if the deploy item is still in a final state (phase `Succeeded` or `Failed`) - it was finished before and nothing has changed, so the reconcile can be aborted at this point. Please note that this does not apply to all deployers and only works if the phase is actually set to `Init` when a reconcile annotation or an outdated observed generation is found.
-
-#### 6. Deployer Logic and Status
-Now the deployer should do its magic. As long as it is actually doing something - or waiting for something - the deploy item's phase should be `Processing` (or `Deleting`, if it is handling the deletion of the deploy item).
 Some deployers need to store information in the deploy item's status during or after processing it.
 
-#### 7. Final State
-If the deployer successfully finished the task described by the deploy item, it must set the phase to `Succeeded`, if it wasn't successfuly and has given up trying, the phase has to be `Failed` instead.
+A deploy item is deleted by Landscaper. The deployer see this at the deletion timestamp. In such a situation, the deployer
+should uninstall the artefacts from the target and if this was successfull remove the finalizers from the deploy item.
+
+There is the following important annotation that needs to be handled by the deployer in case of a deletion:
+- `landscaper.gardener.cloud/delete-without-uninstall: true`: If this annotation is set at the deploy item and the deploy
+  item is deleted by the Landscaper, the deployer should remove the finalizer also if uninstalling the deployed artefacts
+  failed or even skip this uninstallation step at all.
+
+#### 5. Final State
+If the deployer successfully finished the task described by the deploy item, the deployer is required to set 
+`deployItemPhase` on `Succeeded` and `jobIdFinished` on the value of `jobId`.
+
+If it wasn't successfully and has given up trying, `deployItemPhase` has to be set on `Failed` and `jobIdFinished` 
+on the value of `jobId`.
 
 ## How is a Deployer installed
 
 A Deployer is basically a Kubernetes controller that watches DeployItems.
 By default, it's up to the administrator to install and update the deployers.
 
-As most deployer have a similar way to be installed, Landscaper offers a convenient way how to install and manage the complete lifecycle of a deployer.
-This LM (Lifecycle Management) also includes the management of different deployers across fenced environments.
+As most deployer have a similar way to be installed, Landscaper offers a convenient way how to install and manage the 
+complete lifecycle of a deployer. This LM (Lifecycle Management) also includes the management of different deployers 
+across fenced environments.
 
 A deployer has to implement the DLM contract (Deployer Lifecycle Management) to be managed by the landscaper.
 For a technical overview about the DLM see [here](./deployer_lifecycle_management.md).
 
 The DLM contract describes that the Installation of a Deployer has to be defined using a `Blueprint` (Component Descriptor + Blueprint).
-By default, the agent comes with a helm deployer so that all deployers can be installed using deploy items of type `landscaper.gardener.cloud/helm`.
-If other deployitems are needed to install your deployer, another deployer registration should be created for that deployer.
-With that the deployers will install each other as long there are no cyclic dependencies between them.
+By default, the agent comes with a helm deployer so that all deployers can be installed using deploy items of type 
+`landscaper.gardener.cloud/helm`. If other deployitems are needed to install your deployer, another deployer 
+registration should be created for that deployer. With that the deployers will install each other as long there are no 
+cyclic dependencies between them.
 
 The DLM offers some environment specific imports for the deployer blueprint:
 
@@ -204,7 +252,7 @@ imports:
             type: object
 ```
 
-Other imports can be freely used and configured using the `InstllationTemplate` in the `DeployerRegistration`.
+Other imports can be freely used and configured using the `InstallationTemplate` in the `DeployerRegistration`.
 
 ```yaml
 apiVersion: landscaper.gardener.cloud/v1alpha1

--- a/docs/tutorials/00-landscaper-installation.md
+++ b/docs/tutorials/00-landscaper-installation.md
@@ -24,6 +24,7 @@ The `landscaper-cli` can install the Landscaper together with an OCI registry. T
 
 First the helm values for the Landscaper configuration (`landscaper-values.yaml`) have to be created:
 
+
 ```yaml
 landscaper:
     landscaper:

--- a/docs/tutorials/01-create-simple-blueprint.md
+++ b/docs/tutorials/01-create-simple-blueprint.md
@@ -493,7 +493,7 @@ componentDescriptor:
     version: v0.3.2
 ```
 
-__Blueprint__: Once the Component Descriptor is known to the iinstallation, the Blueprint artifact can be referenced by its unique name `ingress-nginx-blueprint`.
+__Blueprint__: Once the Component Descriptor is known to the installation, the Blueprint artifact can be referenced by its unique name `ingress-nginx-blueprint`.
 
 ```yaml
 blueprint:
@@ -539,6 +539,10 @@ The final _Installation_ resource will look like the following YAML snippet.
 apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
   name: my-ingress
 spec:
   componentDescriptor:

--- a/docs/tutorials/03-simple-import.md
+++ b/docs/tutorials/03-simple-import.md
@@ -226,6 +226,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-echo-server
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/04-aggregated-blueprint.md
+++ b/docs/tutorials/04-aggregated-blueprint.md
@@ -292,6 +292,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-aggregation
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/05-external-jsonschema.md
+++ b/docs/tutorials/05-external-jsonschema.md
@@ -356,6 +356,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-echo-server
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/resources/aggregated/installation.yaml
+++ b/docs/tutorials/resources/aggregated/installation.yaml
@@ -6,6 +6,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-aggregation
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
      ref:

--- a/docs/tutorials/resources/echo-server/installation.yaml
+++ b/docs/tutorials/resources/echo-server/installation.yaml
@@ -6,6 +6,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-echo-server
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/resources/external-jsonschema/installation.yaml
+++ b/docs/tutorials/resources/external-jsonschema/installation.yaml
@@ -6,6 +6,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-echo-server
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/resources/ingress-nginx-upgrade/installation.yaml
+++ b/docs/tutorials/resources/ingress-nginx-upgrade/installation.yaml
@@ -6,6 +6,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-ingress
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/resources/ingress-nginx/installation.yaml
+++ b/docs/tutorials/resources/ingress-nginx/installation.yaml
@@ -6,6 +6,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-ingress
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/tutorials/resources/local-ingress-nginx/installation.yaml
+++ b/docs/tutorials/resources/local-ingress-nginx/installation.yaml
@@ -6,6 +6,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-ingress
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   componentDescriptor:
     ref:

--- a/docs/usage/Installations.md
+++ b/docs/usage/Installations.md
@@ -36,6 +36,10 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: Installation
 metadata:
   name: my-installation
+  annotations:
+    # this annotation is required such that the installation is picked up by the Landscaper
+    # it will be removed when processing has started
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   
   context: "" # defaults to "default"
@@ -114,7 +118,7 @@ spec:
       target: "" # reference a contextified target or a global taret with a '#' prefix.
 
 status:
-  phase: Progressing | Pending | Deleting | Completed | Failed
+  phase: Init | ObjectsCreated | Progressing | Completing | Succeeded | Failed | InitDelete | TriggerDelete | Deleting | DeleteFailed
 
   imports:
   - name: "" # logical internal name
@@ -984,16 +988,4 @@ spec:
 
 ## Operations
 
-The behavior of an installation is set by using operation annotations.
-These annotations are set automatically by the landscaper as part of the default reconciliation loop.
-An operator can also set annotations manually to enforce a specific behavior.
-
-- **`landscaper.gardener.cloud/operation`**:
-
-  - `reconcile`: start a default reconcile on the installation
-  - `force-reconcile`: skip the reconcile/pending check and directly start a new reconcilition flow. 
-    > **Warning:** Imports still have to be satisfied.
-  - `abort`: abort the current run which will abort all subinstallation but will wait until all current running components have finished.
- 
-- **`landscaper.gardener.cloud/skip`**: 
-  - `true`: skips the reconciliation of a component which means that it will not be triggered by configuration or import change.
+An operator can set annotations manually to enforce a specific behavior ([see](./Annotations.md)).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind api-change
/priority 3

**What this PR does / why we need it**:

This PR modifies parts of the documentation with respect to the new reconcile logic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
