### PR TITLE
Remove log from operation

### DIFF
--- a/cmd/container-deployer/container-deployer-wait/app/app.go
+++ b/cmd/container-deployer/container-deployer-wait/app/app.go
@@ -9,8 +9,9 @@ import (
 	"fmt"
 	"os"
 
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/spf13/cobra"
+
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 
 	"github.com/gardener/landscaper/pkg/deployer/container/wait"
 	"github.com/gardener/landscaper/pkg/version"

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
@@ -198,40 +198,32 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 }
 
 func (c *controller) handlePhaseInit(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.UpdateDeployItems(ctx)
 }
 
 func (c *controller) handlePhaseProgressing(ctx context.Context, exec *lsv1alpha1.Execution) (
 	*execution.DeployItemClassification, lserrors.LsError) {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.TriggerDeployItems(ctx)
 }
 
 func (c *controller) handlePhaseCompleting(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.CollectAndUpdateExportsNew(ctx)
 }
 
 func (c *controller) handlePhaseInitDelete(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	op := "handlePhaseInitDelete"
 
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	managedItems, err := o.ListManagedDeployItems(ctx)
 	if err != nil {
@@ -263,10 +255,8 @@ func (c *controller) handlePhaseInitDelete(ctx context.Context, exec *lsv1alpha1
 
 func (c *controller) handlePhaseDeleting(ctx context.Context, exec *lsv1alpha1.Execution) (
 	*execution.DeployItemClassification, lserrors.LsError) {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	return o.TriggerDeployItemsForDelete(ctx)
 }
@@ -305,8 +295,6 @@ func (c *controller) reconcileOld(ctx context.Context, req reconcile.Request) (r
 }
 
 func (c *controller) Ensure(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	if err := HandleAnnotationsAndGeneration(ctx, c.client, exec); err != nil {
 		return err
 	}
@@ -319,7 +307,7 @@ func (c *controller) Ensure(ctx context.Context, exec *lsv1alpha1.Execution) lse
 	}
 
 	forceReconcile := lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.ForceReconcileOperation)
-	op := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec,
+	op := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec,
 		forceReconcile)
 
 	if !exec.DeletionTimestamp.IsZero() {
@@ -357,8 +345,6 @@ func (c *controller) Writer() *read_write_layer.Writer {
 }
 
 func (c *controller) handleInterruptOperation(ctx context.Context, exec *lsv1alpha1.Execution) error {
-	logger, ctx := logging.FromContextOrNew(ctx, nil)
-
 	delete(exec.Annotations, lsv1alpha1.OperationAnnotation)
 	if err := c.Writer().UpdateExecution(ctx, read_write_layer.W000100, exec); err != nil {
 		return err
@@ -367,7 +353,7 @@ func (c *controller) handleInterruptOperation(ctx context.Context, exec *lsv1alp
 	op := "handleInterruptOperation"
 
 	forceReconcile := false
-	o := execution.NewOperation(operation.NewOperation(logger, c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
+	o := execution.NewOperation(operation.NewOperation(c.client, c.scheme, c.eventRecorder), exec, forceReconcile)
 
 	managedItems, err := o.ListManagedDeployItems(ctx)
 	if err != nil {

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -43,7 +43,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 )
 
 const (

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -43,7 +43,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 )
 
 const (
@@ -59,6 +59,7 @@ func NewController(logger logging.Logger,
 	lsConfig *config.LandscaperConfiguration) (reconcile.Reconciler, error) {
 
 	ctrl := &Controller{
+		log:                 logger,
 		LsConfig:            lsConfig,
 		ComponentOverwriter: overwriter,
 	}
@@ -72,14 +73,15 @@ func NewController(logger logging.Logger,
 		logger.Debug("setup shared components registry  cache")
 	}
 
-	op := operation.NewOperation(logger, kubeClient, scheme, eventRecorder)
+	op := operation.NewOperation(kubeClient, scheme, eventRecorder)
 	ctrl.Operation = *op
 	return ctrl, nil
 }
 
 // NewTestActuator creates a new Controller that is only meant for testing.
-func NewTestActuator(op operation.Operation, configuration *config.LandscaperConfiguration) *Controller {
+func NewTestActuator(op operation.Operation, logger logging.Logger, configuration *config.LandscaperConfiguration) *Controller {
 	a := &Controller{
+		log:       logger,
 		Operation: op,
 		LsConfig:  configuration,
 	}
@@ -89,6 +91,7 @@ func NewTestActuator(op operation.Operation, configuration *config.LandscaperCon
 // Controller is the controller that reconciles a installation resource.
 type Controller struct {
 	operation.Operation
+	log                 logging.Logger
 	LsConfig            *config.LandscaperConfiguration
 	SharedCache         cache.Cache
 	ComponentOverwriter componentoverwrites.Overwriter
@@ -103,7 +106,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (c *Controller) reconcileNew(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger, ctx := c.Log().StartReconcileAndAddToContext(ctx, req)
+	logger, ctx := c.log.StartReconcileAndAddToContext(ctx, req)
 
 	inst := &lsv1alpha1.Installation{}
 	if err := read_write_layer.GetInstallation(ctx, c.Client(), req.NamespacedName, inst); err != nil {
@@ -174,7 +177,7 @@ func (c *Controller) reconcileNew(ctx context.Context, req reconcile.Request) (r
 }
 
 func (c *Controller) reconcileOld(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger, ctx := c.Log().StartReconcileAndAddToContext(ctx, req)
+	logger, ctx := c.log.StartReconcileAndAddToContext(ctx, req)
 
 	inst := &lsv1alpha1.Installation{}
 	if err := read_write_layer.GetInstallation(ctx, c.Client(), req.NamespacedName, inst); err != nil {

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -55,9 +55,9 @@ var _ = Describe("Delete", func() {
 			fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata")
 			Expect(err).ToNot(HaveOccurred())
 
-			op = lsoperation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
+			op = lsoperation.NewOperation(testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 
-			ctrl = installationsctl.NewTestActuator(*op, &config.LandscaperConfiguration{
+			ctrl = installationsctl.NewTestActuator(*op, logging.Discard(), &config.LandscaperConfiguration{
 				Registry: config.RegistryConfiguration{
 					Local: &config.LocalRegistryConfiguration{
 						RootPath: "./testdata",
@@ -89,7 +89,7 @@ var _ = Describe("Delete", func() {
 			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstRoot, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			instController := installationsctl.NewTestActuator(*instOp.Operation, nil)
+			instController := installationsctl.NewTestActuator(*instOp.Operation, logging.Discard(), nil)
 			Expect(instController.DeleteExecutionAndSubinstallations(ctx, instOp.Inst.Info)).To(Succeed())
 
 			instA := &lsv1alpha1.Installation{}
@@ -115,7 +115,7 @@ var _ = Describe("Delete", func() {
 			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			instController := installationsctl.NewTestActuator(*instOp.Operation, nil)
+			instController := installationsctl.NewTestActuator(*instOp.Operation, logging.Discard(), nil)
 			err = instController.DeleteExecutionAndSubinstallations(ctx, instOp.Inst.Info)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -134,7 +134,7 @@ var _ = Describe("Delete", func() {
 			instOp, err := installations.NewInstallationOperationFromOperation(ctx, op, inInstB, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			instController := installationsctl.NewTestActuator(*instOp.Operation, nil)
+			instController := installationsctl.NewTestActuator(*instOp.Operation, logging.Discard(), nil)
 			Expect(instController.DeleteExecutionAndSubinstallations(ctx, instOp.Inst.Info)).To(Succeed())
 
 			instC := &lsv1alpha1.Installation{}

--- a/pkg/landscaper/controllers/installations/reconcile_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_test.go
@@ -7,6 +7,8 @@ package installations_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+
 	"github.com/gardener/landscaper/pkg/utils"
 
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
@@ -20,7 +22,6 @@ import (
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	installationsctl "github.com/gardener/landscaper/pkg/landscaper/controllers/installations"
 	lsoperation "github.com/gardener/landscaper/pkg/landscaper/operation"
@@ -46,9 +47,9 @@ var _ = Describe("Reconcile", func() {
 			fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata")
 			Expect(err).ToNot(HaveOccurred())
 
-			op = lsoperation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
+			op = lsoperation.NewOperation(testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 
-			ctrl = installationsctl.NewTestActuator(*op, &config.LandscaperConfiguration{
+			ctrl = installationsctl.NewTestActuator(*op, logging.Discard(), &config.LandscaperConfiguration{
 				Registry: config.RegistryConfiguration{
 					Local: &config.LocalRegistryConfiguration{
 						RootPath: "./testdata",

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -14,11 +14,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
 
 	"github.com/gardener/component-cli/ociclient/credentials"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	"github.com/gardener/landscaper/pkg/utils"
 )

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gardener/component-cli/ociclient/credentials"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	"github.com/gardener/landscaper/pkg/utils"
 )

--- a/pkg/landscaper/execution/delete_test.go
+++ b/pkg/landscaper/execution/delete_test.go
@@ -20,7 +20,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 

--- a/pkg/landscaper/execution/delete_test.go
+++ b/pkg/landscaper/execution/delete_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,7 +20,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
@@ -45,7 +44,7 @@ var _ = Describe("Delete", func() {
 
 		fakeExecutions = state.Executions
 		fakeDeployItems = state.DeployItems
-		op = operation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
+		op = operation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
 	})
 
 	It("should block deletion if deploy items still exist", func() {

--- a/pkg/landscaper/execution/execution.go
+++ b/pkg/landscaper/execution/execution.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 

--- a/pkg/landscaper/execution/execution.go
+++ b/pkg/landscaper/execution/execution.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -17,7 +17,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 

--- a/pkg/landscaper/execution/reconcile_test.go
+++ b/pkg/landscaper/execution/reconcile_test.go
@@ -13,12 +13,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lserrors "github.com/gardener/landscaper/apis/errors"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
@@ -42,7 +41,7 @@ var _ = Describe("Reconcile", func() {
 
 		fakeExecutions = state.Executions
 		fakeDeployItems = state.DeployItems
-		op = operation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
+		op = operation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
 	})
 
 	It("should deploy the specified deploy items", func() {

--- a/pkg/landscaper/installations/builder.go
+++ b/pkg/landscaper/installations/builder.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lsoperation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/landscaper/registry/componentoverwrites"
 	"github.com/gardener/landscaper/pkg/landscaper/registry/components/cdutils"
@@ -103,13 +102,6 @@ func (b *OperationBuilder) Scheme(s *runtime.Scheme) *OperationBuilder {
 // ComponentRegistry sets the component registry.
 func (b *OperationBuilder) ComponentRegistry(resolver ctf.ComponentResolver) *OperationBuilder {
 	b.Builder.ComponentRegistry(resolver)
-	return b
-}
-
-// WithLogger sets a logger.
-// If no logger is given the logger from the context is used.
-func (b *OperationBuilder) WithLogger(log logging.Logger) *OperationBuilder {
-	b.Builder.WithLogger(log)
 	return b
 }
 

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/onsi/gomega/gstruct"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/registry/componentoverwrites"
 
 	testutils "github.com/gardener/landscaper/test/utils"
@@ -53,7 +52,7 @@ var _ = Describe("Context", func() {
 		fakeCompRepo, err = componentsregistry.NewLocalClient("./testdata/registry")
 		Expect(err).ToNot(HaveOccurred())
 
-		op = lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
+		op = lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeCompRepo)
 	})
 
 	AfterEach(func() {

--- a/pkg/landscaper/installations/executions/executions_test.go
+++ b/pkg/landscaper/installations/executions/executions_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/gardener/landscaper/apis/core"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions"
@@ -68,7 +67,7 @@ var _ = Describe("DeployItemExecutions", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/executions/operation_test.go
+++ b/pkg/landscaper/installations/executions/operation_test.go
@@ -17,7 +17,6 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/deployer/container"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions"
@@ -109,7 +108,6 @@ var _ = Describe("Execution Operation", func() {
 			Client(kClient).
 			ComponentDescriptor(cd).
 			ComponentRegistry(componentResolver).
-			WithLogger(logging.Discard()).
 			WithContext(lsCtx).
 			Build(ctx)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/landscaper/installations/exports/constructor_test.go
+++ b/pkg/landscaper/installations/exports/constructor_test.go
@@ -20,7 +20,6 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
@@ -55,7 +54,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/conditional_imports_test.go
+++ b/pkg/landscaper/installations/imports/conditional_imports_test.go
@@ -19,7 +19,6 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/imports"
@@ -60,7 +59,7 @@ var _ = Describe("ConditionalImports", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -23,7 +23,6 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
@@ -59,7 +58,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/imports/importexec_test.go
+++ b/pkg/landscaper/installations/imports/importexec_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/imports"
@@ -66,7 +65,7 @@ var _ = Describe("ImportExecutions", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/operation_test.go
+++ b/pkg/landscaper/installations/operation_test.go
@@ -17,12 +17,11 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils"
 	testutils "github.com/gardener/landscaper/test/utils"
 )
@@ -36,7 +35,7 @@ var _ = Describe("Operation", func() {
 
 	BeforeEach(func() {
 		kubeClient = fake.NewClientBuilder().WithScheme(api.LandscaperScheme).Build()
-		commonOp := operation.NewOperation(logging.Discard(), kubeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
+		commonOp := operation.NewOperation(kubeClient, api.LandscaperScheme, record.NewFakeRecorder(1024))
 		op = &installations.Operation{
 			Inst: &installations.Installation{
 				InstallationBase: installations.InstallationBase{Info: &lsv1alpha1.Installation{}},

--- a/pkg/landscaper/installations/operation_test.go
+++ b/pkg/landscaper/installations/operation_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils"
 	testutils "github.com/gardener/landscaper/test/utils"
 )

--- a/pkg/landscaper/installations/reconcilehelper/outdated_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/outdated_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/reconcilehelper"
@@ -48,7 +47,7 @@ var _ = Describe("OutdatedImports", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/reconcilehelper/validation_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/validation_test.go
@@ -18,7 +18,6 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/reconcilehelper"
@@ -52,7 +51,7 @@ var _ = Describe("Validation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op = &installations.Operation{
-			Operation: lsoperation.NewOperation(logging.Discard(), fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+			Operation: lsoperation.NewOperation(fakeClient, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 				SetComponentsRegistry(fakeCompRepo),
 		}
 	})

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gardener/component-spec/bindings-go/ctf"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations"
@@ -122,7 +121,6 @@ var _ = Describe("SubInstallation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		op, err = lsoperation.NewBuilder().
-			WithLogger(logging.Discard()).
 			Client(fakeClient).Scheme(api.LandscaperScheme).
 			WithEventRecorder(record.NewFakeRecorder(1024)).
 			ComponentRegistry(fakeCompRepo).

--- a/pkg/landscaper/operation/builder.go
+++ b/pkg/landscaper/operation/builder.go
@@ -13,13 +13,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 )
 
 // Builder implements the builder-pattern to craft the operation
 type Builder struct {
-	log               logging.Logger
 	client            client.Client
 	scheme            *runtime.Scheme
 	eventRecorder     record.EventRecorder
@@ -49,13 +47,6 @@ func (b *Builder) ComponentRegistry(resolver ctf.ComponentResolver) *Builder {
 	return b
 }
 
-// WithLogger sets a logger.
-// If no logger is given the logger from the context is used.
-func (b *Builder) WithLogger(log logging.Logger) *Builder {
-	b.log = log
-	return b
-}
-
 // WithEventRecorder sets a event recorder.
 func (b *Builder) WithEventRecorder(er record.EventRecorder) *Builder {
 	b.eventRecorder = er
@@ -65,9 +56,6 @@ func (b *Builder) WithEventRecorder(er record.EventRecorder) *Builder {
 func (b *Builder) applyDefaults(ctx context.Context) {
 	if b.scheme == nil {
 		b.scheme = api.LandscaperScheme
-	}
-	if b.log.IsInitialized() {
-		b.log = logging.FromContextOrDiscard(ctx)
 	}
 	if b.eventRecorder == nil {
 		b.eventRecorder = record.NewFakeRecorder(1024)
@@ -92,7 +80,6 @@ func (b *Builder) Build(ctx context.Context) (*Operation, error) {
 	}
 
 	return &Operation{
-		log:               b.log,
 		client:            b.client,
 		scheme:            b.scheme,
 		eventRecorder:     b.eventRecorder,

--- a/pkg/landscaper/operation/operation.go
+++ b/pkg/landscaper/operation/operation.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
@@ -22,7 +21,6 @@ type RegistriesAccessor interface {
 
 // Operation is the type that is used to share common operational data across the landscaper reconciler
 type Operation struct {
-	log               logging.Logger
 	client            client.Client
 	scheme            *runtime.Scheme
 	eventRecorder     record.EventRecorder
@@ -31,9 +29,8 @@ type Operation struct {
 
 // NewOperation creates a new internal installation Operation object.
 // DEPRECATED: use the Builder instead.
-func NewOperation(log logging.Logger, c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *Operation {
+func NewOperation(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *Operation {
 	return &Operation{
-		log:           log,
 		client:        c,
 		scheme:        scheme,
 		eventRecorder: recorder,
@@ -43,16 +40,10 @@ func NewOperation(log logging.Logger, c client.Client, scheme *runtime.Scheme, r
 // Copy creates a new operation with the same client, scheme and component resolver
 func (o *Operation) Copy() *Operation {
 	return &Operation{
-		log:               o.log,
 		client:            o.client,
 		scheme:            o.scheme,
 		componentRegistry: o.componentRegistry,
 	}
-}
-
-// Log returns a logging instance
-func (o *Operation) Log() logging.Logger {
-	return o.log
 }
 
 // Client returns a controller runtime client.Registry

--- a/test/landscaper/e2e/inlinecd_test.go
+++ b/test/landscaper/e2e/inlinecd_test.go
@@ -26,7 +26,7 @@ import (
 	mockctlr "github.com/gardener/landscaper/pkg/deployer/mock"
 	execctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/execution"
 	instctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/installations"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	testutils "github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"

--- a/test/landscaper/e2e/inlinecd_test.go
+++ b/test/landscaper/e2e/inlinecd_test.go
@@ -26,7 +26,7 @@ import (
 	mockctlr "github.com/gardener/landscaper/pkg/deployer/mock"
 	execctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/execution"
 	instctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/installations"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	testutils "github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
@@ -46,10 +46,10 @@ var _ = Describe("Inline Component Descriptor", func() {
 		fakeComponentRegistry, err = componentsregistry.NewLocalClient(filepath.Join(projectRoot, "examples", "02-inline-cd"))
 		Expect(err).ToNot(HaveOccurred())
 
-		op := operation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).
+		op := operation.NewOperation(testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).
 			SetComponentsRegistry(fakeComponentRegistry)
 
-		instActuator = instctlr.NewTestActuator(*op, &config.LandscaperConfiguration{
+		instActuator = instctlr.NewTestActuator(*op, logging.Discard(), &config.LandscaperConfiguration{
 			Registry: config.RegistryConfiguration{
 				Local: &config.LocalRegistryConfiguration{RootPath: filepath.Join(projectRoot, "examples", "02-inline-cd")},
 			},

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -26,7 +26,7 @@ import (
 	mockctlr "github.com/gardener/landscaper/pkg/deployer/mock"
 	execctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/execution"
 	instctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/installations"
-	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/operation"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	testutils "github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -26,7 +26,7 @@ import (
 	mockctlr "github.com/gardener/landscaper/pkg/deployer/mock"
 	execctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/execution"
 	instctlr "github.com/gardener/landscaper/pkg/landscaper/controllers/installations"
-	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	operation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 	testutils "github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
@@ -46,9 +46,9 @@ var _ = Describe("Simple", func() {
 		fakeComponentRegistry, err = componentsregistry.NewLocalClient(filepath.Join(projectRoot, "examples", "01-simple"))
 		Expect(err).ToNot(HaveOccurred())
 
-		op := operation.NewOperation(logging.Discard(), testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeComponentRegistry)
+		op := operation.NewOperation(testenv.Client, api.LandscaperScheme, record.NewFakeRecorder(1024)).SetComponentsRegistry(fakeComponentRegistry)
 
-		instActuator = instctlr.NewTestActuator(*op, &config.LandscaperConfiguration{
+		instActuator = instctlr.NewTestActuator(*op, logging.Discard(), &config.LandscaperConfiguration{
 			Registry: config.RegistryConfiguration{
 				Local: &config.LocalRegistryConfiguration{RootPath: filepath.Join(projectRoot, "examples", "01-simple")},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Removes log from basic operation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
