### PR TITLE
Improve logging for controller-utils

### DIFF
--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -241,7 +241,8 @@ func (o *Options) DeployInternalDeployers(ctx context.Context, mgr manager.Manag
 }
 
 func (o *Options) ensureCRDs(ctx context.Context, mgr manager.Manager) error {
-	crdmgr, err := crdmanager.NewCrdManager(logging.Wrap(ctrl.Log.WithName("crdManager")), mgr, o.Config)
+	ctx = logging.NewContext(ctx, logging.Wrap(ctrl.Log.WithName("crdManager")))
+	crdmgr, err := crdmanager.NewCrdManager(mgr, o.Config)
 	if err != nil {
 		return fmt.Errorf("unable to setup CRD manager: %w", err)
 	}

--- a/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/controller-utils/pkg/kubernetes/kubernetes.go
@@ -532,7 +532,7 @@ func DecodeObjects(log logging.Logger, name string, data []byte) ([]*unstructure
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, fmt.Sprintf("unable to decode resource %d of file %q", i, name))
+			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
 			continue
 		}
 		if decodedObj == nil {
@@ -561,7 +561,8 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, fmt.Sprintf("unable to decode resource %d of file %q", i, name))
+			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
+
 			continue
 		}
 		if obj == nil || obj.Raw == nil {
@@ -570,7 +571,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 		// ignore the obj if no group version is defined
 		var typeMeta runtime.TypeMeta
 		if err := json.Unmarshal(obj.Raw, &typeMeta); err != nil {
-			log.Error(err, fmt.Sprintf("unable to parse type meta %d of file %q to runtime object", i, name))
+			log.Error(err, "unable to parse type meta", "resourceIndex", i, "resourceName", name)
 			continue
 		}
 		if typeMeta.GetObjectKind().GroupVersionKind().Empty() {

--- a/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/controller-utils/pkg/kubernetes/kubernetes.go
@@ -532,7 +532,7 @@ func DecodeObjects(log logging.Logger, name string, data []byte) ([]*unstructure
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
+			log.Error(err, "unable to decode resource", "resourceIndex", i, "fileName", name)
 			continue
 		}
 		if decodedObj == nil {
@@ -561,7 +561,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
+			log.Error(err, "unable to decode resource", "resourceIndex", i, "fileName", name)
 
 			continue
 		}
@@ -571,7 +571,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 		// ignore the obj if no group version is defined
 		var typeMeta runtime.TypeMeta
 		if err := json.Unmarshal(obj.Raw, &typeMeta); err != nil {
-			log.Error(err, "unable to parse type meta", "resourceIndex", i, "resourceName", name)
+			log.Error(err, "unable to parse type meta", "resourceIndex", i, "fileName", name)
 			continue
 		}
 		if typeMeta.GetObjectKind().GroupVersionKind().Empty() {

--- a/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/controller-utils/pkg/kubernetes/kubernetes.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"time"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -532,7 +534,7 @@ func DecodeObjects(log logging.Logger, name string, data []byte) ([]*unstructure
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, "unable to decode resource", "resourceIndex", i, "fileName", name)
+			log.Error(err, "unable to decode resource", lc.KeyIndex, i, lc.KeyFileName, name)
 			continue
 		}
 		if decodedObj == nil {
@@ -561,7 +563,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, "unable to decode resource", "resourceIndex", i, "fileName", name)
+			log.Error(err, "unable to decode resource", lc.KeyIndex, i, lc.KeyFileName, name)
 
 			continue
 		}
@@ -571,7 +573,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 		// ignore the obj if no group version is defined
 		var typeMeta runtime.TypeMeta
 		if err := json.Unmarshal(obj.Raw, &typeMeta); err != nil {
-			log.Error(err, "unable to parse type meta", "resourceIndex", i, "fileName", name)
+			log.Error(err, "unable to parse type meta", lc.KeyIndex, i, lc.KeyFileName, name)
 			continue
 		}
 		if typeMeta.GetObjectKind().GroupVersionKind().Empty() {

--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -49,6 +49,10 @@ const (
 	KeyVersion = "version"
 	// KeyDeletionTimestamp is for referencing a deletion timestamp. The value should be of type time.Time.
 	KeyDeletionTimestamp = "deletionTimestamp"
+	// KeyIndex is for generic numeric indexes.
+	KeyIndex = "index"
+	// KeyFileName is for the name of a file.
+	KeyFileName = "fileName"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/pkg/landscaper/crdmanager/crdmanager.go
+++ b/pkg/landscaper/crdmanager/crdmanager.go
@@ -7,11 +7,10 @@ package crdmanager
 import (
 	"embed"
 
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"github.com/gardener/landscaper/apis/config"
 	"github.com/gardener/landscaper/controller-utils/pkg/crdmanager"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -22,6 +21,6 @@ const (
 var importedCrdFS embed.FS
 
 // NewCrdManager returns a new instance of the CRDManager
-func NewCrdManager(log logging.Logger, mgr manager.Manager, lsConfig *config.LandscaperConfiguration) (*crdmanager.CRDManager, error) {
-	return crdmanager.NewCrdManager(log, mgr, lsConfig.CrdManagement, &importedCrdFS, embedFSCrdRootDir)
+func NewCrdManager(mgr manager.Manager, lsConfig *config.LandscaperConfiguration) (*crdmanager.CRDManager, error) {
+	return crdmanager.NewCrdManager(mgr, lsConfig.CrdManagement, &importedCrdFS, embedFSCrdRootDir)
 }

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/kubernetes.go
@@ -532,7 +532,7 @@ func DecodeObjects(log logging.Logger, name string, data []byte) ([]*unstructure
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, fmt.Sprintf("unable to decode resource %d of file %q", i, name))
+			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
 			continue
 		}
 		if decodedObj == nil {
@@ -561,7 +561,8 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, fmt.Sprintf("unable to decode resource %d of file %q", i, name))
+			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
+
 			continue
 		}
 		if obj == nil || obj.Raw == nil {
@@ -570,7 +571,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 		// ignore the obj if no group version is defined
 		var typeMeta runtime.TypeMeta
 		if err := json.Unmarshal(obj.Raw, &typeMeta); err != nil {
-			log.Error(err, fmt.Sprintf("unable to parse type meta %d of file %q to runtime object", i, name))
+			log.Error(err, "unable to parse type meta", "resourceIndex", i, "resourceName", name)
 			continue
 		}
 		if typeMeta.GetObjectKind().GroupVersionKind().Empty() {

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/kubernetes/kubernetes.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"time"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -532,7 +534,7 @@ func DecodeObjects(log logging.Logger, name string, data []byte) ([]*unstructure
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
+			log.Error(err, "unable to decode resource", lc.KeyIndex, i, lc.KeyFileName, name)
 			continue
 		}
 		if decodedObj == nil {
@@ -561,7 +563,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 			if err == io.EOF {
 				break
 			}
-			log.Error(err, "unable to decode resource", "resourceIndex", i, "resourceName", name)
+			log.Error(err, "unable to decode resource", lc.KeyIndex, i, lc.KeyFileName, name)
 
 			continue
 		}
@@ -571,7 +573,7 @@ func DecodeObjectsToRawExtension(log logging.Logger, name string, data []byte) (
 		// ignore the obj if no group version is defined
 		var typeMeta runtime.TypeMeta
 		if err := json.Unmarshal(obj.Raw, &typeMeta); err != nil {
-			log.Error(err, "unable to parse type meta", "resourceIndex", i, "resourceName", name)
+			log.Error(err, "unable to parse type meta", lc.KeyIndex, i, lc.KeyFileName, name)
 			continue
 		}
 		if typeMeta.GetObjectKind().GroupVersionKind().Empty() {

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -49,6 +49,10 @@ const (
 	KeyVersion = "version"
 	// KeyDeletionTimestamp is for referencing a deletion timestamp. The value should be of type time.Time.
 	KeyDeletionTimestamp = "deletionTimestamp"
+	// KeyIndex is for generic numeric indexes.
+	KeyIndex = "index"
+	// KeyFileName is for the name of a file.
+	KeyFileName = "fileName"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
