### PR TITLE
Logging of the execution controller

### DIFF
--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -29,6 +29,10 @@ const (
 	KeyDeployItemPhase = "deployitemPhase"
 	// KeyWriteID is for a writer ID.
 	KeyWriteID = "writeID"
+	// KeyGeneration is for the generation of a resource.
+	KeyGeneration = "generation"
+	// KeyObservedGeneration is for the observed generation of a resource.
+	KeyObservedGeneration = "observedGeneration"
 	// KeyGenerationOld is for the old generation of a resource.
 	KeyGenerationOld = "oldGeneration"
 	// KeyGenerationNew is for the new generation of a resource.

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
+	golang.org/x/net v0.0.0-20220524220425-1d687d428aca
 	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/yaml.v3 v3.0.1
@@ -141,7 +142,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/net v0.0.0-20220524220425-1d687d428aca // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -10,36 +10,32 @@ import (
 	"reflect"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/gardener/landscaper/pkg/utils"
-
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	lserrors "github.com/gardener/landscaper/apis/errors"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	lserrors "github.com/gardener/landscaper/apis/errors"
+	"github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
 	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
 // NewController creates a new execution controller that reconcile Execution resources.
-func NewController(log logging.Logger, kubeClient client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder) (reconcile.Reconciler, error) {
+func NewController(logger logging.Logger, kubeClient client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder) (reconcile.Reconciler, error) {
 	return &controller{
-		log:           log,
+		log:           logger,
 		client:        kubeClient,
 		scheme:        scheme,
 		eventRecorder: eventRecorder,
@@ -63,11 +59,12 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 func (c *controller) reconcileNew(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := c.log.StartReconcile(req)
+	ctx = logging.NewContext(ctx, logger)
 
 	exec := &lsv1alpha1.Execution{}
 	if err := read_write_layer.GetExecution(ctx, c.client, req.NamespacedName, exec); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Debug(err.Error())
+			logger.Info(err.Error())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -81,7 +78,7 @@ func (c *controller) reconcileNew(ctx context.Context, req reconcile.Request) (r
 	}
 
 	if lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.InterruptOperation) {
-		if err := c.handleInterruptOperation(ctx, logger, exec); err != nil {
+		if err := c.handleInterruptOperation(ctx, exec); err != nil {
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil
@@ -90,7 +87,7 @@ func (c *controller) reconcileNew(ctx context.Context, req reconcile.Request) (r
 	if exec.Status.JobID != exec.Status.JobIDFinished {
 		// Execution is unfinished
 
-		err := c.handleReconcilePhase(ctx, logger, exec)
+		err := c.handleReconcilePhase(ctx, exec)
 		return reconcile.Result{}, err
 	} else {
 		// Execution is finished; nothing to do
@@ -98,7 +95,7 @@ func (c *controller) reconcileNew(ctx context.Context, req reconcile.Request) (r
 	}
 }
 
-func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) lserrors.LsError {
+func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
 	op := "handleReconcilePhase"
 
 	// A final or empty execution phase means that the current job was not yet started.
@@ -121,7 +118,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logge
 	}
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseInit {
-		if err := c.handlePhaseInit(ctx, log, exec); err != nil {
+		if err := c.handlePhaseInit(ctx, exec); err != nil {
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err, read_write_layer.W000131)
 		}
 
@@ -131,7 +128,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logge
 	}
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseProgressing {
-		deployItemClassification, err := c.handlePhaseProgressing(ctx, log, exec)
+		deployItemClassification, err := c.handlePhaseProgressing(ctx, exec)
 		if err != nil {
 			return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000133)
 		}
@@ -155,7 +152,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logge
 	}
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseCompleting {
-		if err := c.handlePhaseCompleting(ctx, log, exec); err != nil {
+		if err := c.handlePhaseCompleting(ctx, exec); err != nil {
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err, read_write_layer.W000138)
 		}
 
@@ -167,7 +164,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logge
 	// Handle deletion phases
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseInitDelete {
-		if err := c.handlePhaseInitDelete(ctx, log, exec); err != nil {
+		if err := c.handlePhaseInitDelete(ctx, exec); err != nil {
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseDeleteFailed, err, read_write_layer.W000140)
 		}
 
@@ -177,7 +174,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logge
 	}
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseDeleting {
-		deployItemClassification, err := c.handlePhaseDeleting(ctx, log, exec)
+		deployItemClassification, err := c.handlePhaseDeleting(ctx, exec)
 		if err != nil {
 			return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000142)
 		}
@@ -200,34 +197,41 @@ func (c *controller) handleReconcilePhase(ctx context.Context, log logging.Logge
 	return nil
 }
 
-func (c *controller) handlePhaseInit(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) lserrors.LsError {
+func (c *controller) handlePhaseInit(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.UpdateDeployItems(ctx)
 }
 
-func (c *controller) handlePhaseProgressing(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) (
+func (c *controller) handlePhaseProgressing(ctx context.Context, exec *lsv1alpha1.Execution) (
 	*execution.DeployItemClassification, lserrors.LsError) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.TriggerDeployItems(ctx)
 }
 
-func (c *controller) handlePhaseCompleting(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) lserrors.LsError {
+func (c *controller) handlePhaseCompleting(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.CollectAndUpdateExportsNew(ctx)
 }
 
-func (c *controller) handlePhaseInitDelete(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) lserrors.LsError {
+func (c *controller) handlePhaseInitDelete(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	op := "handlePhaseInitDelete"
 
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	managedItems, err := o.ListManagedDeployItems(ctx)
 	if err != nil {
@@ -257,22 +261,24 @@ func (c *controller) handlePhaseInitDelete(ctx context.Context, log logging.Logg
 	return nil
 }
 
-func (c *controller) handlePhaseDeleting(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) (
+func (c *controller) handlePhaseDeleting(ctx context.Context, exec *lsv1alpha1.Execution) (
 	*execution.DeployItemClassification, lserrors.LsError) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.TriggerDeployItemsForDelete(ctx)
 }
 
 func (c *controller) reconcileOld(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := c.log.StartReconcile(req)
+	ctx = logging.NewContext(ctx, logger)
 
 	exec := &lsv1alpha1.Execution{}
 	if err := read_write_layer.GetExecution(ctx, c.client, req.NamespacedName, exec); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Debug(err.Error())
+			logger.Info(err.Error())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -286,7 +292,7 @@ func (c *controller) reconcileOld(ctx context.Context, req reconcile.Request) (r
 
 	oldExec := exec.DeepCopy()
 
-	lsError := c.Ensure(ctx, logger, exec)
+	lsError := c.Ensure(ctx, exec)
 
 	lsErr2 := c.removeForceReconcileAnnotation(ctx, exec)
 	if lsError == nil {
@@ -295,11 +301,13 @@ func (c *controller) reconcileOld(ctx context.Context, req reconcile.Request) (r
 	}
 
 	isDelete := !exec.DeletionTimestamp.IsZero()
-	return reconcile.Result{}, handleError(ctx, lsError, logger, c.client, c.eventRecorder, oldExec, exec, isDelete)
+	return reconcile.Result{}, handleError(ctx, lsError, c.client, c.eventRecorder, oldExec, exec, isDelete)
 }
 
-func (c *controller) Ensure(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) lserrors.LsError {
-	if err := HandleAnnotationsAndGeneration(ctx, log, c.client, exec); err != nil {
+func (c *controller) Ensure(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
+	if err := HandleAnnotationsAndGeneration(ctx, c.client, exec); err != nil {
 		return err
 	}
 
@@ -311,7 +319,7 @@ func (c *controller) Ensure(ctx context.Context, log logging.Logger, exec *lsv1a
 	}
 
 	forceReconcile := lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
-	op := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec,
+	op := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec,
 		forceReconcile)
 
 	if !exec.DeletionTimestamp.IsZero() {
@@ -319,7 +327,7 @@ func (c *controller) Ensure(ctx context.Context, log logging.Logger, exec *lsv1a
 	}
 
 	if lsv1alpha1helper.IsCompletedExecutionPhase(exec.Status.Phase) {
-		err := op.HandleDeployItemPhaseAndGenerationChanges(ctx, log)
+		err := op.HandleDeployItemPhaseAndGenerationChanges(ctx)
 		if err != nil {
 			return lserrors.NewWrappedError(err, "Reconcile", "HandleDeployItemPhaseAndGenerationChanges", err.Error())
 		}
@@ -332,10 +340,12 @@ func (c *controller) Ensure(ctx context.Context, log logging.Logger, exec *lsv1a
 }
 
 func (c *controller) removeForceReconcileAnnotation(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	if lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.ForceReconcileOperation) {
 		old := exec.DeepCopy()
 		delete(exec.Annotations, lsv1alpha1.OperationAnnotation)
-		writer := read_write_layer.NewWriter(c.log, c.client)
+		writer := read_write_layer.NewWriter(logger, c.client)
 		if err := writer.PatchExecution(ctx, read_write_layer.W000029, exec, old); err != nil {
 			c.eventRecorder.Event(exec, corev1.EventTypeWarning, "RemoveForceReconcileAnnotation", err.Error())
 			return lserrors.NewWrappedError(err, "Reconcile", "RemoveForceReconcileAnnotation", err.Error())
@@ -348,7 +358,9 @@ func (c *controller) Writer() *read_write_layer.Writer {
 	return read_write_layer.NewWriter(c.log, c.client)
 }
 
-func (c *controller) handleInterruptOperation(ctx context.Context, log logging.Logger, exec *lsv1alpha1.Execution) error {
+func (c *controller) handleInterruptOperation(ctx context.Context, exec *lsv1alpha1.Execution) error {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	delete(exec.Annotations, lsv1alpha1.OperationAnnotation)
 	if err := c.Writer().UpdateExecution(ctx, read_write_layer.W000100, exec); err != nil {
 		return err
@@ -357,7 +369,7 @@ func (c *controller) handleInterruptOperation(ctx context.Context, log logging.L
 	op := "handleInterruptOperation"
 
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(log, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	managedItems, err := o.ListManagedDeployItems(ctx)
 	if err != nil {
@@ -389,11 +401,12 @@ func (c *controller) handleInterruptOperation(ctx context.Context, log logging.L
 
 func (c *controller) setExecutionPhaseAndUpdate(ctx context.Context, exec *lsv1alpha1.Execution,
 	phase lsv1alpha1.ExecPhase, lsErr lserrors.LsError, writeID read_write_layer.WriteID) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	exec.Status.LastError = lserrors.TryUpdateLsError(exec.Status.LastError, lsErr)
 
 	if lsErr != nil {
-		c.log.Error(lsErr, "setExecutionPhaseAndUpdate:"+lsErr.Error())
+		logger.Error(lsErr, "setExecutionPhaseAndUpdate")
 	}
 
 	exec.Status.ExecutionPhase = phase
@@ -416,7 +429,7 @@ func (c *controller) setExecutionPhaseAndUpdate(ctx context.Context, exec *lsv1a
 			}
 		}
 
-		c.log.Error(err, "unable to update status")
+		logger.Error(err, "unable to update status")
 
 		if lsErr == nil {
 			return lserrors.NewWrappedError(err, "setExecutionPhaseAndUpdate", "UpdateExecutionStatus", err.Error())
@@ -429,7 +442,9 @@ func (c *controller) setExecutionPhaseAndUpdate(ctx context.Context, exec *lsv1a
 // HandleAnnotationsAndGeneration is meant to be called at the beginning of the reconcile loop.
 // If a reconcile is needed due to the reconcile annotation or a change in the generation, it will set the phase to Init and remove the reconcile annotation.
 // Returns: an error, if updating the execution failed, nil otherwise
-func HandleAnnotationsAndGeneration(ctx context.Context, log logging.Logger, c client.Client, exec *lsv1alpha1.Execution) lserrors.LsError {
+func HandleAnnotationsAndGeneration(ctx context.Context, c client.Client, exec *lsv1alpha1.Execution) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	operation := "HandleAnnotationsAndGeneration"
 	hasReconcileAnnotation := lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.ReconcileOperation)
 	hasForceReconcileAnnotation := lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
@@ -439,33 +454,38 @@ func HandleAnnotationsAndGeneration(ctx context.Context, log logging.Logger, c c
 		// - force-reconcile annotation
 		// - outdated generation
 		opAnn := lsv1alpha1helper.GetOperation(exec.ObjectMeta)
-		log.Debug("reconcile required, setting observed generation and phase", "operationAnnotation", opAnn, "observedGeneration", exec.Status.ObservedGeneration, "generation", exec.Generation)
+		logger.Debug("reconcile required, setting observed generation and phase",
+			lc.KeyOperation, opAnn,
+			lc.KeyObservedGeneration, exec.Status.ObservedGeneration,
+			lc.KeyGeneration, exec.Generation)
 		exec.Status.ObservedGeneration = exec.Generation
 		exec.Status.Phase = lsv1alpha1.ExecutionPhaseInit
 
-		log.Debug("updating status")
-		writer := read_write_layer.NewWriter(log, c)
+		logger.Debug("updating status")
+		writer := read_write_layer.NewWriter(logger, c)
 		if err := writer.UpdateExecutionStatus(ctx, read_write_layer.W000033, exec); err != nil {
 			return lserrors.NewWrappedError(err, operation, "update execution status", err.Error())
 		}
-		log.Debug("successfully updated status")
+		logger.Debug("successfully updated status")
 	}
 	if hasReconcileAnnotation {
-		log.Debug("removing reconcile annotation")
+		logger.Debug("removing reconcile annotation")
 		delete(exec.ObjectMeta.Annotations, lsv1alpha1.OperationAnnotation)
-		log.Debug("updating metadata")
-		writer := read_write_layer.NewWriter(log, c)
+		logger.Debug("updating metadata")
+		writer := read_write_layer.NewWriter(logger, c)
 		if err := writer.UpdateExecution(ctx, read_write_layer.W000027, exec); err != nil {
 			return lserrors.NewWrappedError(err, operation, "update execution", err.Error())
 		}
-		log.Debug("successfully updated metadata")
+		logger.Debug("successfully updated metadata")
 	}
 
 	return nil
 }
 
-func handleError(ctx context.Context, err lserrors.LsError, log logging.Logger, c client.Client,
+func handleError(ctx context.Context, err lserrors.LsError, c client.Client,
 	eventRecorder record.EventRecorder, oldExec, exec *lsv1alpha1.Execution, isDelete bool) error {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	// if successfully deleted we could not update the object
 	if isDelete && err == nil {
 		exec2 := &lsv1alpha1.Execution{}
@@ -481,7 +501,7 @@ func handleError(ctx context.Context, err lserrors.LsError, log logging.Logger, 
 	// If err == nil and exec.Status.LastError != nil another object must change its state and initiate a new event
 	// for the execution exec.
 	if err != nil {
-		log.Error(err, "handleError")
+		logger.Error(err, "handleError")
 		exec.Status.LastError = lserrors.TryUpdateLsError(exec.Status.LastError, err)
 	}
 
@@ -497,12 +517,12 @@ func handleError(ctx context.Context, err lserrors.LsError, log logging.Logger, 
 	}
 
 	if !reflect.DeepEqual(oldExec.Status, exec.Status) {
-		writer := read_write_layer.NewWriter(log, c)
+		writer := read_write_layer.NewWriter(logger, c)
 		if updateErr := writer.UpdateExecutionStatus(ctx, read_write_layer.W000031, exec); updateErr != nil {
 			if apierrors.IsConflict(updateErr) { // reduce logging
-				log.Debug(fmt.Sprintf("unable to update status: %s", updateErr.Error()))
+				logger.Debug(fmt.Sprintf("unable to update status: %s", updateErr.Error()))
 			} else {
-				log.Error(updateErr, "unable to update status")
+				logger.Error(updateErr, "unable to update status")
 			}
 			return updateErr
 		}

--- a/pkg/landscaper/execution/execution.go
+++ b/pkg/landscaper/execution/execution.go
@@ -8,18 +8,17 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	lserrors "github.com/gardener/landscaper/apis/errors"
-	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
-
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	lserrors "github.com/gardener/landscaper/apis/errors"
+	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
 // Operation contains all execution operations
@@ -184,10 +183,12 @@ func (o *Operation) getDeployItems(ctx context.Context) ([]*executionItem, []lsv
 
 // UpdateStatus updates the status of a execution
 func (o *Operation) UpdateStatus(ctx context.Context, phase lsv1alpha1.ExecutionPhase, updatedConditions ...lsv1alpha1.Condition) error {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	o.exec.Status.Phase = phase
 	o.exec.Status.Conditions = lsv1alpha1helper.MergeConditions(o.exec.Status.Conditions, updatedConditions...)
 	if err := o.Writer().UpdateExecutionStatus(ctx, read_write_layer.W000032, o.exec); err != nil {
-		o.Log().Error(err, "unable to set installation status")
+		logger.Error(err, "unable to set installation status")
 		return err
 	}
 	return nil

--- a/pkg/landscaper/execution/helper.go
+++ b/pkg/landscaper/execution/helper.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -20,6 +18,7 @@ import (
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
 // ApplyDeployItemTemplate sets and updates the values defined by deploy item template on a deploy item.
@@ -86,7 +85,9 @@ func (o *Operation) getExecutionItems(items []lsv1alpha1.DeployItem) ([]*executi
 // HandleDeployItemPhaseAndGenerationChanges updates the phase of the given execution, if its phase doesn't match the combined phase of its deploy items anymore.
 // If a deploy item's generation differs from the observed one or a deploy item doesn't exist, the phase is set to 'Progressing'.
 // If the phase is changed to 'Succeeded', the exports of the deploy items are updated.
-func (o *Operation) HandleDeployItemPhaseAndGenerationChanges(ctx context.Context, logger logging.Logger) error {
+func (o *Operation) HandleDeployItemPhaseAndGenerationChanges(ctx context.Context) error {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
 	deployitems := []lsv1alpha1.DeployItem{}
 	phases := []lsv1alpha1.ExecutionPhase{}
 	// fetch all managed deploy items and check their phase and generation

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -29,6 +29,10 @@ const (
 	KeyDeployItemPhase = "deployitemPhase"
 	// KeyWriteID is for a writer ID.
 	KeyWriteID = "writeID"
+	// KeyGeneration is for the generation of a resource.
+	KeyGeneration = "generation"
+	// KeyObservedGeneration is for the observed generation of a resource.
+	KeyObservedGeneration = "observedGeneration"
 	// KeyGenerationOld is for the old generation of a resource.
 	KeyGenerationOld = "oldGeneration"
 	// KeyGenerationNew is for the new generation of a resource.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind task
/priority 3

**What this PR does / why we need it**:

This PR implements the new logging for the execution controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The utils/logging.go here is preliminary until the other pull requests for the logging are merged. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
