### PR TITLE
update golang version to 1.18 in release scripts

### DIFF
--- a/.ci/next_version
+++ b/.ci/next_version
@@ -9,8 +9,8 @@ set -o nounset
 set -o pipefail
 
 apk add --no-cache git make musl-dev curl
-curl -LO https://golang.org/dl/go1.16.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.16.linux-amd64.tar.gz
+curl -LO https://golang.org/dl/go1.18.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 

--- a/.ci/release
+++ b/.ci/release
@@ -9,8 +9,8 @@ set -o nounset
 set -o pipefail
 
 apk add --no-cache git make musl-dev curl
-curl -LO https://golang.org/dl/go1.16.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.16.linux-amd64.tar.gz
+curl -LO https://golang.org/dl/go1.18.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/priority 3

**What this PR does / why we need it**:

Update golang to version 1.18 in release scripts to match the golang version in go.mod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
