### PR TITLE
Fix json representation of jobID

### DIFF
--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -97,10 +97,10 @@ type ExecutionStatus struct {
 	ExecutionGenerations []ExecutionGeneration `json:"execGenerations,omitempty"`
 
 	// JobID is the ID of the current working request.
-	JobID string `json:"JobID,omitempty"`
+	JobID string `json:"jobID,omitempty"`
 
 	// JobIDFinished is the ID of the finished working request.
-	JobIDFinished string `json:"JobIDFinished,omitempty"`
+	JobIDFinished string `json:"jobIDFinished,omitempty"`
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecPhase `json:"phase,omitempty"`

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -170,10 +170,10 @@ type ExecutionStatus struct {
 	ExecutionGenerations []ExecutionGeneration `json:"execGenerations,omitempty"`
 
 	// JobID is the ID of the current working request.
-	JobID string `json:"JobID,omitempty"`
+	JobID string `json:"jobID,omitempty"`
 
 	// JobIDFinished is the ID of the finished working request.
-	JobIDFinished string `json:"JobIDFinished,omitempty"`
+	JobIDFinished string `json:"jobIDFinished,omitempty"`
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecPhase `json:"phase,omitempty"`

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -5002,14 +5002,14 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionStatus(ref common.ReferenceCa
 							},
 						},
 					},
-					"JobID": {
+					"jobID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "JobID is the ID of the current working request.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"JobIDFinished": {
+					"jobIDFinished": {
 						SchemaProps: spec.SchemaProps{
 							Description: "JobIDFinished is the ID of the finished working request.",
 							Type:        []string{"string"},

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -97,10 +97,10 @@ type ExecutionStatus struct {
 	ExecutionGenerations []ExecutionGeneration `json:"execGenerations,omitempty"`
 
 	// JobID is the ID of the current working request.
-	JobID string `json:"JobID,omitempty"`
+	JobID string `json:"jobID,omitempty"`
 
 	// JobIDFinished is the ID of the finished working request.
-	JobIDFinished string `json:"JobIDFinished,omitempty"`
+	JobIDFinished string `json:"jobIDFinished,omitempty"`
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecPhase `json:"phase,omitempty"`

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -170,10 +170,10 @@ type ExecutionStatus struct {
 	ExecutionGenerations []ExecutionGeneration `json:"execGenerations,omitempty"`
 
 	// JobID is the ID of the current working request.
-	JobID string `json:"JobID,omitempty"`
+	JobID string `json:"jobID,omitempty"`
 
 	// JobIDFinished is the ID of the finished working request.
-	JobIDFinished string `json:"JobIDFinished,omitempty"`
+	JobIDFinished string `json:"jobIDFinished,omitempty"`
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecPhase `json:"phase,omitempty"`

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3515,7 +3515,7 @@ So in this case, the observedGeneration refers to the executions generation.</p>
 </tr>
 <tr>
 <td>
-<code>JobID</code></br>
+<code>jobID</code></br>
 <em>
 string
 </em>
@@ -3526,7 +3526,7 @@ string
 </tr>
 <tr>
 <td>
-<code>JobIDFinished</code></br>
+<code>jobIDFinished</code></br>
 <em>
 string
 </em>

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -113,12 +113,6 @@ spec:
           status:
             description: Status contains the current status of the execution.
             properties:
-              JobID:
-                description: JobID is the ID of the current working request.
-                type: string
-              JobIDFinished:
-                description: JobIDFinished is the ID of the finished working request.
-                type: string
               conditions:
                 description: Conditions contains the actual condition of a execution
                 items:
@@ -231,6 +225,12 @@ spec:
                 required:
                 - name
                 type: object
+              jobID:
+                description: JobID is the ID of the current working request.
+                type: string
+              jobIDFinished:
+                description: JobIDFinished is the ID of the finished working request.
+                type: string
               lastError:
                 description: LastError describes the last error that occurred.
                 properties:

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -97,10 +97,10 @@ type ExecutionStatus struct {
 	ExecutionGenerations []ExecutionGeneration `json:"execGenerations,omitempty"`
 
 	// JobID is the ID of the current working request.
-	JobID string `json:"JobID,omitempty"`
+	JobID string `json:"jobID,omitempty"`
 
 	// JobIDFinished is the ID of the finished working request.
-	JobIDFinished string `json:"JobIDFinished,omitempty"`
+	JobIDFinished string `json:"jobIDFinished,omitempty"`
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecPhase `json:"phase,omitempty"`

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -170,10 +170,10 @@ type ExecutionStatus struct {
 	ExecutionGenerations []ExecutionGeneration `json:"execGenerations,omitempty"`
 
 	// JobID is the ID of the current working request.
-	JobID string `json:"JobID,omitempty"`
+	JobID string `json:"jobID,omitempty"`
 
 	// JobIDFinished is the ID of the finished working request.
-	JobIDFinished string `json:"JobIDFinished,omitempty"`
+	JobIDFinished string `json:"jobIDFinished,omitempty"`
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecPhase `json:"phase,omitempty"`

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/defaults.go
@@ -29,4 +29,7 @@ func SetDefaults_GarbageCollection(obj *GarbageCollection) {
 	if obj.Worker <= 0 {
 		obj.Worker = 5
 	}
+	if obj.RequeueTimeSeconds <= 0 {
+		obj.RequeueTimeSeconds = 60
+	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request fixes the json/yaml representation of two fields `jobID` and `jobIDFinished` in the execution status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
