### PR TITLE
Improve logging framework

### DIFF
--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -133,6 +133,20 @@ func FromContext(ctx context.Context) (Logger, error) {
 	return Wrap(log), err
 }
 
+// FromContext wraps the result of logr.FromContext into a logging.Logger. If no logger exists a new one is created.
+func FromContextOrNew(ctx context.Context) Logger {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		log, err := GetLogger()
+		if err != nil {
+			panic(err)
+		}
+		return log
+	}
+	return Wrap(log)
+
+}
+
 // FromContextOrDiscard works like FromContext, but it will return a discard logger if no logger is found in the context.
 func FromContextOrDiscard(ctx context.Context) Logger {
 	log, err := FromContext(ctx)

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -133,6 +133,19 @@ func FromContext(ctx context.Context) (Logger, error) {
 	return Wrap(log), err
 }
 
+// FromContext wraps the result of logr.FromContext into a logging.Logger. If no logger exists a new one is created.
+func FromContextOrNew(ctx context.Context) Logger {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		log, err := GetLogger()
+		if err != nil {
+			panic(err)
+		}
+		return log
+	}
+	return Wrap(log)
+}
+
 // FromContextOrDiscard works like FromContext, but it will return a discard logger if no logger is found in the context.
 func FromContextOrDiscard(ctx context.Context) Logger {
 	log, err := FromContext(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

We need a method for getting a logger from the context also if there is no logger available. A panic in case of an error is no problem because in this case something went completely wrong and stopping the system is the best reaction.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
