### PR TITLE
Improve logging for registry

### DIFF
--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -45,6 +45,8 @@ const (
 	KeyJobID = "jobID"
 	// KeyJobIDFinished is for the ID of the finished job.
 	KeyJobIDFinished = "jobIDFinished"
+	// KeyCDName is the name of a component descriptor.
+	KeyCDName = "cdName"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Delete", func() {
 
 		BeforeEach(func() {
 			var err error
-			fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata")
+			fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata")
 			Expect(err).ToNot(HaveOccurred())
 
 			op = lsoperation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)

--- a/pkg/landscaper/controllers/installations/reconcile_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Reconcile", func() {
 
 		BeforeEach(func() {
 			var err error
-			fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata")
+			fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata")
 			Expect(err).ToNot(HaveOccurred())
 
 			op = lsoperation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -38,7 +38,7 @@ func (c *Controller) SetupRegistries(ctx context.Context, op *operation.Operatio
 		return fmt.Errorf("unable to create component registry manager: %w", err)
 	}
 	if c.LsConfig.Registry.Local != nil {
-		componentsOCIRegistry, err := componentsregistry.NewLocalClient(logger, c.LsConfig.Registry.Local.RootPath)
+		componentsOCIRegistry, err := componentsregistry.NewLocalClient(c.LsConfig.Registry.Local.RootPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Context", func() {
 
 		fakeClient = testenv.Client
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)

--- a/pkg/landscaper/installations/executions/executions_test.go
+++ b/pkg/landscaper/installations/executions/executions_test.go
@@ -64,7 +64,7 @@ var _ = Describe("DeployItemExecutions", func() {
 		createDefaultContextsForNamespace(fakeClient)
 		fakeInstallations = state.Installations
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/executions/operation_test.go
+++ b/pkg/landscaper/installations/executions/operation_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Execution Operation", func() {
 		kClient = testenv.Client
 		testInstallations = state.Installations
 
-		componentResolver, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata/registry")
+		componentResolver, err = componentsregistry.NewLocalClient("./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 		repository := componentsregistry.NewLocalRepository("./testdata/registry")
 

--- a/pkg/landscaper/installations/exports/constructor_test.go
+++ b/pkg/landscaper/installations/exports/constructor_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Constructor", func() {
 		fakeInstallations = state.Installations
 		Expect(testutils.CreateExampleDefaultContext(context.TODO(), fakeClient, "test1", "test2", "test3", "test4", "test5", "test6"))
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "../testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("../testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/imports/conditional_imports_test.go
+++ b/pkg/landscaper/installations/imports/conditional_imports_test.go
@@ -56,7 +56,7 @@ var _ = Describe("ConditionalImports", func() {
 
 		createDefaultContextsForNamespace(fakeClient)
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "../testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("../testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Constructor", func() {
 		createDefaultContextsForNamespace(fakeClient)
 		fakeInstallations = state.Installations
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "../testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("../testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/imports/importexec_test.go
+++ b/pkg/landscaper/installations/imports/importexec_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ImportExecutions", func() {
 		createDefaultContextsForNamespace(fakeClient)
 		fakeInstallations = state.Installations
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "../testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("../testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/reconcilehelper/outdated_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/outdated_test.go
@@ -44,7 +44,7 @@ var _ = Describe("OutdatedImports", func() {
 		createDefaultContextsForNamespaces(fakeClient)
 		fakeInstallations = state.Installations
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "../testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("../testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/reconcilehelper/validation_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/validation_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Validation", func() {
 		createDefaultContextsForNamespaces(fakeClient)
 		fakeInstallations = state.Installations
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "../testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("../testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -118,7 +118,7 @@ var _ = Describe("SubInstallation", func() {
 
 		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8", "test9", "test10", "test11", "test12")).To(Succeed())
 
-		fakeCompRepo, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata/registry")
+		fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
 		op, err = lsoperation.NewBuilder().

--- a/pkg/landscaper/jsonschema/jsonschema_suite_test.go
+++ b/pkg/landscaper/jsonschema/jsonschema_suite_test.go
@@ -765,7 +765,7 @@ var _ = Describe("jsonschema", func() {
 		BeforeEach(func() {
 			var err error
 
-			registry, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata/registry")
+			registry, err = componentsregistry.NewLocalClient("./testdata/registry")
 			Expect(err).ToNot(HaveOccurred())
 
 			repository = componentsregistry.NewLocalRepository("./testdata/registry")

--- a/pkg/landscaper/registry/components/manager.go
+++ b/pkg/landscaper/registry/components/manager.go
@@ -12,10 +12,6 @@ import (
 	"github.com/gardener/component-spec/bindings-go/ctf"
 
 	"github.com/gardener/component-cli/ociclient/cache"
-
-	"github.com/gardener/landscaper/apis/config"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	"github.com/gardener/landscaper/pkg/utils"
 )
 
 // TypedRegistry describes a registry that can handle the given type.
@@ -74,17 +70,4 @@ func (m *Manager) ResolveWithBlobResolver(ctx context.Context, repoCtx cdv2.Repo
 		return nil, nil, fmt.Errorf("unknown repository type %s", repoCtx.GetType())
 	}
 	return client.ResolveWithBlobResolver(ctx, repoCtx, name, version)
-}
-
-// SetupManagerFromConfig returns a new Manager instance initialized with the given OCI configuration
-func SetupManagerFromConfig(log logging.Logger, config *config.OCIConfiguration, cacheIdentifier string) (*Manager, error) {
-	var sharedCache cache.Cache
-	if config != nil && config.Cache != nil {
-		var err error
-		sharedCache, err = cache.NewCache(log.Logr(), utils.ToOCICacheOptions(config.Cache, cacheIdentifier)...)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return New(sharedCache)
 }

--- a/pkg/utils/landscaper/installation_simulator_test.go
+++ b/pkg/utils/landscaper/installation_simulator_test.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	lsutils "github.com/gardener/landscaper/pkg/utils/landscaper"
@@ -84,7 +83,7 @@ var _ = Describe("Installation Simulator", func() {
 		ctx := context.Background()
 		defer ctx.Done()
 
-		registry, err = componentsregistry.NewLocalClient(logging.Discard(), testDataDir)
+		registry, err = componentsregistry.NewLocalClient(testDataDir)
 		Expect(err).ToNot(HaveOccurred())
 		repository = componentsregistry.NewLocalRepository(testDataDir)
 

--- a/test/landscaper/e2e/inlinecd_test.go
+++ b/test/landscaper/e2e/inlinecd_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Inline Component Descriptor", func() {
 
 	BeforeEach(func() {
 		var err error
-		fakeComponentRegistry, err = componentsregistry.NewLocalClient(logging.Discard(), filepath.Join(projectRoot, "examples", "02-inline-cd"))
+		fakeComponentRegistry, err = componentsregistry.NewLocalClient(filepath.Join(projectRoot, "examples", "02-inline-cd"))
 		Expect(err).ToNot(HaveOccurred())
 
 		op := operation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Simple", func() {
 
 	BeforeEach(func() {
 		var err error
-		fakeComponentRegistry, err = componentsregistry.NewLocalClient(logging.Discard(), filepath.Join(projectRoot, "examples", "01-simple"))
+		fakeComponentRegistry, err = componentsregistry.NewLocalClient(filepath.Join(projectRoot, "examples", "01-simple"))
 		Expect(err).ToNot(HaveOccurred())
 
 		op := operation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeComponentRegistry)

--- a/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
+++ b/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 
 	. "github.com/onsi/ginkgo"
@@ -116,7 +115,7 @@ var _ = Describe("Landscaper Service Component", func() {
 		ctx := context.Background()
 		defer ctx.Done()
 
-		registry, err = componentsregistry.NewLocalClient(logging.Discard(), "./testdata/registry")
+		registry, err = componentsregistry.NewLocalClient("./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 		repository = componentsregistry.NewLocalRepository("./testdata/registry")
 

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -45,6 +45,8 @@ const (
 	KeyJobID = "jobID"
 	// KeyJobIDFinished is for the ID of the finished job.
 	KeyJobIDFinished = "jobIDFinished"
+	// KeyCDName is the name of a component descriptor.
+	KeyCDName = "cdName"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Improve logging for registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
