### PR TITLE
Improve delete

### DIFF
--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -50,9 +50,9 @@ func (c *Controller) handleDeletionPhaseInit(ctx context.Context, inst *lsv1alph
 			metav1.SetMetaDataAnnotation(&exec.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
 			if err := c.Writer().UpdateExecution(ctx, read_write_layer.W000102, exec); err != nil {
 				if apierrors.IsConflict(err) {
-					return nil, lserrors.NewWrappedError(err, op, "UpdateExecution", err.Error())
+					return nil, lserrors.NewWrappedError(err, op, "UpdateExecutionConflict", err.Error())
 				}
-				return lserrors.NewWrappedError(err, op, "UpdateExecutionConflict", err.Error()), nil
+				return lserrors.NewWrappedError(err, op, "UpdateExecution", err.Error()), nil
 			}
 		}
 

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -49,12 +49,18 @@ func (c *Controller) handleDeletionPhaseInit(ctx context.Context, inst *lsv1alph
 			!lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(exec.ObjectMeta) {
 			metav1.SetMetaDataAnnotation(&exec.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
 			if err := c.Writer().UpdateExecution(ctx, read_write_layer.W000102, exec); err != nil {
-				return lserrors.NewWrappedError(err, op, "UpdateExecution", err.Error()), nil
+				if apierrors.IsConflict(err) {
+					return nil, lserrors.NewWrappedError(err, op, "UpdateExecution", err.Error())
+				}
+				return lserrors.NewWrappedError(err, op, "UpdateExecutionConflict", err.Error()), nil
 			}
 		}
 
 		if exec.DeletionTimestamp.IsZero() {
 			if err = c.Writer().DeleteExecution(ctx, read_write_layer.W000012, exec); err != nil {
+				if apierrors.IsConflict(err) {
+					return nil, lserrors.NewWrappedError(err, op, "DeleteExecutionConflict", err.Error())
+				}
 				return lserrors.NewWrappedError(err, op, "DeleteExecution", err.Error()), nil
 			}
 		}
@@ -70,6 +76,9 @@ func (c *Controller) handleDeletionPhaseInit(ctx context.Context, inst *lsv1alph
 			!lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(subInst.ObjectMeta) {
 			metav1.SetMetaDataAnnotation(&subInst.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
 			if err := c.Writer().UpdateInstallation(ctx, read_write_layer.W000103, subInst); err != nil {
+				if apierrors.IsConflict(err) {
+					return nil, lserrors.NewWrappedError(err, op, "UpdateInstallationConflict", err.Error())
+				}
 				return lserrors.NewWrappedError(err, op, "UpdateInstallation", err.Error()), nil
 			}
 		}
@@ -77,7 +86,7 @@ func (c *Controller) handleDeletionPhaseInit(ctx context.Context, inst *lsv1alph
 		if subInst.DeletionTimestamp.IsZero() {
 			if err = c.Writer().DeleteInstallation(ctx, read_write_layer.W000091, subInst); err != nil {
 				if apierrors.IsConflict(err) {
-					return nil, lserrors.NewWrappedError(err, op, "IsConflict", err.Error())
+					return nil, lserrors.NewWrappedError(err, op, "DeleteInstallationConflict", err.Error())
 				}
 				return lserrors.NewWrappedError(err, op, "DeleteInstallation", err.Error()), nil
 			}
@@ -136,6 +145,23 @@ func (c *Controller) handleDeletionPhaseDeleting(ctx context.Context, inst *lsv1
 		if err = c.Writer().UpdateInstallation(ctx, read_write_layer.W000095, inst); err != nil {
 			return false, false, lserrors.NewWrappedError(err, op, "UpdateInstallation", err.Error())
 		}
+
+		// touch siblings to speed up processing
+		// a potential improvement is to only touch siblings exporting data for the current installation but this would
+		// result in more complex coding and should only be done if the current approach results in performance problems
+		_, siblings, err := installations.GetParentAndSiblings(ctx, c.Client(), inst)
+		if err != nil {
+			return false, false, lserrors.NewWrappedError(err, op, "GetParentAndSiblings", err.Error())
+		}
+		for _, nextSibling := range siblings {
+			if !nextSibling.DeletionTimestamp.IsZero() {
+				lsv1alpha1helper.Touch(&nextSibling.ObjectMeta)
+				if err = c.Writer().UpdateInstallation(ctx, read_write_layer.W000147, nextSibling); err != nil {
+					return false, false, lserrors.NewWrappedError(err, op, "TouchSibling", err.Error())
+				}
+			}
+		}
+
 		return true, true, nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR fixes:

- in case of some write conflicts the deletion of installations is retried
- deletion speed is improved for installations waiting for successors to be deleted for a long time by being touched if such a successor is removed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
