### PR TITLE
Adjust deploy item refs in execution status

### DIFF
--- a/.ci/new-run-tests
+++ b/.ci/new-run-tests
@@ -22,7 +22,7 @@ SOURCE_PATH="$(pwd)"
 
 echo "Run tests"
 go test -timeout=60m -mod=vendor ./test/integration \
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor -ginkgo.seed=17 -ginkgo.failFast \
     --kubeconfig $KUBECONFIG_PATH \
     --registry-config=$REGISTRY_CONFIG \
     --ls-namespace=ls-system \

--- a/.test-defs/integration.yaml
+++ b/.test-defs/integration.yaml
@@ -10,7 +10,7 @@ spec:
   args:
   - >-
     go test -timeout=60m -mod=vendor ./test/integration
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor -ginkgo.seed=17 -ginkgo.failFast
     --kubeconfig $TM_KUBECONFIG_PATH/$CLUSTER_NAME.config
     --registry-config=$TM_SHARED_PATH/docker.config
     --ls-namespace=ls-system

--- a/pkg/landscaper/execution/gc.go
+++ b/pkg/landscaper/execution/gc.go
@@ -43,14 +43,6 @@ func (o *Operation) cleanupOrphanedDeployItemsForNewReconcile(ctx context.Contex
 		return nil
 	}
 	for _, item := range orphaned {
-		if item.DeletionTimestamp.IsZero() {
-			if err := o.Writer().DeleteDeployItem(ctx, read_write_layer.W000064, &item); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return fmt.Errorf("unable to delete deploy item %s", item.Name)
-				}
-			}
-		}
-
 		itemName, ok := item.Labels[lsv1alpha1.ExecutionManagedNameLabel]
 		if ok {
 			o.exec.Status.DeployItemReferences = helper.RemoveVersionedNamedObjectReference(o.exec.Status.DeployItemReferences, itemName)
@@ -58,6 +50,14 @@ func (o *Operation) cleanupOrphanedDeployItemsForNewReconcile(ctx context.Contex
 			if err := o.Writer().UpdateExecutionStatus(ctx, read_write_layer.W000146, o.exec); err != nil {
 				msg := fmt.Sprintf("unable to patch execution status %s", o.exec.Name)
 				return lserrors.NewWrappedError(err, "cleanupOrphanedDeployItemsForNewReconcile", msg, err.Error())
+			}
+		}
+
+		if item.DeletionTimestamp.IsZero() {
+			if err := o.Writer().DeleteDeployItem(ctx, read_write_layer.W000064, &item); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("unable to delete deploy item %s", item.Name)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

During the cleanup of orphaned deploy items it is more robust to proceed in the following order (currently it is the reversed order):
1. cleanup deploy item references in the execution status  
2. delete the deploy item  

Moreover, the `seed` an `failFast` Ginkgo options are set to achieve that the integration tests
- always run in the same order,  
- and stop after the first test that fails.  


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
