### PR TITLE
Fix nilpointer in execution controller

### DIFF
--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -138,7 +138,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logr.Logger, 
 		}
 
 		if !deployItemClassification.HasRunningItems() && deployItemClassification.HasFailedItems() {
-			err = lserrors.NewError(op, "handlePhaseProgressing", "failed sub objects")
+			err = lserrors.NewError(op, "handlePhaseProgressing", "has failed or missing deploy items")
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err, read_write_layer.W000134)
 		} else if !deployItemClassification.HasRunningItems() && !deployItemClassification.HasRunnableItems() && deployItemClassification.HasPendingItems() {
 			err = lserrors.NewError(op, "handlePhaseProgressing", "items could not be started")

--- a/pkg/landscaper/execution/classification.go
+++ b/pkg/landscaper/execution/classification.go
@@ -62,7 +62,12 @@ func newDeployItemClassification(executionJobID string, items []*executionItem) 
 	for i := range items {
 		item := items[i]
 
-		if item.DeployItem != nil && item.DeployItem.Status.JobID == executionJobID {
+		if item.DeployItem == nil {
+			// The items that we are classifying here were all created in the previous phase and should exist.
+			// But a user could have deleted items with "kubectl delete" or "landscaper-cli installations force-delete".
+			// We treat missing items as failed.
+			c.failedItems = append(c.failedItems, item)
+		} else if item.DeployItem.Status.JobID == executionJobID {
 			if item.DeployItem.Status.JobID != item.DeployItem.Status.JobIDFinished {
 				c.runningItems = append(c.runningItems, item)
 			} else if item.DeployItem.Status.DeployItemPhase == lsv1alpha1.DeployItemPhaseSucceeded {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

This PR fixes a nilpointer in the execution controller. 
The error can occur after a force-delete operation and can cause a restart of the landscaper pod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
