### PR TITLE
Webhook integration test: check installation phase

### DIFF
--- a/test/integration/webhook/webhook.go
+++ b/test/integration/webhook/webhook.go
@@ -108,11 +108,12 @@ func WebhookTest(f *framework.Framework) {
 			Expect(inst.Name).ToNot(BeEmpty()) // root installation should have been found
 
 			// apply root installation into cluster and wait for it to be succeeded
+			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
 			utils.ExpectNoError(state.Client.Create(ctx, inst))
-			Eventually(func() lsv1alpha1.ComponentInstallationPhase {
+			Eventually(func() lsv1alpha1.InstallationPhase {
 				utils.ExpectNoError(state.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
-				return inst.Status.Phase
-			}, 30*time.Second, 1*time.Second).Should(Equal(lsv1alpha1.ComponentPhaseSucceeded))
+				return inst.Status.InstallationPhase
+			}, 30*time.Second, 1*time.Second).Should(Equal(lsv1alpha1.InstallationPhaseSucceeded))
 
 			// make installation invalid by duplicating the first export
 			invalidInst := inst.DeepCopy()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR adapts the integration test for the webhook to the new reconcile logic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
