### PR TITLE
Improve Logging Framework

### DIFF
--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -240,9 +240,16 @@ func StartReconcileFromContext(ctx context.Context, req reconcile.Request) (Logg
 	return log.StartReconcile(req), nil
 }
 
-// StartReconcile works like StartReconcile, but it is called on an existing logger instead of fetching one from the context.
-func (l Logger) StartReconcile(req reconcile.Request) Logger {
-	l = l.WithValues(lc.KeyReconciledResource, req.NamespacedName)
-	l.Info(lc.MsgStartReconcile)
-	return l
+// StartReconcile works like StartReconcileFromContext, but it is called on an existing logger instead of fetching one from the context.
+func (l Logger) StartReconcile(req reconcile.Request, keysAndValues ...interface{}) Logger {
+	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues)
+	newLogger.Info(lc.MsgStartReconcile)
+	return newLogger
+}
+
+// StartReconcileAndAddToContext works like StartReconcile, but additionally returns a context with the new logger.
+func (l Logger) StartReconcileAndAddToContext(ctx context.Context, req reconcile.Request, keysAndValues ...interface{}) (Logger, context.Context) {
+	newLogger := l.StartReconcile(req, keysAndValues)
+	ctx = NewContext(ctx, newLogger)
+	return newLogger, ctx
 }

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -26,7 +26,12 @@ Most often, k8s controllers watch a specific resource kind and react on changes 
 
 When setting up a logger for a controller, it is adviced to use the `log.Reconciles(name, kind)` method. This is basically a wrapper for `log.WithName(name).WithValues("reconciledResourceKind", kind)`. Use the singular form for both name and kind, with name being lower camel case and kind being upper camel case.
 
-At the beginning of a controller's `Reconcile` function, call either `logging.StartReconcileFromContext(ctx, req)` (if you don't have a logger available, this will try to fetch one from the context) or `log.StartReconcile(req)` (if you already have a logger), with `req` being the `reconcile.Request` object. The returned logger will then contain a key-value-pair with the namespaced name of the reconciled object. In addition, the function will print a log message that a new reconciliation has begun.
+At the beginning of a controller's `Reconcile` function, call either `logging.StartReconcileFromContext(ctx, req)` (if 
+you don't have a logger available, this will try to fetch one from the context) or `log.StartReconcile(req)` (if you 
+already have a logger), with `req` being the `reconcile.Request` object. The returned logger will then contain a 
+key-value-pair with the namespaced name of the reconciled object. In addition, the function will print a log message 
+that a new reconciliation has begun. Use `log.StartReconcileAndAddToContext(ctx, req,...)` if you need a new context 
+containing the new logger.
 
 #### Conventions for Names, Keys, and Messages
 

--- a/pkg/landscaper/controllers/healthcheck/controller.go
+++ b/pkg/landscaper/controllers/healthcheck/controller.go
@@ -47,7 +47,7 @@ type lsHealthCheckController struct {
 }
 
 func (c *lsHealthCheckController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := c.initialLogger.StartReconcile(req)
+	logger, ctx := c.initialLogger.StartReconcileAndAddToContext(ctx, req)
 
 	if req.Namespace != c.agentConfig.Namespace || req.Name != c.agentConfig.Name {
 		return reconcile.Result{}, nil

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -103,8 +103,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (c *Controller) reconcileNew(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := c.Log().StartReconcile(req)
-	ctx = logging.NewContext(ctx, logger)
+	logger, ctx := c.Log().StartReconcileAndAddToContext(ctx, req)
 
 	inst := &lsv1alpha1.Installation{}
 	if err := read_write_layer.GetInstallation(ctx, c.Client(), req.NamespacedName, inst); err != nil {
@@ -175,8 +174,7 @@ func (c *Controller) reconcileNew(ctx context.Context, req reconcile.Request) (r
 }
 
 func (c *Controller) reconcileOld(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := c.Log().StartReconcile(req)
-	ctx = logging.NewContext(ctx, logger)
+	logger, ctx := c.Log().StartReconcileAndAddToContext(ctx, req)
 
 	inst := &lsv1alpha1.Installation{}
 	if err := read_write_layer.GetInstallation(ctx, c.Client(), req.NamespacedName, inst); err != nil {

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -142,7 +142,7 @@ func FromContextOrDiscard(ctx context.Context) Logger {
 	return log
 }
 
-// FromContext wraps the result of logr.FromContext into a logging.Logger.
+// FromContextOrNew tries to fetch a logger from the context.
 // It is expected that a logger is contained in the context. If retrieving it fails, a new logger will be created and an error is logged.
 // keysAndValuesFallback contains keys and values which will only be added if the logger could not be retrieved and a new one had to be created.
 // The key-value-pairs from keysAndValues will always be added.
@@ -160,6 +160,19 @@ func FromContextOrNew(ctx context.Context, keysAndValuesFallback []interface{}, 
 		newLogger.Error(err2, "unable to fetch logger from context")
 		ctx = NewContext(ctx, newLogger)
 		return newLogger, ctx
+	}
+	log = log.WithValues(keysAndValues...)
+	ctx = NewContext(ctx, log)
+	return log, ctx
+}
+
+// FromContextWithFallback tries to fetch a logger from the context.
+// If that fails, the provided fallback logger is used instead.
+// It returns the fetched logger, enriched with the given key-value-pairs, and a context containing this new logger.
+func FromContextWithFallback(ctx context.Context, fallback Logger, keysAndValues ...interface{}) (Logger, context.Context) {
+	log, err := FromContext(ctx)
+	if err != nil {
+		log = fallback
 	}
 	log = log.WithValues(keysAndValues...)
 	ctx = NewContext(ctx, log)
@@ -227,9 +240,16 @@ func StartReconcileFromContext(ctx context.Context, req reconcile.Request) (Logg
 	return log.StartReconcile(req), nil
 }
 
-// StartReconcile works like StartReconcile, but it is called on an existing logger instead of fetching one from the context.
-func (l Logger) StartReconcile(req reconcile.Request) Logger {
-	l = l.WithValues(lc.KeyReconciledResource, req.NamespacedName)
-	l.Info(lc.MsgStartReconcile)
-	return l
+// StartReconcile works like StartReconcileFromContext, but it is called on an existing logger instead of fetching one from the context.
+func (l Logger) StartReconcile(req reconcile.Request, keysAndValues ...interface{}) Logger {
+	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues)
+	newLogger.Info(lc.MsgStartReconcile)
+	return newLogger
+}
+
+// StartReconcileAndAddToContext works like StartReconcile, but additionally returns a context with the new logger.
+func (l Logger) StartReconcileAndAddToContext(ctx context.Context, req reconcile.Request, keysAndValues ...interface{}) (Logger, context.Context) {
+	newLogger := l.StartReconcile(req, keysAndValues)
+	ctx = NewContext(ctx, newLogger)
+	return newLogger, ctx
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

More helper functions in logging framework.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
