### PR TITLE
fix documentation for deployersConfig

### DIFF
--- a/docs/gettingstarted/install-landscaper-controller.md
+++ b/docs/gettingstarted/install-landscaper-controller.md
@@ -126,14 +126,16 @@ landscaper:
     landscaper:
       deployers: [container, helm]
       deployersConfig:
-        # match the deployer name
-        container: 
-          # provide any helm charts values.
-          deployer:
-            oci:
-              allowPlainHttp: false
-        helm:
-          # ...
+        Deployers:
+          # match the deployer name
+          container:
+            deployer:
+              # provide any helm charts values.
+              oci:
+                allowPlainHttp: false
+          helm:
+            deployer:
+              # ...
 ```
 
 Additional external deployer can be either configured by applying the `DeployerRegistration` directly or providing the Registration in the helm chart.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug
/priority 3

**What this PR does / why we need it**:

Fix the description of the "deployersConfig" in the landscaper helm chart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
