### PR TITLE
Logging of the deployitem controller (timeout controller)

### DIFF
--- a/pkg/landscaper/controllers/context/controller.go
+++ b/pkg/landscaper/controllers/context/controller.go
@@ -24,13 +24,13 @@ import (
 )
 
 // NewDefaulterController creates a new context controller that reconciles the default context object in the namespaces.
-func NewDefaulterController(log logging.Logger,
+func NewDefaulterController(logger logging.Logger,
 	kubeClient client.Client,
 	scheme *runtime.Scheme,
 	eventRecorder record.EventRecorder,
 	config config.ContextControllerConfig) (reconcile.Reconciler, error) {
 	return &defaulterController{
-		log:               log,
+		log:               logger,
 		client:            kubeClient,
 		scheme:            scheme,
 		eventRecorder:     eventRecorder,
@@ -52,12 +52,14 @@ func (c *defaulterController) Reconcile(ctx context.Context, req reconcile.Reque
 	if c.excludeNamespaces.Has(req.Name) {
 		return reconcile.Result{}, nil
 	}
+
 	logger := c.log.StartReconcile(req)
+	ctx = logging.NewContext(ctx, logger)
 
 	ns := &corev1.Namespace{}
 	if err := c.client.Get(ctx, req.NamespacedName, ns); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Debug(err.Error())
+			logger.Info(err.Error())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind task
/priority 3

**What this PR does / why we need it**:

This PR implements the new logging for the deployitem (timeout) controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
