### PR TITLE
Fix documentation with respect to delete without uninstall

### DIFF
--- a/docs/technical/deployer_contract.md
+++ b/docs/technical/deployer_contract.md
@@ -177,8 +177,8 @@ should uninstall the artefacts from the target and if this was successfull remov
 
 There is the following important annotation that needs to be handled by the deployer in case of a deletion:
 - `landscaper.gardener.cloud/delete-without-uninstall: true`: If this annotation is set at the deploy item and the deploy
-  item is deleted by the Landscaper, the deployer should remove the finalizer also if uninstalling the deployed artefacts
-  failed or even skip this uninstallation step at all.
+  item is deleted by the Landscaper, the deployer should only remove the finalizer from the deploy item
+  without uninstalling the deployed artefacts.
 
 #### 5. Final State
 If the deployer successfully finished the task described by the deploy item, the deployer is required to set 

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -55,9 +55,8 @@ Setting this annotation at a deploy item has no effect.
 If the annotation `landscaper.gardener.cloud/delete-without-uninstall: "true"` has been added to an installation, then
 afterwards a deletion of the installation has the following effect:
 
-- the installation, its sub installations, executions, and deploy items will be deleted,
-- the installed artifacts on the target clusters will not be deleted. Particular deployer might try to uninstall the
-  artefacts on the target cluster first but if this step fails, they must continue, i.e. remove the finalizer at the 
-  deploy item.
+- The installation, its sub installations, executions, and deploy items will be deleted,
+- The installed artifacts on the target clusters will not be deleted. The deployers will only remove the finalizers at the 
+  deploy items such that they could be deleted.
 
 Note that you have to add the annotation **before** you delete the installation.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Fix documentation with respect to delete without uninstall. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
