### PR TITLE
improve logging in cmd package and agent

### DIFF
--- a/cmd/container-deployer/container-deployer-controller/app/app.go
+++ b/cmd/container-deployer/container-deployer-controller/app/app.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	containerctlr "github.com/gardener/landscaper/pkg/deployer/container"
 	"github.com/gardener/landscaper/pkg/version"
 )
@@ -34,6 +35,7 @@ func NewContainerDeployerControllerCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
+	o.DeployerOptions.Log.Info("Starting Container Deployer", lc.KeyVersion, version.Get().GitVersion)
 	if err := containerctlr.AddControllerToManager(o.DeployerOptions.Log,
 		o.DeployerOptions.HostMgr,
 		o.DeployerOptions.LsMgr,

--- a/cmd/container-deployer/container-deployer-init/app/app.go
+++ b/cmd/container-deployer/container-deployer-init/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/spf13/cobra"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	initpkg "github.com/gardener/landscaper/pkg/deployer/container/init"
 	"github.com/gardener/landscaper/pkg/version"
 )
@@ -38,7 +39,7 @@ func NewContainerDeployerInitCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) {
-	o.log.Info(fmt.Sprintf("starting init executor with version %s", version.Get().GitVersion))
+	o.log.Info("Starting init executor for container deployer", lc.KeyVersion, version.Get().GitVersion)
 	if err := initpkg.Run(ctx, o.log, osfs.New()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/container-deployer/container-deployer-wait/app/app.go
+++ b/cmd/container-deployer/container-deployer-wait/app/app.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/spf13/cobra"
 
 	"github.com/gardener/landscaper/pkg/deployer/container/wait"
@@ -39,7 +40,7 @@ It waits until the main container has finished, then back-ups the optional state
 }
 
 func (o *options) run(ctx context.Context) {
-	o.log.Info(fmt.Sprintf("running wait executor with version %s", version.Get().GitVersion))
+	o.log.Info("Starting wait executor for container deployer", lc.KeyVersion, version.Get().GitVersion)
 	if err := wait.Run(ctx, o.log); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/helm-deployer-controller/app/app.go
+++ b/cmd/helm-deployer-controller/app/app.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"fmt"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	"github.com/spf13/cobra"
 
 	helmctrl "github.com/gardener/landscaper/pkg/deployer/helm"
+	"github.com/gardener/landscaper/pkg/version"
 )
 
 func NewHelmDeployerControllerCommand(ctx context.Context) *cobra.Command {
@@ -33,7 +36,8 @@ func NewHelmDeployerControllerCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
-	if err := helmctrl.AddDeployerToManager(o.DeployerOptions.Log.WithName("deployer"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
+	o.DeployerOptions.Log.Info("Starting helm deployer", lc.KeyVersion, version.Get().GitVersion)
+	if err := helmctrl.AddDeployerToManager(o.DeployerOptions.Log.WithName("helm"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup helm controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/cmd/landscaper-agent/app/app.go
+++ b/cmd/landscaper-agent/app/app.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -27,12 +26,10 @@ func NewLandscaperAgentCommand(ctx context.Context) *cobra.Command {
 
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(); err != nil {
-				fmt.Print(err)
-				os.Exit(1)
+				panic(err)
 			}
 			if err := options.run(ctx); err != nil {
-				options.log.Error(err, "unable to run landscaper controller")
-				os.Exit(1)
+				panic(fmt.Errorf("unable to run landscaper controller: %w", err))
 			}
 		},
 	}
@@ -43,7 +40,7 @@ func NewLandscaperAgentCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
-	o.log.Info(fmt.Sprintf("Start Landscaper Agent with version %q", version.Get().String()))
+	o.log.Info("Starting Landscaper Agent", "version", version.Get().String())
 
 	if err := agent.AddToManager(ctx, o.log, o.LsMgr, o.HostMgr, o.config); err != nil {
 		return fmt.Errorf("unable to setup default agent: %w", err)

--- a/cmd/landscaper-agent/app/app.go
+++ b/cmd/landscaper-agent/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/agent"
 
 	"github.com/gardener/landscaper/pkg/version"
@@ -40,7 +41,7 @@ func NewLandscaperAgentCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
-	o.log.Info("Starting Landscaper Agent", "version", version.Get().String())
+	o.log.Info("Starting Landscaper Agent", lc.KeyVersion, version.Get().String())
 
 	if err := agent.AddToManager(ctx, o.log, o.LsMgr, o.HostMgr, o.config); err != nil {
 		return fmt.Errorf("unable to setup default agent: %w", err)

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	lsutils "github.com/gardener/landscaper/pkg/utils"
 
 	"golang.org/x/sync/errgroup"
@@ -76,7 +77,7 @@ func NewLandscaperControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *Options) run(ctx context.Context) error {
 	setupLogger := o.Log.WithName("setup")
-	setupLogger.Info(fmt.Sprintf("Start Landscaper Controller with version %q", version.Get().String()))
+	setupLogger.Info("Starting Landscaper Controller", lc.KeyVersion, version.Get().String())
 
 	configBytes, err := yaml.Marshal(o.Config)
 	if err != nil {

--- a/cmd/landscaper-webhooks-server/app/app.go
+++ b/cmd/landscaper-webhooks-server/app/app.go
@@ -26,6 +26,7 @@ import (
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	webhookcert "github.com/gardener/landscaper/controller-utils/pkg/webhook"
 	webhook "github.com/gardener/landscaper/pkg/utils/webhook"
 )
@@ -57,7 +58,7 @@ func NewLandscaperWebhooksCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
-	o.log.Info(fmt.Sprintf("Start Landscaper Webhooks Server with version %q", version.Get().String()))
+	o.log.Info("Starting Landscaper Webhooks Server", lc.KeyVersion, version.Get().String())
 
 	webhookServer := &ctrlwebhook.Server{
 		Port:       o.port,
@@ -88,8 +89,7 @@ func (o *options) run(ctx context.Context) error {
 	}
 
 	if err := webhookServer.Start(ctx); err != nil {
-		o.log.Error(err, "error while starting webhook server")
-		os.Exit(1)
+		panic(fmt.Errorf("error while starting webhook server: %w", err))
 	}
 	return nil
 }

--- a/cmd/manifest-deployer-controller/app/app.go
+++ b/cmd/manifest-deployer-controller/app/app.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	manifestctlr "github.com/gardener/landscaper/pkg/deployer/manifest"
+	"github.com/gardener/landscaper/pkg/version"
 )
 
 func NewManifestDeployerControllerCommand(ctx context.Context) *cobra.Command {
@@ -34,6 +36,7 @@ func NewManifestDeployerControllerCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
+	o.DeployerOptions.Log.Info("Starting Manifest Deployer", lc.KeyVersion, version.Get().GitVersion)
 	if err := manifestctlr.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup helm controller")
 	}

--- a/cmd/mock-deployer-controller/app/app.go
+++ b/cmd/mock-deployer-controller/app/app.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	mockctrl "github.com/gardener/landscaper/pkg/deployer/mock"
+	"github.com/gardener/landscaper/pkg/version"
 )
 
 func NewMockDeployerControllerCommand(ctx context.Context) *cobra.Command {
@@ -34,6 +36,7 @@ func NewMockDeployerControllerCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) run(ctx context.Context) error {
+	o.DeployerOptions.Log.Info("Starting Mock Deployer", lc.KeyVersion, version.Get().GitVersion)
 	if err := mockctrl.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup mock controller")
 	}

--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -45,6 +45,10 @@ const (
 	KeyJobID = "jobID"
 	// KeyJobIDFinished is for the ID of the finished job.
 	KeyJobIDFinished = "jobIDFinished"
+	// KeyVersion is for referencing a version
+	KeyVersion = "version"
+	// KeyDeletionTimestamp is for referencing a deletion timestamp. The value should be of type time.Time.
+	KeyDeletionTimestamp = "deletionTimestamp"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -242,14 +242,14 @@ func StartReconcileFromContext(ctx context.Context, req reconcile.Request) (Logg
 
 // StartReconcile works like StartReconcileFromContext, but it is called on an existing logger instead of fetching one from the context.
 func (l Logger) StartReconcile(req reconcile.Request, keysAndValues ...interface{}) Logger {
-	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues)
+	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues...)
 	newLogger.Info(lc.MsgStartReconcile)
 	return newLogger
 }
 
 // StartReconcileAndAddToContext works like StartReconcile, but additionally returns a context with the new logger.
 func (l Logger) StartReconcileAndAddToContext(ctx context.Context, req reconcile.Request, keysAndValues ...interface{}) (Logger, context.Context) {
-	newLogger := l.StartReconcile(req, keysAndValues)
+	newLogger := l.StartReconcile(req, keysAndValues...)
 	ctx = NewContext(ctx, newLogger)
 	return newLogger, ctx
 }

--- a/pkg/agent/add.go
+++ b/pkg/agent/add.go
@@ -27,7 +27,7 @@ import (
 
 // AddToManager adds the agent to the provided manager.
 func AddToManager(ctx context.Context, logger logging.Logger, lsMgr manager.Manager, hostMgr manager.Manager, config config.AgentConfiguration) error {
-	log := logger.WithName("agent").WithValues("responsibleForEnvironment", config.Name)
+	log := logger.WithName("agent").WithValues("targetEnvironment", config.Name)
 	ctx = logging.NewContext(ctx, log)
 	// create direct client for the agent to ensure the landscaper resources
 	lsClient, err := client.New(lsMgr.GetConfig(), client.Options{

--- a/pkg/agent/add.go
+++ b/pkg/agent/add.go
@@ -27,7 +27,8 @@ import (
 
 // AddToManager adds the agent to the provided manager.
 func AddToManager(ctx context.Context, logger logging.Logger, lsMgr manager.Manager, hostMgr manager.Manager, config config.AgentConfiguration) error {
-	log := logger.WithName("agent")
+	log := logger.WithName("agent").WithValues("responsibleForEnvironment", config.Name)
+	ctx = logging.NewContext(ctx, log)
 	// create direct client for the agent to ensure the landscaper resources
 	lsClient, err := client.New(lsMgr.GetConfig(), client.Options{
 		Scheme: lsMgr.GetScheme(),
@@ -41,8 +42,7 @@ func AddToManager(ctx context.Context, logger logging.Logger, lsMgr manager.Mana
 	if err != nil {
 		return fmt.Errorf("unable to create direct landscaper kubernetes client: %w", err)
 	}
-	agent := New(log,
-		lsMgr.GetClient(),
+	agent := New(lsMgr.GetClient(),
 		lsMgr.GetConfig(),
 		lsMgr.GetScheme(),
 		hostMgr.GetClient(),
@@ -60,7 +60,7 @@ func AddToManager(ctx context.Context, logger logging.Logger, lsMgr manager.Mana
 
 	err = builder.ControllerManagedBy(lsMgr).
 		For(&lsv1alpha1.Environment{}).
-		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Logr() }).
+		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Reconciles("environment", "Environment").Logr() }).
 		Complete(agent)
 	if err != nil {
 		return err

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -254,7 +254,7 @@ func (a *Agent) RemoveHostResources(ctx context.Context, kubeClient client.Clien
 func (a *Agent) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger, ctx := logging.MustStartReconcileFromContext(ctx, req, nil)
 	if req.Name != a.config.Name {
-		logger.Info("Not responsible for this environment", "targetEnvironment", a.config.Name)
+		logger.Info("Not responsible for this environment")
 		return reconcile.Result{}, nil
 	}
 	logger.Info("Ensuring Landscaper resources")

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -14,24 +14,27 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/utils"
 
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 )
 
 // Agent is the internal landscaper agent that contains all landscaper specific code.
 type Agent struct {
-	log            logging.Logger
 	config         config.AgentConfiguration
 	lsClient       client.Client
 	lsRestConfig   *rest.Config
@@ -42,8 +45,7 @@ type Agent struct {
 }
 
 // New creates a new agent.
-func New(log logging.Logger,
-	lsClient client.Client,
+func New(lsClient client.Client,
 	lsRestConfig *rest.Config,
 	lsScheme *runtime.Scheme,
 	hostClient client.Client,
@@ -51,7 +53,6 @@ func New(log logging.Logger,
 	hostScheme *runtime.Scheme,
 	config config.AgentConfiguration) *Agent {
 	return &Agent{
-		log:            log,
 		config:         config,
 		lsClient:       lsClient,
 		lsRestConfig:   lsRestConfig,
@@ -65,6 +66,7 @@ func New(log logging.Logger,
 // EnsureLandscaperResources ensures that all landscaper resources
 // like the Environment and the Target are registered in the landscaper cluster.
 func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostClient client.Client) (*lsv1alpha1.Environment, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "EnsureLandscaperResources")
 	target, err := utils.NewTargetBuilder(string(lsv1alpha1.KubernetesClusterTargetType)).
 		Config(lsv1alpha1.KubernetesClusterTargetConfig{
 			Kubeconfig: lsv1alpha1.ValueRef{
@@ -109,6 +111,7 @@ func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostCli
 
 	if err := lsClient.Get(ctx, kutil.ObjectKeyFromObject(env), env); err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Info("Environment not found, creating it")
 			mutateFunc()
 			if err := lsClient.Create(ctx, env); err != nil {
 				return nil, err
@@ -119,19 +122,24 @@ func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostCli
 	}
 
 	if !env.DeletionTimestamp.IsZero() {
+		logger.Debug("Environment has deletion timestamp", lc.KeyDeletionTimestamp, env.DeletionTimestamp.Time)
 		// the environment has the deployer management finalizer if there are still deployer installation
 		// therefore do nothing.
 		if !controllerutil.ContainsFinalizer(env, lsv1alpha1.LandscaperDMFinalizer) {
+			logger.Debug("Cleaning up resources")
 			// cleanup resources but do not remove the finalizer
 			// as we would otherwise just right directly reconcile a new environment.
 			if err := a.RemoveHostResources(ctx, hostClient); err != nil {
 				return nil, fmt.Errorf("unable to remove host resources: %w", err)
 			}
 			return env, nil
+		} else {
+			logger.Debug("Environment still has Landscaper deployer management finalizer")
 		}
 		// still update the environment to reconcile possible new configurations.
 	}
 
+	logger.Info("Updating Environment")
 	mutateFunc()
 	if err := lsClient.Update(ctx, env); err != nil {
 		return nil, err
@@ -144,24 +152,28 @@ func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostCli
 // The function ensure the following resources:
 // - the secret containing the kubeconfig for the host kubeconfig
 func (a *Agent) EnsureHostResources(ctx context.Context, kubeClient client.Client) (*rest.Config, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "EnsureHostResources")
 	// create a dedicated service account and rbac rules for the kubeconfig
 	// Currently that kubeconfig has access to all resources as the deployers could install anything.
 	// We might need to restrict that in the future but at least the access the be audited.
 	sa := &corev1.ServiceAccount{}
 	sa.Name = fmt.Sprintf("deployer-%s", a.config.Name)
 	sa.Namespace = a.config.Namespace
+	logger.Info("Creating/Updating resource", lc.KeyResource, kutil.ObjectKeyFromObject(sa).String(), lc.KeyResourceKind, "ServiceAccount")
 	if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, sa, func() error {
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("unable to create service account %q for deployer on host cluster: %w", sa.Name, err)
 	}
 	cr := DeployerClusterRole(a.config.Name)
+	logger.Info("Creating/Updating resource", lc.KeyResource, kutil.ObjectKeyFromObject(cr).String(), lc.KeyResourceKind, "ClusterRole")
 	if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, cr, func() error {
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("unable to create cluster role %q for deployer on host cluster: %w", cr.Name, err)
 	}
 	crb := DeployerClusterRoleBinding(sa, a.config.Name)
+	logger.Info("Creating/Updating resource", lc.KeyResource, kutil.ObjectKeyFromObject(crb).String(), lc.KeyResourceKind, "ClusterRoleBinding")
 	if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, crb, func() error {
 		crb.Subjects = DeployerClusterRoleBindingSubjects(sa)
 		return nil
@@ -171,7 +183,7 @@ func (a *Agent) EnsureHostResources(ctx context.Context, kubeClient client.Clien
 
 	hostRestConfig := rest.CopyConfig(a.hostRestConfig)
 	if err := kutil.AddServiceAccountToken(ctx, kubeClient, sa, hostRestConfig); err != nil {
-		a.log.Error(err, "unable to add a service account token", "service-account", sa.Name)
+		logger.Error(err, "unable to add a service account token", "service-account", sa.Name)
 		return nil, err
 	}
 
@@ -198,9 +210,11 @@ func (a *Agent) EnsureHostResources(ctx context.Context, kubeClient client.Clien
 
 // RemoveHostResources removes all resources created by the agent from the host.
 func (a *Agent) RemoveHostResources(ctx context.Context, kubeClient client.Client) error {
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "RemoveHostResources")
 	sa := &corev1.ServiceAccount{}
 	sa.Name = fmt.Sprintf("deployer-%s", a.config.Name)
 	sa.Namespace = a.config.Namespace
+	sa.SetGroupVersionKind(schema.GroupVersionKind{})
 	cr := DeployerClusterRole(a.config.Name)
 	crb := DeployerClusterRoleBinding(sa, a.config.Name)
 
@@ -211,6 +225,15 @@ func (a *Agent) RemoveHostResources(ctx context.Context, kubeClient client.Clien
 				continue
 			}
 			return err
+		}
+		if logger.Enabled(logging.DEBUG) {
+			log := logger.WithValues(lc.KeyResource, kutil.ObjectKeyFromObject(obj).String())
+			gvk, err := apiutil.GVKForObject(obj, api.LandscaperScheme)
+			if err != nil {
+				log.Error(err, "unable to find GVK for object")
+			} else {
+				log.Debug("Waiting for resource to be deleted", lc.KeyResourceKind, gvk.Kind)
+			}
 		}
 	}
 	err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (done bool, err error) {
@@ -229,17 +252,22 @@ func (a *Agent) RemoveHostResources(ctx context.Context, kubeClient client.Clien
 
 // Reconcile reconciles the environment and target on the landscaper.
 func (a *Agent) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger, ctx := logging.MustStartReconcileFromContext(ctx, req, nil)
 	if req.Name != a.config.Name {
+		logger.Info("Not responsible for this environment", "targetEnvironment", a.config.Name)
 		return reconcile.Result{}, nil
 	}
+	logger.Info("Ensuring Landscaper resources")
 	env, err := a.EnsureLandscaperResources(ctx, a.lsClient, a.hostClient)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if !env.DeletionTimestamp.IsZero() && !controllerutil.ContainsFinalizer(env, lsv1alpha1.LandscaperDMFinalizer) {
+		logger.Info("Environment is in deletion", lc.KeyDeletionTimestamp, env.DeletionTimestamp.Time)
 		return reconcile.Result{}, nil
 	}
+	logger.Info("Ensuring host resources")
 	if _, err := a.EnsureHostResources(ctx, a.hostClient); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -19,7 +19,6 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/agent"
 	"github.com/gardener/landscaper/pkg/api"
 )
@@ -41,8 +40,7 @@ var _ = Describe("Agent", func() {
 		agConfig = &config.AgentConfiguration{}
 		agConfig.Name = "testenv"
 		agConfig.Namespace = state.Namespace
-		ag = agent.New(logging.Discard(),
-			testenv.Client,
+		ag = agent.New(testenv.Client,
 			testenv.Env.Config,
 			api.LandscaperScheme,
 			testenv.Client,

--- a/pkg/deployer/lib/cmd/default.go
+++ b/pkg/deployer/lib/cmd/default.go
@@ -60,6 +60,7 @@ func (o *DefaultOptions) Complete() error {
 	if err != nil {
 		return err
 	}
+	log = log.WithName("deployer")
 	o.Log = log
 	ctrl.SetLogger(log.Logr())
 

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -45,6 +45,10 @@ const (
 	KeyJobID = "jobID"
 	// KeyJobIDFinished is for the ID of the finished job.
 	KeyJobIDFinished = "jobIDFinished"
+	// KeyVersion is for referencing a version
+	KeyVersion = "version"
+	// KeyDeletionTimestamp is for referencing a deletion timestamp. The value should be of type time.Time.
+	KeyDeletionTimestamp = "deletionTimestamp"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -242,14 +242,14 @@ func StartReconcileFromContext(ctx context.Context, req reconcile.Request) (Logg
 
 // StartReconcile works like StartReconcileFromContext, but it is called on an existing logger instead of fetching one from the context.
 func (l Logger) StartReconcile(req reconcile.Request, keysAndValues ...interface{}) Logger {
-	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues)
+	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues...)
 	newLogger.Info(lc.MsgStartReconcile)
 	return newLogger
 }
 
 // StartReconcileAndAddToContext works like StartReconcile, but additionally returns a context with the new logger.
 func (l Logger) StartReconcileAndAddToContext(ctx context.Context, req reconcile.Request, keysAndValues ...interface{}) (Logger, context.Context) {
-	newLogger := l.StartReconcile(req, keysAndValues)
+	newLogger := l.StartReconcile(req, keysAndValues...)
 	ctx = NewContext(ctx, newLogger)
 	return newLogger, ctx
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

Improves the logging in the `cmd` package as well as the agent.
Also fixes two minor bugs in the logging framework which cause the landscaper to panic shortly after the start.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
