### PR TITLE
Improve logging for installations

### DIFF
--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -107,7 +107,7 @@ func (c *Controller) reconcileNew(ctx context.Context, req reconcile.Request) (r
 	inst := &lsv1alpha1.Installation{}
 	if err := read_write_layer.GetInstallation(ctx, c.Client(), req.NamespacedName, inst); err != nil {
 		if apierrors.IsNotFound(err) {
-			c.Log().Debug(err.Error())
+			logger.Info(err.Error())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -179,7 +179,7 @@ func (c *Controller) reconcileOld(ctx context.Context, req reconcile.Request) (r
 	inst := &lsv1alpha1.Installation{}
 	if err := read_write_layer.GetInstallation(ctx, c.Client(), req.NamespacedName, inst); err != nil {
 		if apierrors.IsNotFound(err) {
-			c.Log().Debug(err.Error())
+			logger.Info(err.Error())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -216,7 +216,7 @@ func (c *Controller) reconcileOld(ctx context.Context, req reconcile.Request) (r
 
 	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.AbortOperation) {
 		// todo: handle abort..
-		c.Log().Info("do abort")
+		logger.Info("do abort")
 	}
 
 	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) {
@@ -237,6 +237,8 @@ func (c *Controller) reconcileOld(ctx context.Context, req reconcile.Request) (r
 // initPrerequisites prepares installation operations by fetching context and registries, resolving the blueprint and creating an internal installation.
 // It does not modify the installation resource in the cluster in any way.
 func (c *Controller) initPrerequisites(ctx context.Context, inst *lsv1alpha1.Installation) (*installations.Operation, lserrors.LsError) {
+	logger := logging.FromContext(ctx)
+
 	currOp := "InitPrerequisites"
 	op := c.Operation.Copy()
 

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -10,6 +10,8 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -201,6 +203,9 @@ func (c *Controller) handlePhaseInit(ctx context.Context, inst *lsv1alpha1.Insta
 
 func (c *Controller) init(ctx context.Context, inst *lsv1alpha1.Installation) (*installations.Operation,
 	*imports.Imports, string, map[string]*installations.InstallationBase, lserrors.LsError, lserrors.LsError) {
+
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
+
 	currentOperation := "init"
 
 	instOp, fatalError := c.initPrerequisites(ctx, inst)
@@ -255,7 +260,7 @@ func (c *Controller) init(ctx context.Context, inst *lsv1alpha1.Installation) (*
 		return nil, nil, "", nil, fatalError, nil
 	}
 
-	c.Log().Debug("imports hash computation", "hash", hash)
+	logger.Debug("imports hash computation", "hash", hash)
 
 	return instOp, imps, hash, predecessorMap, nil, nil
 }
@@ -344,6 +349,9 @@ func (c *Controller) handlePhaseProgressing(ctx context.Context, inst *lsv1alpha
 }
 
 func (c *Controller) handlePhaseCompleting(ctx context.Context, inst *lsv1alpha1.Installation) (lserrors.LsError, lserrors.LsError) {
+
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
+
 	currentOperation := "handlePhaseCompleting"
 
 	instOp, imps, importsHash, _, fatalError, fatalError2 := c.init(ctx, inst)
@@ -355,8 +363,7 @@ func (c *Controller) handlePhaseCompleting(ctx context.Context, inst *lsv1alpha1
 	}
 
 	if importsHash != inst.Status.ImportsHash {
-		c.Log().WithValues("oldHash", inst.Status.ImportsHash, "newHash", importsHash).Info("changed hash")
-
+		logger.Info("changed hash", "oldHash", inst.Status.ImportsHash, "newHash", importsHash)
 		return lserrors.NewError(currentOperation, "CheckImportsHash", "imports have changed"), nil
 	}
 
@@ -392,11 +399,12 @@ func (c *Controller) handlePhaseCompleting(ctx context.Context, inst *lsv1alpha1
 }
 
 func (c *Controller) reconcile(ctx context.Context, inst *lsv1alpha1.Installation) lserrors.LsError {
-	var (
-		currentOperation = "Validate"
-		log              = c.Log()
-	)
-	log.WithValues(lc.KeyMethod, "reconcile").Debug(lc.MsgStartMethod)
+
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
+
+	currentOperation := "Validate"
+
+	logger.Debug(lc.MsgStartMethod, lc.KeyMethod, "reconcile")
 
 	combinedState, lsErr := c.combinedPhaseOfSubobjects(ctx, inst, currentOperation)
 	if lsErr != nil {
@@ -404,7 +412,7 @@ func (c *Controller) reconcile(ctx context.Context, inst *lsv1alpha1.Installatio
 	}
 
 	if !lsv1alpha1helper.IsCompletedInstallationPhase(combinedState) {
-		log.Info("Waiting for all deploy items and nested installations to be completed")
+		logger.Info("Waiting for all deploy items and nested installations to be completed")
 		inst.Status.Phase = lsv1alpha1.ComponentPhaseProgressing
 		return nil
 	}
@@ -528,8 +536,12 @@ func (c *Controller) combinedPhaseOfSubobjects(ctx context.Context, inst *lsv1al
 }
 
 func (c *Controller) forceReconcile(ctx context.Context, inst *lsv1alpha1.Installation) lserrors.LsError {
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
+
 	currentOperation := "ForceReconcile"
-	c.Log().WithValues(lc.KeyMethod, "forceReconcile").Debug(lc.MsgStartMethod)
+
+	logger.Debug(lc.MsgStartMethod, lc.KeyMethod, "forceReconcile")
+
 	instOp, lsErr := c.initPrerequisites(ctx, inst)
 	if lsErr != nil {
 		return lsErr
@@ -636,8 +648,10 @@ func (c *Controller) Update(ctx context.Context, op *installations.Operation, im
 }
 
 func (c *Controller) removeReconcileAnnotation(ctx context.Context, inst *lsv1alpha1.Installation) lserrors.LsError {
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
+
 	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) {
-		c.Log().Debug("remove reconcile annotation")
+		logger.Debug("remove reconcile annotation")
 		delete(inst.Annotations, lsv1alpha1.OperationAnnotation)
 		if err := c.Writer().UpdateInstallation(ctx, read_write_layer.W000009, inst); client.IgnoreNotFound(err) != nil {
 			return lserrors.NewWrappedError(err, "RemoveReconcileAnnotation", "UpdateInstallation", err.Error())
@@ -647,8 +661,9 @@ func (c *Controller) removeReconcileAnnotation(ctx context.Context, inst *lsv1al
 }
 
 func (c *Controller) removeForceReconcileAnnotation(ctx context.Context, inst *lsv1alpha1.Installation) lserrors.LsError {
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
 	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
-		c.Log().Debug("remove force reconcile annotation")
+		logger.Debug("remove force reconcile annotation")
 		delete(inst.Annotations, lsv1alpha1.OperationAnnotation)
 		if err := c.Writer().UpdateInstallation(ctx, read_write_layer.W000003, inst); err != nil {
 			return lserrors.NewWrappedError(err, "RemoveForceReconcileAnnotation", "UpdateInstallation", err.Error())

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -9,6 +9,9 @@ import (
 	"errors"
 	"fmt"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+	"github.com/gardener/landscaper/pkg/utils"
+
 	"github.com/google/uuid"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -182,10 +185,9 @@ func (c *Controller) handleDeletionPhaseDeleting(ctx context.Context, inst *lsv1
 }
 
 func (c *Controller) handleDelete(ctx context.Context, inst *lsv1alpha1.Installation) lserrors.LsError {
-	var (
-		currentOperation = "handleDelete"
-		log              = c.Log()
-	)
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String())
+
+	currentOperation := "handleDelete"
 
 	inst.Status.Phase = lsv1alpha1.ComponentPhaseDeleting
 	inst.Status.ObservedGeneration = inst.GetGeneration()
@@ -218,7 +220,7 @@ func (c *Controller) handleDelete(ctx context.Context, inst *lsv1alpha1.Installa
 	// before A is completed. This occurs if the process of adding the deletion timestamps was interrupted after A and
 	// before B.
 	if !allCompletedOrWithDeletionTimestamp(exec, subinst) {
-		log.Debug("Waiting for execution and subinstallations to be completed")
+		logger.Debug("Waiting for execution and subinstallations to be completed")
 		return nil
 	}
 

--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -9,6 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+	"github.com/gardener/landscaper/pkg/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,6 +47,8 @@ func NewConstructor(op *installations.Operation) *Constructor {
 
 // Construct loads the exported data from the execution and the subinstallations.
 func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject, []*dataobjects.Target, error) {
+	logger, ctx := utils.FromContextOrNew(ctx, lc.KeyReconciledResource, client.ObjectKeyFromObject(c.Inst.Info).String())
+
 	var (
 		fldPath         = field.NewPath(fmt.Sprintf("(inst: %s)", c.Inst.Info.Name)).Child("internalExports")
 		internalExports = map[string]interface{}{
@@ -89,7 +94,7 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 		def, err := c.Inst.GetExportDefinition(name)
 		if err != nil {
 			// ignore additional exports
-			c.Log().Debug("key exported that is not defined by the blueprint", "name", name)
+			logger.Info("key exported that is not defined by the blueprint", "name", name)
 			delete(exports, name)
 			continue
 		}

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -235,7 +235,7 @@ func (o *Operation) cleanupOrphanedSubInstallations(ctx context.Context,
 		}
 
 		// delete installation
-		logger.Debug("delete orphaned installation", "name", subInst.Name)
+		logger.Info("delete orphaned installation", "name", subInst.Name)
 		if err := o.Writer().DeleteInstallation(ctx, read_write_layer.W000021, subInst); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -17,7 +17,7 @@ func FromContextOrNew(ctx context.Context, keysAndValuesForNewLogger ...interfac
 			panic(err)
 		}
 
-		newLogger = newLogger.WithValues(keysAndValuesForNewLogger)
+		newLogger = newLogger.WithValues("CreatedBy", "FromContextOrNew", keysAndValuesForNewLogger)
 		ctx = logging.NewContext(ctx, newLogger)
 		return newLogger, ctx
 	} else {

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"github.com/go-logr/logr"
+	"golang.org/x/net/context"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+)
+
+// FromContext wraps the result of logr.FromContext into a logging.Logger. If no logger exists a new one is created.
+// If a new logger has to be created, it logs with the provided keys and valuers
+func FromContextOrNew(ctx context.Context, keysAndValuesForNewLogger ...interface{}) (logging.Logger, context.Context) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		newLogger, err := logging.GetLogger()
+		if err != nil {
+			panic(err)
+		}
+
+		newLogger = newLogger.WithValues(keysAndValuesForNewLogger)
+		ctx = logging.NewContext(ctx, newLogger)
+		return newLogger, ctx
+	} else {
+		wrappedLogger := logging.Wrap(log)
+		ctx = logging.NewContext(ctx, wrappedLogger)
+		return wrappedLogger, ctx
+	}
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Implement new logging for installations controller

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
