### PR TITLE
Fix delete

### DIFF
--- a/pkg/landscaper/execution/classification.go
+++ b/pkg/landscaper/execution/classification.go
@@ -134,6 +134,9 @@ func newDeployItemClassificationForDelete(executionJobID string, items []*execut
 		} else if item.DeployItem.Status.JobID == executionJobID {
 			if item.DeployItem.Status.JobID != item.DeployItem.Status.JobIDFinished {
 				c.runningItems = append(c.runningItems, item)
+			} else if item.DeployItem.Status.JobID == item.DeployItem.Status.JobIDFinished &&
+				item.DeployItem.Status.DeployItemPhase != lsv1alpha1.DeployItemPhaseFailed {
+				c.runningItems = append(c.runningItems, item)
 			} else {
 				c.failedItems = append(c.failedItems, item)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

During deletion, collect deploy items with a finished job id the same as the execution as running, if they are not in phase failed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
