### PR TITLE
Cleanup orphaned deploy items

### DIFF
--- a/apis/core/v1alpha1/helper/helpers.go
+++ b/apis/core/v1alpha1/helper/helpers.go
@@ -239,6 +239,16 @@ func SetVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObjectRef
 	return append(objects, obj)
 }
 
+// RemoveVersionedNamedObjectReference removes the first versioned object reference with the given name.
+func RemoveVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObjectReference, name string) []v1alpha1.VersionedNamedObjectReference {
+	for i, ref := range objects {
+		if ref.Name == name {
+			return append(objects[:i], objects[i+1:]...)
+		}
+	}
+	return objects
+}
+
 // IsCompletedInstallationPhase returns true if the phase indicates a final state.
 func IsCompletedInstallationPhase(phase v1alpha1.ComponentInstallationPhase) bool {
 	return phase == v1alpha1.ComponentPhaseFailed || phase == v1alpha1.ComponentPhaseAborted || phase == v1alpha1.ComponentPhaseSucceeded

--- a/pkg/landscaper/controllers/execution/testdata/test1/00-execution.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test1/00-execution.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: exec-1
+  namespace:  {{ .Namespace }}
+  generation: 2
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  deployItems:
+    - name: a
+      type: landscaper.gardener.cloud/helm
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+    - name: b
+      type: landscaper.gardener.cloud/helm
+      dependsOn:
+        - a
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+    - name: c
+      type: landscaper.gardener.cloud/helm
+      dependsOn:
+        - a
+        - b
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+
+status:
+  phase: Failed
+
+  observedGeneration: 2
+
+  deployItemRefs:
+  - name: a
+    ref:
+      name: di-a
+      namespace: test1
+      observedGeneration: 2
+  - name: b
+    ref:
+      name: di-b
+      namespace: test1
+      observedGeneration: 2
+  - name: c
+    ref:
+      name: di-c
+      namespace: test1
+      observedGeneration: 2
+  execGenerations:
+    - name: a
+      observedGeneration: 2
+    - name: b
+      observedGeneration: 2
+    - name: c
+      observedGeneration: 2

--- a/pkg/landscaper/controllers/execution/testdata/test1/10-deploy-item.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test1/10-deploy-item.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-a
+  namespace:  {{ .Namespace }}
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 2
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: a
+spec:
+  type: landscaper.gardener.cloud/helm
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+    my-val: val1
+
+status:
+  phase: Succeeded

--- a/pkg/landscaper/controllers/execution/testdata/test1/20-deploy-item.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test1/20-deploy-item.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-b
+  namespace:  {{ .Namespace }}
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 2
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: b
+spec:
+  type: landscaper.gardener.cloud/container
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+    my-val: val1
+
+status:
+  phase: Succeeded

--- a/pkg/landscaper/controllers/execution/testdata/test1/30-deploy-item.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test1/30-deploy-item.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-c
+  namespace:  {{ .Namespace }}
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 2
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: c
+spec:
+  type: landscaper.gardener.cloud/manifest
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+    my-val: val1
+
+status:
+  phase: Failed

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -333,3 +333,12 @@ func setExecutionGeneration(objects []lsv1alpha1.ExecutionGeneration, name strin
 	}
 	return append(objects, lsv1alpha1.ExecutionGeneration{Name: name, ObservedGeneration: gen})
 }
+
+func removeExecutionGeneration(objects []lsv1alpha1.ExecutionGeneration, name string) []lsv1alpha1.ExecutionGeneration {
+	for i, ref := range objects {
+		if ref.Name == name {
+			return append(objects[:i], objects[i+1:]...)
+		}
+	}
+	return objects
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -239,6 +239,16 @@ func SetVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObjectRef
 	return append(objects, obj)
 }
 
+// RemoveVersionedNamedObjectReference removes the first versioned object reference with the given name.
+func RemoveVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObjectReference, name string) []v1alpha1.VersionedNamedObjectReference {
+	for i, ref := range objects {
+		if ref.Name == name {
+			return append(objects[:i], objects[i+1:]...)
+		}
+	}
+	return objects
+}
+
 // IsCompletedInstallationPhase returns true if the phase indicates a final state.
 func IsCompletedInstallationPhase(phase v1alpha1.ComponentInstallationPhase) bool {
 	return phase == v1alpha1.ComponentPhaseFailed || phase == v1alpha1.ComponentPhaseAborted || phase == v1alpha1.ComponentPhaseSucceeded


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request fixes the deletion of orhaned deploy items.

Suppose an installation has several deploy items. You apply an update of the installation, that removes some of the deploy items. Then the new reconcile algorithm has not triggered the deletion of the removed deploy items. Moreover, the status of the execution was not adjusted (fields `DeployItemReferences` and `ExecutionGenerations`.) 

This is fixed in this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
