### PR TITLE
added timed wait for objects, created by the integration test, being deleted

### DIFF
--- a/test/integration/core/registry.go
+++ b/test/integration/core/registry.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	commonutils "github.com/gardener/landscaper/pkg/utils"
 
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
@@ -25,7 +27,6 @@ import (
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/landscaper/apis/mediatype"
@@ -124,14 +125,14 @@ func RegistryTest(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is already deleted or has an deletion timestamp
-			nginxDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				gomega.Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(gomega.BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nginxIngressObjectKey.Name,
+					Namespace: nginxIngressObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 }

--- a/test/integration/tutorial/external-jsonschema.go
+++ b/test/integration/tutorial/external-jsonschema.go
@@ -9,13 +9,14 @@ import (
 	"path/filepath"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
@@ -82,13 +83,14 @@ func ExternalJSONSchemaTest(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is alread deleted or has an deletion timestamp
-			err = f.Client.Get(ctx, echoServerDeploymentObjectKey, echoServerDeploy)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(echoServerDeploy.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress-nginx-controller",
+					Namespace: state.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 }
@@ -153,13 +155,14 @@ func ExternalJSONSchemaTestForNewReconcile(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is alread deleted or has an deletion timestamp
-			err = f.Client.Get(ctx, echoServerDeploymentObjectKey, echoServerDeploy)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(echoServerDeploy.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress-nginx-controller",
+					Namespace: state.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 }

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -9,13 +9,14 @@ import (
 	"path/filepath"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
@@ -101,14 +102,14 @@ func NginxIngressTest(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is already deleted or has an deletion timestamp
-			nginxDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nginxIngressObjectKey.Name,
+					Namespace: nginxIngressObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 
@@ -168,14 +169,14 @@ func NginxIngressTest(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is already deleted or has an deletion timestamp
-			nginxDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nginxIngressObjectKey.Name,
+					Namespace: nginxIngressObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 }
@@ -261,14 +262,14 @@ func NginxIngressTestForNewReconcile(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is already deleted or has an deletion timestamp
-			nginxDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nginxIngressObjectKey.Name,
+					Namespace: nginxIngressObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 
@@ -330,14 +331,14 @@ func NginxIngressTestForNewReconcile(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the nginx deployment is already deleted or has an deletion timestamp
-			nginxDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, nginxIngressObjectKey, nginxDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(nginxDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nginxIngressObjectKey.Name,
+					Namespace: nginxIngressObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 }

--- a/test/integration/tutorial/simple-import.go
+++ b/test/integration/tutorial/simple-import.go
@@ -9,13 +9,14 @@ import (
 	"path/filepath"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
@@ -88,18 +89,27 @@ func SimpleImport(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the echo server deployment is already deleted or has an deletion timestamp
-			echoServerDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, echoServerObjectKey, echoServerDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(echoServerDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the echo server deployment will be deleted
+			echoServerDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      echoServerObjectKey.Name,
+					Namespace: echoServerObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, echoServerDeployment, 2*time.Minute))
 
 			By("Delete nginx installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, nginxInst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxInst, 2*time.Minute))
+
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress-nginx-controller",
+					Namespace: state.Namespace,
+				},
+			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 
@@ -172,18 +182,27 @@ func SimpleImportForNewReconcile(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Delete(ctx, inst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, inst, 2*time.Minute))
 
-			// expect that the echo server deployment is already deleted or has an deletion timestamp
-			echoServerDeployment := &appsv1.Deployment{}
-			err = f.Client.Get(ctx, echoServerObjectKey, echoServerDeployment)
-			if err != nil && !apierrors.IsNotFound(err) {
-				utils.ExpectNoError(err)
-			} else if err == nil {
-				Expect(echoServerDeployment.DeletionTimestamp.IsZero()).To(BeTrue())
+			// expect that the echo server deployment will be deleted
+			echoServerDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      echoServerObjectKey.Name,
+					Namespace: echoServerObjectKey.Namespace,
+				},
 			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, echoServerDeployment, 2*time.Minute))
 
 			By("Delete nginx installation")
 			utils.ExpectNoError(f.Client.Delete(ctx, nginxInst))
 			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxInst, 2*time.Minute))
+
+			// expect that the nginx deployment will be deleted
+			nginxDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress-nginx-controller",
+					Namespace: state.Namespace,
+				},
+			}
+			utils.ExpectNoError(utils.WaitForObjectDeletion(ctx, f.Client, nginxDeployment, 2*time.Minute))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Currently for some deployments created by the integration test, we don't wait for the actual deleteion but only for the deletion timestamp being set.
This could lead to race conditions in the integration tests.
This PR adds a timed wait for these objects being actually being deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
