### PR TITLE
Refactor logging in deployers

### DIFF
--- a/cmd/container-deployer/container-deployer-controller/app/app.go
+++ b/cmd/container-deployer/container-deployer-controller/app/app.go
@@ -36,7 +36,7 @@ func NewContainerDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting Container Deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := containerctlr.AddControllerToManager(o.DeployerOptions.Log,
+	if err := containerctlr.AddControllerToManager(o.DeployerOptions.Log.WithName("container"),
 		o.DeployerOptions.HostMgr,
 		o.DeployerOptions.LsMgr,
 		o.Config); err != nil {

--- a/cmd/container-deployer/container-deployer-controller/app/app.go
+++ b/cmd/container-deployer/container-deployer-controller/app/app.go
@@ -36,7 +36,7 @@ func NewContainerDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting Container Deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := containerctlr.AddControllerToManager(o.DeployerOptions.Log.WithName("container"),
+	if err := containerctlr.AddControllerToManager(o.DeployerOptions.Log,
 		o.DeployerOptions.HostMgr,
 		o.DeployerOptions.LsMgr,
 		o.Config); err != nil {

--- a/cmd/container-deployer/container-deployer-init/app/app.go
+++ b/cmd/container-deployer/container-deployer-init/app/app.go
@@ -40,7 +40,7 @@ func NewContainerDeployerInitCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) {
 	o.log.Info("Starting init executor for container deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := initpkg.Run(ctx, o.log, osfs.New()); err != nil {
+	if err := initpkg.Run(ctx, osfs.New()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/container-deployer/container-deployer-init/app/app.go
+++ b/cmd/container-deployer/container-deployer-init/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/spf13/cobra"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	initpkg "github.com/gardener/landscaper/pkg/deployer/container/init"
 	"github.com/gardener/landscaper/pkg/version"
@@ -40,7 +41,7 @@ func NewContainerDeployerInitCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) {
 	o.log.Info("Starting init executor for container deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := initpkg.Run(ctx, osfs.New()); err != nil {
+	if err := initpkg.Run(logging.NewContext(ctx, o.log), osfs.New()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/container-deployer/container-deployer-wait/app/app.go
+++ b/cmd/container-deployer/container-deployer-wait/app/app.go
@@ -42,7 +42,7 @@ It waits until the main container has finished, then back-ups the optional state
 
 func (o *options) run(ctx context.Context) {
 	o.log.Info("Starting wait executor for container deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := wait.Run(ctx, o.log); err != nil {
+	if err := wait.Run(ctx); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/helm-deployer-controller/app/app.go
+++ b/cmd/helm-deployer-controller/app/app.go
@@ -37,7 +37,7 @@ func NewHelmDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting helm deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := helmctrl.AddDeployerToManager(o.DeployerOptions.Log.WithName("helm"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
+	if err := helmctrl.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup helm controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/cmd/manifest-deployer-controller/app/app.go
+++ b/cmd/manifest-deployer-controller/app/app.go
@@ -37,7 +37,7 @@ func NewManifestDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting Manifest Deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := manifestctlr.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
+	if err := manifestctlr.AddDeployerToManager(o.DeployerOptions.Log.WithName("k8sManifest"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup helm controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/cmd/manifest-deployer-controller/app/app.go
+++ b/cmd/manifest-deployer-controller/app/app.go
@@ -37,7 +37,7 @@ func NewManifestDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting Manifest Deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := manifestctlr.AddDeployerToManager(o.DeployerOptions.Log.WithName("k8sManifest"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
+	if err := manifestctlr.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup helm controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/cmd/mock-deployer-controller/app/app.go
+++ b/cmd/mock-deployer-controller/app/app.go
@@ -37,7 +37,7 @@ func NewMockDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting Mock Deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := mockctrl.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
+	if err := mockctrl.AddDeployerToManager(o.DeployerOptions.Log.WithName("mock"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup mock controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/cmd/mock-deployer-controller/app/app.go
+++ b/cmd/mock-deployer-controller/app/app.go
@@ -37,7 +37,7 @@ func NewMockDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting Mock Deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := mockctrl.AddDeployerToManager(o.DeployerOptions.Log.WithName("mock"), o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
+	if err := mockctrl.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr, o.Config); err != nil {
 		return fmt.Errorf("unable to setup mock controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -71,8 +71,12 @@ const (
 	KeyGroupVersionKind = "groupVersionKind"
 	// KeyStatus is for a status of whatever kind.
 	KeyStatus = "status"
-	// KeyOperationAnnotation is for logging the value of the current operation annotation
+	// KeyOperationAnnotation is for logging the value of the current operation annotation.
 	KeyOperationAnnotation = "operationAnnotation"
+	// KeyReason is for providing a reason.
+	KeyReason = "reason"
+	// KeyPhase is for a generic phase. For the phases of Installations, Executions, or DeployItems, use the more specific constants.
+	KeyPhase = "phase"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -63,6 +63,10 @@ const (
 	KeyFileName = "fileName"
 	// KeyServiceAccount is for a kubernetes service account.
 	KeyServiceAccount = "serviceAccount"
+	// KeyDeployItemType is for the type of deployitem which is handled by the controller.
+	KeyDeployItemType = "deployItemType"
+	// KeyError is for logging an error message without using 'logger.Error' for whatever reason.
+	KeyError = "error"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -67,6 +67,12 @@ const (
 	KeyDeployItemType = "deployItemType"
 	// KeyError is for logging an error message without using 'logger.Error' for whatever reason.
 	KeyError = "error"
+	// KeyGroupVersionKind is for listing group, version, and kind of a resource.
+	KeyGroupVersionKind = "groupVersionKind"
+	// KeyStatus is for a status of whatever kind.
+	KeyStatus = "status"
+	// KeyOperationAnnotation is for logging the value of the current operation annotation
+	KeyOperationAnnotation = "operationAnnotation"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -161,8 +161,10 @@ func FromContextOrNew(ctx context.Context, keysAndValuesFallback []interface{}, 
 		ctx = NewContext(ctx, newLogger)
 		return newLogger, ctx
 	}
-	log = log.WithValues(keysAndValues...)
-	ctx = NewContext(ctx, log)
+	if len(keysAndValues) > 0 {
+		log = log.WithValues(keysAndValues...)
+		ctx = NewContext(ctx, log)
+	}
 	return log, ctx
 }
 

--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -143,7 +143,6 @@ func FromContextOrDiscard(ctx context.Context) Logger {
 }
 
 // NewContext is a wrapper for logr.NewContext.
-// It adds the logger to the context twice, in a wrapped as well as a logr version.
 func NewContext(ctx context.Context, log Logger) context.Context {
 	return logr.NewContext(ctx, log.Logr())
 }

--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -142,6 +142,24 @@ func FromContextOrDiscard(ctx context.Context) Logger {
 	return log
 }
 
+// NewContext is a wrapper for logr.NewContext.
+// It adds the logger to the context twice, in a wrapped as well as a logr version.
+func NewContext(ctx context.Context, log Logger) context.Context {
+	return logr.NewContext(ctx, log.Logr())
+}
+
+// Discard is a wrapper for logr.Discard.
+func Discard() Logger {
+	return Wrap(logr.Discard())
+}
+
+// ADDITIONAL FUNCTIONS
+
+// Wrap constructs a new Logger, using the provided logr.Logger internally.
+func Wrap(log logr.Logger) Logger {
+	return Logger{internal: log}
+}
+
 // FromContextOrNew tries to fetch a logger from the context.
 // It is expected that a logger is contained in the context. If retrieving it fails, a new logger will be created and an error is logged.
 // keysAndValuesFallback contains keys and values which will only be added if the logger could not be retrieved and a new one had to be created.
@@ -181,21 +199,9 @@ func FromContextWithFallback(ctx context.Context, fallback Logger, keysAndValues
 	return log, ctx
 }
 
-func Discard() Logger {
-	return Wrap(logr.Discard())
-}
-
-// NewContext is a wrapper for logr.NewContext.
-// It adds the logger to the context twice, in a wrapped as well as a logr version.
-func NewContext(ctx context.Context, log Logger) context.Context {
-	return logr.NewContext(ctx, log.Logr())
-}
-
-// ADDITIONAL FUNCTIONS
-
-// Wrap constructs a new Logger, using the provided logr.Logger internally.
-func Wrap(log logr.Logger) Logger {
-	return Logger{internal: log}
+// NewContextWithDiscard adds a discard logger to the given context and returns the new context.
+func NewContextWithDiscard(ctx context.Context) context.Context {
+	return NewContext(ctx, Discard())
 }
 
 // Debug logs a message at DEBUG level.

--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -230,7 +230,14 @@ func (l Logger) IsInitialized() bool {
 // Reconciles is meant to be used for the logger initialization for controllers.
 // It is a wrapper for WithName(name).WithValues(lc.KeyReconciledResourceKind, reconciledResource).
 func (l Logger) Reconciles(name, reconciledResource string) Logger {
-	return l.WithName(name).WithValues(lc.KeyReconciledResourceKind, reconciledResource)
+	log := l
+	if len(name) != 0 {
+		log = log.WithName(name)
+	}
+	if len(reconciledResource) != 0 {
+		log = log.WithValues(lc.KeyReconciledResourceKind, reconciledResource)
+	}
+	return log
 }
 
 // Logr returns the internal logr.Logger.

--- a/pkg/deployer/container/add.go
+++ b/pkg/deployer/container/add.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,6 +20,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	deployerlib "github.com/gardener/landscaper/pkg/deployer/lib"
 	"github.com/gardener/landscaper/pkg/version"
+	"github.com/go-logr/logr"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"
@@ -75,6 +77,7 @@ func AddControllerToManager(logger logging.Logger, hostMgr, lsMgr manager.Manage
 
 	if err := ctrl.NewControllerManagedBy(lsMgr).
 		For(&lsv1alpha1.DeployItem{}, builder.WithPredicates(noopPredicate{})).
+		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Logr() }).
 		Watches(src, &PodEventHandler{}).
 		Complete(podRec); err != nil {
 		return err

--- a/pkg/deployer/container/cleanup.go
+++ b/pkg/deployer/container/cleanup.go
@@ -69,7 +69,7 @@ func CleanupRBAC(ctx context.Context, deployItem *lsv1alpha1.DeployItem, hostCli
 	if err := hostClient.Delete(ctx, sa); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	log.Debug("successfully removed init container rbac resources")
+	log.Debug("Successfully removed init container rbac resources")
 
 	sa = &corev1.ServiceAccount{}
 	sa.Name = WaitContainerServiceAccountName(deployItem)
@@ -93,7 +93,7 @@ func CleanupRBAC(ctx context.Context, deployItem *lsv1alpha1.DeployItem, hostCli
 		return err
 	}
 
-	log.Debug("successfully removed wait container rbac resources")
+	log.Debug("Successfully removed wait container rbac resources")
 
 	return nil
 }

--- a/pkg/deployer/container/container.go
+++ b/pkg/deployer/container/container.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lserrors "github.com/gardener/landscaper/apis/errors"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/utils"
@@ -42,7 +41,6 @@ func NewDeployItemBuilder() *utils.DeployItemBuilder {
 
 // Container is the internal representation of a DeployItem of Type Container
 type Container struct {
-	log      logging.Logger
 	lsClient client.Client
 	// hostClient is a cached client that is used to interact with the host cluster
 	// The host cluster is the cluster where the pods are executed.
@@ -65,8 +63,7 @@ type Container struct {
 }
 
 // New creates a new internal container item
-func New(log logging.Logger,
-	lsClient,
+func New(lsClient,
 	hostClient,
 	directHostClient client.Client,
 	config containerv1alpha1.Configuration,
@@ -94,7 +91,6 @@ func New(log logging.Logger,
 	}
 
 	return &Container{
-		log:                   log,
 		lsClient:              lsClient,
 		hostClient:            hostClient,
 		directHostClient:      directHostClient,

--- a/pkg/deployer/container/init/e2e_test.go
+++ b/pkg/deployer/container/init/e2e_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Init e2e", func() {
 
 		opts := &options{}
 		opts.Complete(ctx)
-		Expect(run(ctx, logging.Discard(), opts, testenv.Client, resFs)).To(Succeed())
+		Expect(run(ctx, opts, testenv.Client, resFs)).To(Succeed())
 
 		resData, err := vfs.ReadFile(resFs, testFilePath)
 		utils.ExpectNoError(err)

--- a/pkg/deployer/container/init/e2e_test.go
+++ b/pkg/deployer/container/init/e2e_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Init e2e", func() {
 	})
 
 	It("should restore a backup", func() {
-		ctx := context.Background()
+		ctx := logging.NewContextWithDiscard(context.Background())
 		defer ctx.Done()
 		var (
 			fs           = memoryfs.New()
@@ -84,7 +84,7 @@ var _ = Describe("Init e2e", func() {
 		utils.ExpectNoError(fs.MkdirAll(container.StatePath, os.ModePerm))
 		utils.ExpectNoError(vfs.WriteFile(fs, testFilePath, testData, os.ModePerm))
 
-		s := state.New(logging.Discard(), testenv.Client, testState.Namespace, di, container.StatePath).WithFs(fs)
+		s := state.New(testenv.Client, testState.Namespace, di, container.StatePath).WithFs(fs)
 
 		utils.ExpectNoError(s.Backup(ctx))
 
@@ -94,7 +94,7 @@ var _ = Describe("Init e2e", func() {
 		Expect(vfs.WriteFile(resFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
 
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		Expect(run(ctx, opts, testenv.Client, resFs)).To(Succeed())
 
 		resData, err := vfs.ReadFile(resFs, testFilePath)

--- a/pkg/deployer/container/init/init_suite_test.go
+++ b/pkg/deployer/container/init/init_suite_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/00-di-simple.yaml")
@@ -86,7 +86,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/01-di-blueprint.yaml")
@@ -106,7 +106,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/02-di-inline-blueprint.yaml")
@@ -126,7 +126,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/01-di-blueprint.yaml")
@@ -148,7 +148,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/03-di-inline-cd.yaml")
@@ -170,7 +170,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/04-di-inline-bp-no-cd.yaml")
@@ -190,7 +190,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		memFs := memoryfs.New()
 
 		file, err := ioutil.ReadFile("./testdata/05-di-inline-bp-inline-cd.yaml")
@@ -216,7 +216,7 @@ var _ = Describe("Constructor", func() {
 		defer ctx.Done()
 		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
-		opts.Complete(ctx)
+		opts.Complete()
 		opts.RegistrySecretBasePath = "/unexisting/path"
 		memFs := memoryfs.New()
 

--- a/pkg/deployer/container/init/init_suite_test.go
+++ b/pkg/deployer/container/init/init_suite_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/deployer/container"
 	mock_client "github.com/gardener/landscaper/controller-utils/pkg/kubernetes/mock"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/test/utils"
 )
 
@@ -73,7 +72,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		dataBytes, err := vfs.ReadFile(memFs, container.ImportsPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -94,7 +93,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		info, err := vfs.ReadDir(memFs, container.ContentPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -114,7 +113,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		info, err := vfs.ReadDir(memFs, container.ContentPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -134,7 +133,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		data, err := vfs.ReadFile(memFs, container.ComponentDescriptorPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -156,7 +155,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		data, err := vfs.ReadFile(memFs, container.ComponentDescriptorPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -178,7 +177,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		info, err := vfs.ReadDir(memFs, container.ContentPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -198,7 +197,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		info, err := vfs.ReadDir(memFs, container.ContentPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -225,7 +224,7 @@ var _ = Describe("Constructor", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
-		Expect(run(ctx, logging.Discard(), opts, fakeClient, memFs)).To(Succeed())
+		Expect(run(ctx, opts, fakeClient, memFs)).To(Succeed())
 
 		info, err := vfs.ReadDir(memFs, container.ContentPath)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/deployer/container/init/init_suite_test.go
+++ b/pkg/deployer/container/init/init_suite_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch import values from DeployItem's configuration and write them to 'import.json'", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -84,7 +84,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch a blueprint from a DeployItem's configuration and write them to the content path", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -104,7 +104,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch an inline blueprint from a DeployItem's configuration and write them to the content path", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -124,7 +124,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch component descriptor from DeployItem's configuration and write them to the component descriptor path", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -146,7 +146,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch an inline component descriptor from DeployItem's configuration and write them to the component descriptor path", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -168,7 +168,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch an inline blueprint from a DeployItem's configuration with no Component Descriptor at all and write them to the content path", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -188,7 +188,7 @@ var _ = Describe("Constructor", func() {
 	It("should fetch an inline blueprint and an inline Component Descriptor from a DeployItem's configuration and write them to the content path", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		memFs := memoryfs.New()
@@ -214,7 +214,7 @@ var _ = Describe("Constructor", func() {
 	It("should ignore if the registry secrets path does not exist", func() {
 		ctx := context.Background()
 		defer ctx.Done()
-		fakeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		fakeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 		opts := &options{}
 		opts.Complete(ctx)
 		opts.RegistrySecretBasePath = "/unexisting/path"

--- a/pkg/deployer/container/init/options.go
+++ b/pkg/deployer/container/init/options.go
@@ -5,7 +5,6 @@
 package init
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"os"
@@ -40,7 +39,7 @@ type options struct {
 }
 
 // Complete reads necessary options from the expected sources.
-func (o *options) Complete(ctx context.Context) {
+func (o *options) Complete() {
 	o.ConfigurationFilePath = os.Getenv(container.ConfigurationPathName)
 	o.ImportsFilePath = os.Getenv(container.ImportsPathName)
 	o.ExportsFilePath = os.Getenv(container.ExportsPathName)

--- a/pkg/deployer/container/reconciler_deployitem.go
+++ b/pkg/deployer/container/reconciler_deployitem.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gardener/component-cli/ociclient/cache"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/utils"
@@ -70,8 +69,7 @@ type deployer struct {
 }
 
 func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, _ *lsv1alpha1.Target) error {
-	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace})
-	containerOp, err := New(logger, d.lsClient, d.hostClient, d.directHostClient, d.config, di, lsCtx, d.sharedCache)
+	containerOp, err := New(d.lsClient, d.hostClient, d.directHostClient, d.config, di, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
@@ -79,8 +77,7 @@ func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di 
 }
 
 func (d deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace})
-	containerOp, err := New(logger, d.lsClient, d.hostClient, d.directHostClient, d.config, di, lsCtx, d.sharedCache)
+	containerOp, err := New(d.lsClient, d.hostClient, d.directHostClient, d.config, di, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
@@ -102,7 +99,7 @@ func (d *deployer) ExtensionHooks() extension.ReconcileExtensionHooks {
 
 func (d *deployer) NextReconcile(ctx context.Context, last time.Time, di *lsv1alpha1.DeployItem) (*time.Time, error) {
 	// TODO: parse provider configuration directly and do not init the container helper struct
-	containerOp, err := New(d.log, d.lsClient, d.hostClient, d.directHostClient, d.config, di, nil, d.sharedCache)
+	containerOp, err := New(d.lsClient, d.hostClient, d.directHostClient, d.config, di, nil, d.sharedCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/container/reconciler_pod.go
+++ b/pkg/deployer/container/reconciler_pod.go
@@ -64,7 +64,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	old := deployItem.DeepCopy()
 	err = r.diRec.Reconcile(ctx, lsCtx, deployItem, nil)
 	lsErr := lserror.BuildLsErrorOrNil(err, "Reconcile", "Reconcile")
-	return reconcile.Result{}, deployerlib.HandleErrorFunc(ctx, lsErr, r.log, r.lsClient, r.lsEventRecorder, old, deployItem, false)
+	return reconcile.Result{}, deployerlib.HandleErrorFunc(ctx, lsErr, r.lsClient, r.lsEventRecorder, old, deployItem, false)
 }
 
 // PodEventHandler implements the controller runtime handler interface

--- a/pkg/deployer/container/reconciler_pod.go
+++ b/pkg/deployer/container/reconciler_pod.go
@@ -54,7 +54,8 @@ func NewPodReconciler(
 }
 
 func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	deployItem, lsCtx, err := GetAndCheckReconcile(r.log, r.lsClient, r.config)(ctx, req)
+	_, ctx = r.log.StartReconcileAndAddToContext(ctx, req)
+	deployItem, lsCtx, err := GetAndCheckReconcile(r.lsClient, r.config)(ctx, req)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/deployer/container/state/state_test.go
+++ b/pkg/deployer/container/state/state_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Container Deployer State", func() {
 	})
 
 	It("should save a file and restore it", func() {
-		ctx := context.Background()
+		ctx := logging.NewContextWithDiscard(context.Background())
 		defer ctx.Done()
 		var (
 			fs           = memoryfs.New()
@@ -51,7 +51,7 @@ var _ = Describe("Container Deployer State", func() {
 		utils.ExpectNoError(fs.MkdirAll(testDir, os.ModePerm))
 		utils.ExpectNoError(vfs.WriteFile(fs, testFilePath, testData, os.ModePerm))
 
-		s := state.New(logging.Discard(), testenv.Client, testState.Namespace, lsv1alpha1.ObjectReference{
+		s := state.New(testenv.Client, testState.Namespace, lsv1alpha1.ObjectReference{
 			Name:      "testname",
 			Namespace: "testns",
 		}, testDir).WithFs(fs)
@@ -66,7 +66,7 @@ var _ = Describe("Container Deployer State", func() {
 	})
 
 	It("should garbage collect old state secrets", func() {
-		ctx := context.Background()
+		ctx := logging.NewContextWithDiscard(context.Background())
 		defer ctx.Done()
 		var (
 			fs           = memoryfs.New()
@@ -78,7 +78,7 @@ var _ = Describe("Container Deployer State", func() {
 		utils.ExpectNoError(fs.MkdirAll(testDir, os.ModePerm))
 		utils.ExpectNoError(vfs.WriteFile(fs, testFilePath, testData, os.ModePerm))
 
-		s := state.New(logging.Discard(), testenv.Client, testState.Namespace, lsv1alpha1.ObjectReference{
+		s := state.New(testenv.Client, testState.Namespace, lsv1alpha1.ObjectReference{
 			Name:      "testname",
 			Namespace: "testns",
 		}, testDir).WithFs(fs)
@@ -109,7 +109,7 @@ var _ = Describe("Container Deployer State", func() {
 	})
 
 	It("should cleanup the state", func() {
-		ctx := context.Background()
+		ctx := logging.NewContextWithDiscard(context.Background())
 		defer ctx.Done()
 		var (
 			fs           = memoryfs.New()
@@ -121,7 +121,7 @@ var _ = Describe("Container Deployer State", func() {
 		utils.ExpectNoError(fs.MkdirAll(testDir, os.ModePerm))
 		utils.ExpectNoError(vfs.WriteFile(fs, testFilePath, testData, os.ModePerm))
 
-		s := state.New(logging.Discard(), testenv.Client, testState.Namespace, lsv1alpha1.ObjectReference{
+		s := state.New(testenv.Client, testState.Namespace, lsv1alpha1.ObjectReference{
 			Name:      "testname",
 			Namespace: "testns",
 		}, testDir).WithFs(fs)

--- a/pkg/deployer/container/test/e2e_test.go
+++ b/pkg/deployer/container/test/e2e_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Container Deployer", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		ctrl = deployerlib.NewController(
-			logging.Discard(),
 			testenv.Client,
 			api.LandscaperScheme,
 			record.NewFakeRecorder(1024),

--- a/pkg/deployer/container/wait/sidecar.go
+++ b/pkg/deployer/container/wait/sidecar.go
@@ -21,6 +21,7 @@ import (
 // Run runs the container deployer sidecar.
 func Run(ctx context.Context) error {
 	log, ctx := logging.FromContextOrNew(ctx, nil)
+	log = log.WithName("container").WithName("wait")
 	opts := &options{}
 	opts.Setup()
 
@@ -40,7 +41,7 @@ func Run(ctx context.Context) error {
 			Scheme: api.LandscaperScheme,
 		})
 		if err != nil {
-			log.Error(err, "unable to build kubernetes client")
+			log.Error(err, "Unable to build kubernetes client")
 			return false, nil
 		}
 		return true, nil
@@ -55,7 +56,7 @@ func Run(ctx context.Context) error {
 	}
 
 	// backup state
-	if err := state.New(log, kubeClient, opts.podNamespace, opts.DeployItemKey, opts.StatePath).Backup(ctx); err != nil {
+	if err := state.New(kubeClient, opts.podNamespace, opts.DeployItemKey, opts.StatePath).Backup(ctx); err != nil {
 		return withTerminationLog(log, err)
 	}
 
@@ -72,7 +73,7 @@ func withTerminationLog(log logging.Logger, err error) error {
 	}
 
 	if err := ioutil.WriteFile("/dev/termination-log", []byte(err.Error()), os.ModePerm); err != nil {
-		log.Error(err, "unable to write termination message")
+		log.Error(err, "Unable to write termination message")
 	}
 	return err
 }

--- a/pkg/deployer/container/wait/sidecar.go
+++ b/pkg/deployer/container/wait/sidecar.go
@@ -19,7 +19,8 @@ import (
 )
 
 // Run runs the container deployer sidecar.
-func Run(ctx context.Context, log logging.Logger) error {
+func Run(ctx context.Context) error {
+	log, ctx := logging.FromContextOrNew(ctx, nil)
 	opts := &options{}
 	opts.Setup()
 
@@ -49,7 +50,7 @@ func Run(ctx context.Context, log logging.Logger) error {
 
 	// wait for the main container to finish.
 	// event if the exitcode != 0, the state is still backed up.
-	if err := WaitUntilMainContainerFinished(ctx, log, kubeClient, opts.PodKey.NamespacedName()); err != nil {
+	if err := WaitUntilMainContainerFinished(ctx, kubeClient, opts.PodKey.NamespacedName()); err != nil {
 		return withTerminationLog(log, err)
 	}
 
@@ -59,7 +60,7 @@ func Run(ctx context.Context, log logging.Logger) error {
 	}
 
 	// upload exports
-	if err := UploadExport(ctx, log, kubeClient, opts.DeployItemKey, opts.PodKey, opts.ExportFilePath); err != nil {
+	if err := UploadExport(ctx, kubeClient, opts.DeployItemKey, opts.PodKey, opts.ExportFilePath); err != nil {
 		return withTerminationLog(log, err)
 	}
 	return nil

--- a/pkg/deployer/container/wait/uploadexport.go
+++ b/pkg/deployer/container/wait/uploadexport.go
@@ -24,7 +24,8 @@ import (
 
 // UploadExport reads the export config from the given path and stores
 // the data as secret in the host cluster
-func UploadExport(ctx context.Context, log logging.Logger, kubeClient client.Client, deployItemKey lsv1alpha1.ObjectReference, podKey lsv1alpha1.ObjectReference, exportFilePath string) error {
+func UploadExport(ctx context.Context, kubeClient client.Client, deployItemKey lsv1alpha1.ObjectReference, podKey lsv1alpha1.ObjectReference, exportFilePath string) error {
+	log, ctx := logging.FromContextOrNew(ctx, nil)
 	pod := &corev1.Pod{}
 	if err := kubeClient.Get(ctx, podKey.NamespacedName(), pod); err != nil {
 		return err
@@ -44,7 +45,7 @@ func UploadExport(ctx context.Context, log logging.Logger, kubeClient client.Cli
 	exportData, err := ioutil.ReadFile(exportFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Info("no export config found. Skip upload.")
+			log.Info("No export config found. Skip upload.")
 			return nil
 		}
 		return err

--- a/pkg/deployer/container/wait/wait.go
+++ b/pkg/deployer/container/wait/wait.go
@@ -23,7 +23,8 @@ import (
 // For a comparison of different possibilities to wait for a container to finish
 // see the argo doc: https://github.com/argoproj/argo/blob/master/docs/workflow-executors.md
 // This method currently uses the k8s api method for simplicity and stability reasons.
-func WaitUntilMainContainerFinished(ctx context.Context, log logging.Logger, kubeClient client.Client, podKey client.ObjectKey) error {
+func WaitUntilMainContainerFinished(ctx context.Context, kubeClient client.Client, podKey client.ObjectKey) error {
+	log, ctx := logging.FromContextOrNew(ctx, nil)
 	backoff := wait.Backoff{
 		Duration: 30 * time.Second,
 		Factor:   1.25,

--- a/pkg/deployer/container/wait/wait.go
+++ b/pkg/deployer/container/wait/wait.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gardener/landscaper/apis/deployer/container"
 	kubernetesutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 )
 
 // WaitUntilMainContainerFinished waits until the main container of the pod has finished.
@@ -41,18 +42,18 @@ func WaitUntilMainContainerFinished(ctx context.Context, kubeClient client.Clien
 			if apierrors.IsUnauthorized(err) {
 				return false, err
 			}
-			log.Error(err, "unable to get pod", "pod", podKey.String())
+			log.Error(err, "Unable to get pod", lc.KeyResource, podKey.String())
 			return false, nil
 		}
 
 		mainContainerStatus, err := kubernetesutil.GetStatusForContainer(pod.Status.ContainerStatuses, container.MainContainerName)
 		if err != nil {
-			log.Error(err, "unable to get container status for main container")
+			log.Error(err, "Unable to get container status for main container")
 			return false, nil
 		}
 
 		if mainContainerStatus.State.Terminated == nil {
-			log.Debug("main container is still running...")
+			log.Debug("Main container is still running...")
 			return false, nil
 		}
 		return true, nil

--- a/pkg/deployer/helm/add.go
+++ b/pkg/deployer/helm/add.go
@@ -17,7 +17,7 @@ import (
 
 // AddDeployerToManager adds a new helm deployers to a controller manager.
 func AddDeployerToManager(logger logging.Logger, lsMgr, hostMgr manager.Manager, config helmv1alpha1.Configuration) error {
-	log := logger.WithName("HelmDeployer")
+	log := logger.WithName("helm")
 	d, err := NewDeployer(
 		log,
 		lsMgr.GetClient(),

--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -126,7 +126,7 @@ func (h *Helm) ApplyFiles(ctx context.Context, files, crds map[string]string, ex
 
 func (h *Helm) applyManifests(ctx context.Context, targetClient client.Client, targetClientSet kubernetes.Interface,
 	manifests []managedresource.Manifest) (*resourcemanager.ManifestApplier, error) {
-	applier := resourcemanager.NewManifestApplier(h.log, resourcemanager.ManifestApplierOptions{
+	applier := resourcemanager.NewManifestApplier(resourcemanager.ManifestApplierOptions{
 		Decoder:          serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder(),
 		KubeClient:       targetClient,
 		Clientset:        targetClientSet,
@@ -202,7 +202,6 @@ func (h *Helm) checkResourcesReady(ctx context.Context, client client.Client) er
 			Context:          ctx,
 			Client:           client,
 			CurrentOp:        "DefaultCheckResourcesReadinessHelm",
-			Log:              h.log,
 			Timeout:          h.ProviderConfiguration.ReadinessChecks.Timeout,
 			ManagedResources: h.ProviderStatus.ManagedResources.TypedObjectReferenceList(),
 		}
@@ -217,7 +216,6 @@ func (h *Helm) checkResourcesReady(ctx context.Context, client client.Client) er
 			customReadinessCheck := health.CustomReadinessCheck{
 				Context:          ctx,
 				Client:           client,
-				Log:              h.log,
 				CurrentOp:        "CustomCheckResourcesReadinessHelm",
 				Timeout:          h.ProviderConfiguration.ReadinessChecks.Timeout,
 				ManagedResources: h.ProviderStatus.ManagedResources.TypedObjectReferenceList(),
@@ -251,7 +249,7 @@ func (h *Helm) readExportValues(ctx context.Context, currOp string, targetClient
 		if h.Configuration.Export.DefaultTimeout != nil {
 			opts.DefaultTimeout = &h.Configuration.Export.DefaultTimeout.Duration
 		}
-		resourceExports, err := resourcemanager.NewExporter(h.log, opts).
+		resourceExports, err := resourcemanager.NewExporter(opts).
 			Export(ctx, exportDefinition)
 		if err != nil {
 			return lserrors.NewWrappedError(err,

--- a/pkg/deployer/helm/test/e2e_test.go
+++ b/pkg/deployer/helm/test/e2e_test.go
@@ -63,7 +63,6 @@ var _ = Describe("Helm Deployer", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		ctrl := deployerlib.NewController(
-			logging.Discard(),
 			testenv.Client,
 			api.LandscaperScheme,
 			record.NewFakeRecorder(1024),

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -103,7 +103,7 @@ func Add(log logging.Logger, lsMgr, hostMgr manager.Manager, args DeployerArgs) 
 		hostMgr.GetScheme(),
 		args)
 
-	log = log.Reconciles("deployItem", "DeployItem").WithValues(lc.KeyDeployItemType, string(args.Type))
+	log = log.Reconciles("", "DeployItem").WithValues(lc.KeyDeployItemType, string(args.Type))
 
 	return builder.ControllerManagedBy(lsMgr).
 		For(&lsv1alpha1.DeployItem{}, builder.WithPredicates(NewTypePredicate(args.Type))).

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -26,7 +26,6 @@ import (
 	health "github.com/gardener/landscaper/apis/deployer/utils/readinesschecks"
 	lserror "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/utils"
 )
 
@@ -34,7 +33,6 @@ import (
 type CustomReadinessCheck struct {
 	Context          context.Context
 	Client           client.Client
-	Log              logging.Logger
 	CurrentOp        string
 	Timeout          *lsv1alpha1.Duration
 	ManagedResources []lsv1alpha1.TypedObjectReference
@@ -63,7 +61,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady() error {
 	}
 
 	timeout := c.Timeout.Duration
-	if err := WaitForObjectsReady(c.Context, timeout, c.Log, c.Client, objects, c.CheckObject); err != nil {
+	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject); err != nil {
 		return lserror.NewWrappedError(err,
 			c.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck_test.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck_test.go
@@ -32,9 +32,8 @@ var _ = Describe("Custom health checks", func() {
 
 	BeforeEach(func() {
 		customHealthCheck = CustomReadinessCheck{
-			Context:   ctx,
+			Context:   logging.NewContext(ctx, logging.Discard()),
 			Client:    testenv.Client,
-			Log:       logging.Discard(),
 			CurrentOp: "custom health check test",
 			Timeout:   &lsv1alpha1.Duration{Duration: 180 * time.Second},
 		}

--- a/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
@@ -18,14 +18,12 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lserror "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 )
 
 // DefaultReadinessCheck contains all the data and methods required to kick off a default readiness check
 type DefaultReadinessCheck struct {
 	Context          context.Context
 	Client           client.Client
-	Log              logging.Logger
 	CurrentOp        string
 	Timeout          *lsv1alpha1.Duration
 	ManagedResources []lsv1alpha1.TypedObjectReference
@@ -45,7 +43,7 @@ func (d *DefaultReadinessCheck) CheckResourcesReady() error {
 	}
 
 	timeout := d.Timeout.Duration
-	if err := WaitForObjectsReady(d.Context, timeout, d.Log, d.Client, objects, d.CheckObject); err != nil {
+	if err := WaitForObjectsReady(d.Context, timeout, d.Client, objects, d.CheckObject); err != nil {
 		return lserror.NewWrappedError(err,
 			d.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}

--- a/pkg/deployer/lib/resourcemanager/exporter_test.go
+++ b/pkg/deployer/lib/resourcemanager/exporter_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Exporter", func() {
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
+		ctx = logging.NewContextWithDiscard(ctx)
 		var err error
 		state, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -67,7 +68,7 @@ var _ = Describe("Exporter", func() {
 				},
 			},
 		}
-		res, err := resourcemanager.NewExporter(logging.Discard(), resourcemanager.ExporterOptions{
+		res, err := resourcemanager.NewExporter(resourcemanager.ExporterOptions{
 			KubeClient: testenv.Client,
 			Objects: managedresource.ManagedResourceStatusList{
 				{
@@ -120,7 +121,7 @@ var _ = Describe("Exporter", func() {
 				},
 			},
 		}
-		res, err := resourcemanager.NewExporter(logging.Discard(), resourcemanager.ExporterOptions{
+		res, err := resourcemanager.NewExporter(resourcemanager.ExporterOptions{
 			KubeClient: testenv.Client,
 			Objects: managedresource.ManagedResourceStatusList{
 				{
@@ -175,7 +176,7 @@ var _ = Describe("Exporter", func() {
 				},
 			},
 		}
-		res, err := resourcemanager.NewExporter(logging.Discard(), resourcemanager.ExporterOptions{
+		res, err := resourcemanager.NewExporter(resourcemanager.ExporterOptions{
 			KubeClient:     testenv.Client,
 			DefaultTimeout: &timeout,
 			Objects: managedresource.ManagedResourceStatusList{
@@ -221,7 +222,7 @@ var _ = Describe("Exporter", func() {
 				},
 			},
 		}
-		_, err := resourcemanager.NewExporter(logging.Discard(), resourcemanager.ExporterOptions{
+		_, err := resourcemanager.NewExporter(resourcemanager.ExporterOptions{
 			KubeClient:     testenv.Client,
 			DefaultTimeout: &timeout,
 			Objects:        managedresource.ManagedResourceStatusList{},
@@ -269,7 +270,7 @@ var _ = Describe("Exporter", func() {
 					},
 				},
 			}
-			res, err := resourcemanager.NewExporter(logging.Discard(), resourcemanager.ExporterOptions{
+			res, err := resourcemanager.NewExporter(resourcemanager.ExporterOptions{
 				KubeClient:     testenv.Client,
 				DefaultTimeout: &timeout,
 				Objects: managedresource.ManagedResourceStatusList{
@@ -331,7 +332,7 @@ var _ = Describe("Exporter", func() {
 					},
 				},
 			}
-			res, err := resourcemanager.NewExporter(logging.Discard(), resourcemanager.ExporterOptions{
+			res, err := resourcemanager.NewExporter(resourcemanager.ExporterOptions{
 				KubeClient:     testenv.Client,
 				DefaultTimeout: &timeout,
 				Objects: managedresource.ManagedResourceStatusList{

--- a/pkg/deployer/lib/resourcemanager/objectapplier_test.go
+++ b/pkg/deployer/lib/resourcemanager/objectapplier_test.go
@@ -30,20 +30,21 @@ var _ = Describe("ObjectApplier", func() {
 
 	var (
 		state *envtest.State
+		ctx   context.Context
 	)
 
 	BeforeEach(func() {
 		var err error
-		state, err = testenv.InitState(context.TODO())
+		ctx = logging.NewContextWithDiscard(context.TODO())
+		state, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(state.CleanupState(context.TODO()))
+		Expect(state.CleanupState(ctx))
 	})
 
 	It("should apply and update a configmap", func() {
-		ctx := context.TODO()
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
 		cm.Namespace = state.Namespace
@@ -68,7 +69,7 @@ var _ = Describe("ObjectApplier", func() {
 			ManagedResources: managedresource.ManagedResourceStatusList{},
 		}
 
-		managedResources, err := resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err := resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		res := &corev1.ConfigMap{}
@@ -92,7 +93,7 @@ var _ = Describe("ObjectApplier", func() {
 			},
 		}
 		opts.ManagedResources = managedResources
-		_, err = resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		_, err = resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		res = &corev1.ConfigMap{}
@@ -101,7 +102,6 @@ var _ = Describe("ObjectApplier", func() {
 	})
 
 	It("should delete a orphaned resource", func() {
-		ctx := context.TODO()
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
 		cm.Namespace = state.Namespace
@@ -125,7 +125,7 @@ var _ = Describe("ObjectApplier", func() {
 			},
 			ManagedResources: managedresource.ManagedResourceStatusList{},
 		}
-		managedResources, err := resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err := resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		res := &corev1.ConfigMap{}
@@ -142,7 +142,7 @@ var _ = Describe("ObjectApplier", func() {
 
 		opts.Manifests = []managedresource.Manifest{}
 		opts.ManagedResources = managedResources
-		managedResources, err = resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err = resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		res = &corev1.ConfigMap{}
@@ -151,8 +151,6 @@ var _ = Describe("ObjectApplier", func() {
 	})
 
 	It("should keep a sorted list of managed resources", func() {
-		ctx := context.TODO()
-
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
 		cm.Namespace = state.Namespace
@@ -187,7 +185,7 @@ var _ = Describe("ObjectApplier", func() {
 			},
 			ManagedResources: managedresource.ManagedResourceStatusList{},
 		}
-		managedResources, err := resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err := resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		res := &corev1.ConfigMap{}
@@ -205,7 +203,7 @@ var _ = Describe("ObjectApplier", func() {
 
 			opts.Manifests[0].Manifest = cmRaw
 			opts.ManagedResources = managedResources
-			managedResources, err = resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+			managedResources, err = resourcemanager.ApplyManifests(ctx, opts)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(managedResources).To(HaveLen(2))
@@ -216,8 +214,6 @@ var _ = Describe("ObjectApplier", func() {
 	})
 
 	It("should create a namespace before other resources", func() {
-		ctx := context.TODO()
-
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
 		cm.Namespace = "test"
@@ -249,7 +245,7 @@ var _ = Describe("ObjectApplier", func() {
 			},
 			ManagedResources: managedresource.ManagedResourceStatusList{},
 		}
-		managedResources, err := resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err := resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		res := &corev1.ConfigMap{}
@@ -262,8 +258,6 @@ var _ = Describe("ObjectApplier", func() {
 	})
 
 	It("should not update immutable resources", func() {
-		ctx := context.Background()
-
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-cm"
 		cm.Namespace = "test"
@@ -288,7 +282,7 @@ var _ = Describe("ObjectApplier", func() {
 			},
 			ManagedResources: managedresource.ManagedResourceStatusList{},
 		}
-		managedResources, err := resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err := resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(managedResources).To(HaveLen(1))
@@ -316,7 +310,7 @@ var _ = Describe("ObjectApplier", func() {
 			},
 			ManagedResources: managedresource.ManagedResourceStatusList{},
 		}
-		managedResources, err = resourcemanager.ApplyManifests(ctx, logging.Discard(), opts)
+		managedResources, err = resourcemanager.ApplyManifests(ctx, opts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(managedResources).To(HaveLen(1))

--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +19,8 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 
 	lserrors "github.com/gardener/landscaper/apis/errors"
 	"github.com/gardener/landscaper/pkg/api"

--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,21 +50,21 @@ func HandleAnnotationsAndGeneration(ctx context.Context,
 		// - force-reconcile annotation
 		// - outdated generation
 		opAnn := lsv1alpha1helper.GetOperation(di.ObjectMeta)
-		log.Debug("reconcile required, setting observed generation, phase, and last change reconcile timestamp", "operationAnnotation", opAnn, "observedGeneration", di.Status.ObservedGeneration, "generation", di.Generation)
+		log.Info("Reconcile required, setting observed generation, phase, and last change reconcile timestamp", lc.KeyOperationAnnotation, opAnn, lc.KeyObservedGeneration, di.Status.ObservedGeneration, lc.KeyGeneration, di.Generation)
 		if err := PrepareReconcile(ctx, kubeClient, di, deployerInfo); err != nil {
 			return err
 		}
 	}
 
 	if hasReconcileAnnotation {
-		log.Debug("removing reconcile annotation")
+		log.Debug("Removing reconcile annotation")
 		delete(di.ObjectMeta.Annotations, lsv1alpha1.OperationAnnotation)
-		log.Debug("updating metadata")
+		log.Debug("Updating metadata")
 		writer := read_write_layer.NewWriter(kubeClient)
 		if err := writer.UpdateDeployItem(ctx, read_write_layer.W000046, di); err != nil {
 			return err
 		}
-		log.Debug("successfully updated metadata")
+		log.Debug("Successfully updated metadata")
 	}
 
 	return nil
@@ -78,16 +79,16 @@ func PrepareReconcile(ctx context.Context, kubeClient client.Client, di *lsv1alp
 	now := metav1.Now()
 	di.Status.LastReconcileTime = &now
 	if di.Status.Deployer.Identity != deployerInfo.Identity {
-		log.Debug("updating deployer identity")
+		log.Debug("Updating deployer identity")
 		di.Status.Deployer = deployerInfo
 	}
 
-	log.Debug("updating status")
+	log.Debug("Updating status")
 	writer := read_write_layer.NewWriter(kubeClient)
 	if err := writer.UpdateDeployItemStatus(ctx, read_write_layer.W000058, di); err != nil {
 		return err
 	}
-	log.Debug("successfully updated status")
+	log.Debug("Successfully updated status")
 	return nil
 }
 

--- a/pkg/deployer/manifest/add.go
+++ b/pkg/deployer/manifest/add.go
@@ -17,7 +17,7 @@ import (
 
 // AddDeployerToManager adds a new helm deployers to a controller manager.
 func AddDeployerToManager(logger logging.Logger, lsMgr, hostMgr manager.Manager, config manifestv1alpha2.Configuration) error {
-	log := logger.WithName("ManifestDeployer")
+	log := logger.WithName("k8sManifest")
 	d, err := NewDeployer(
 		log,
 		lsMgr.GetClient(),

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -49,7 +49,7 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 		}
 	}
 
-	applier := resourcemanager.NewManifestApplier(m.log, resourcemanager.ManifestApplierOptions{
+	applier := resourcemanager.NewManifestApplier(resourcemanager.ManifestApplierOptions{
 		Decoder:          serializer.NewCodecFactory(Scheme).UniversalDecoder(),
 		KubeClient:       targetClient,
 		Clientset:        targetClientSet,
@@ -96,7 +96,7 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 		if m.Configuration.Export.DefaultTimeout != nil {
 			opts.DefaultTimeout = &m.Configuration.Export.DefaultTimeout.Duration
 		}
-		exporter := resourcemanager.NewExporter(m.log, opts)
+		exporter := resourcemanager.NewExporter(opts)
 		exports, err := exporter.Export(ctx, m.ProviderConfiguration.Exports)
 		if err != nil {
 			return lserrors.NewWrappedError(err, currOp, "ReadExportValues", err.Error())
@@ -122,7 +122,6 @@ func (m *Manifest) CheckResourcesReady(ctx context.Context, client client.Client
 			Context:          ctx,
 			Client:           client,
 			CurrentOp:        "DefaultCheckResourcesReadinessManifest",
-			Log:              m.log,
 			Timeout:          m.ProviderConfiguration.ReadinessChecks.Timeout,
 			ManagedResources: managedresources,
 		}
@@ -137,7 +136,6 @@ func (m *Manifest) CheckResourcesReady(ctx context.Context, client client.Client
 			customReadinessCheck := health.CustomReadinessCheck{
 				Context:          ctx,
 				Client:           client,
-				Log:              m.log,
 				CurrentOp:        "CustomCheckResourcesReadinessManifest",
 				Timeout:          m.ProviderConfiguration.ReadinessChecks.Timeout,
 				ManagedResources: managedresources,

--- a/pkg/deployer/manifest/test/e2e_test.go
+++ b/pkg/deployer/manifest/test/e2e_test.go
@@ -54,7 +54,6 @@ var _ = Describe("Manifest Deployer", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		ctrl = deployerlib.NewController(
-			logging.Discard(),
 			testenv.Client,
 			api.LandscaperScheme,
 			record.NewFakeRecorder(1024),

--- a/pkg/deployer/mock/add.go
+++ b/pkg/deployer/mock/add.go
@@ -19,7 +19,7 @@ import (
 
 // AddDeployerToManager adds a new helm deployers to a controller manager.
 func AddDeployerToManager(logger logging.Logger, lsMgr, hostMgr manager.Manager, config mockv1alpha1.Configuration) error {
-	log := logger.WithName("MockDeployer")
+	log := logger.WithName("mock")
 	d, err := NewDeployer(
 		log,
 		lsMgr.GetClient(),

--- a/pkg/deployer/mock/add.go
+++ b/pkg/deployer/mock/add.go
@@ -53,8 +53,8 @@ func NewController(log logging.Logger, kubeClient client.Client, scheme *runtime
 		return nil, err
 	}
 
-	return deployerlib.NewController(log,
-		kubeClient, scheme, eventRecorder,
+	return deployerlib.NewController(kubeClient,
+		scheme, eventRecorder,
 		kubeClient, scheme,
 		deployerlib.DeployerArgs{
 			Type:            Type,

--- a/pkg/landscaper/controllers/deployitem/add.go
+++ b/pkg/landscaper/controllers/deployitem/add.go
@@ -25,7 +25,7 @@ func AddControllerToManager(logger logging.Logger,
 	deployItemPickupTimeout,
 	deployItemAbortingTimeout,
 	deployItemDefaultTimeout *lscore.Duration) error {
-	log := logger.Reconciles("deployItem", "DeployItem")
+	log := logger.Reconciles("", "DeployItem")
 	a, err := NewController(
 		log,
 		mgr.GetClient(),

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -71,8 +71,12 @@ const (
 	KeyGroupVersionKind = "groupVersionKind"
 	// KeyStatus is for a status of whatever kind.
 	KeyStatus = "status"
-	// KeyOperationAnnotation is for logging the value of the current operation annotation
+	// KeyOperationAnnotation is for logging the value of the current operation annotation.
 	KeyOperationAnnotation = "operationAnnotation"
+	// KeyReason is for providing a reason.
+	KeyReason = "reason"
+	// KeyPhase is for a generic phase. For the phases of Installations, Executions, or DeployItems, use the more specific constants.
+	KeyPhase = "phase"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -63,6 +63,10 @@ const (
 	KeyFileName = "fileName"
 	// KeyServiceAccount is for a kubernetes service account.
 	KeyServiceAccount = "serviceAccount"
+	// KeyDeployItemType is for the type of deployitem which is handled by the controller.
+	KeyDeployItemType = "deployItemType"
+	// KeyError is for logging an error message without using 'logger.Error' for whatever reason.
+	KeyError = "error"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -67,6 +67,12 @@ const (
 	KeyDeployItemType = "deployItemType"
 	// KeyError is for logging an error message without using 'logger.Error' for whatever reason.
 	KeyError = "error"
+	// KeyGroupVersionKind is for listing group, version, and kind of a resource.
+	KeyGroupVersionKind = "groupVersionKind"
+	// KeyStatus is for a status of whatever kind.
+	KeyStatus = "status"
+	// KeyOperationAnnotation is for logging the value of the current operation annotation
+	KeyOperationAnnotation = "operationAnnotation"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -161,8 +161,10 @@ func FromContextOrNew(ctx context.Context, keysAndValuesFallback []interface{}, 
 		ctx = NewContext(ctx, newLogger)
 		return newLogger, ctx
 	}
-	log = log.WithValues(keysAndValues...)
-	ctx = NewContext(ctx, log)
+	if len(keysAndValues) > 0 {
+		log = log.WithValues(keysAndValues...)
+		ctx = NewContext(ctx, log)
+	}
 	return log, ctx
 }
 

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -143,7 +143,6 @@ func FromContextOrDiscard(ctx context.Context) Logger {
 }
 
 // NewContext is a wrapper for logr.NewContext.
-// It adds the logger to the context twice, in a wrapped as well as a logr version.
 func NewContext(ctx context.Context, log Logger) context.Context {
 	return logr.NewContext(ctx, log.Logr())
 }

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -142,6 +142,24 @@ func FromContextOrDiscard(ctx context.Context) Logger {
 	return log
 }
 
+// NewContext is a wrapper for logr.NewContext.
+// It adds the logger to the context twice, in a wrapped as well as a logr version.
+func NewContext(ctx context.Context, log Logger) context.Context {
+	return logr.NewContext(ctx, log.Logr())
+}
+
+// Discard is a wrapper for logr.Discard.
+func Discard() Logger {
+	return Wrap(logr.Discard())
+}
+
+// ADDITIONAL FUNCTIONS
+
+// Wrap constructs a new Logger, using the provided logr.Logger internally.
+func Wrap(log logr.Logger) Logger {
+	return Logger{internal: log}
+}
+
 // FromContextOrNew tries to fetch a logger from the context.
 // It is expected that a logger is contained in the context. If retrieving it fails, a new logger will be created and an error is logged.
 // keysAndValuesFallback contains keys and values which will only be added if the logger could not be retrieved and a new one had to be created.
@@ -181,21 +199,9 @@ func FromContextWithFallback(ctx context.Context, fallback Logger, keysAndValues
 	return log, ctx
 }
 
-func Discard() Logger {
-	return Wrap(logr.Discard())
-}
-
-// NewContext is a wrapper for logr.NewContext.
-// It adds the logger to the context twice, in a wrapped as well as a logr version.
-func NewContext(ctx context.Context, log Logger) context.Context {
-	return logr.NewContext(ctx, log.Logr())
-}
-
-// ADDITIONAL FUNCTIONS
-
-// Wrap constructs a new Logger, using the provided logr.Logger internally.
-func Wrap(log logr.Logger) Logger {
-	return Logger{internal: log}
+// NewContextWithDiscard adds a discard logger to the given context and returns the new context.
+func NewContextWithDiscard(ctx context.Context) context.Context {
+	return NewContext(ctx, Discard())
 }
 
 // Debug logs a message at DEBUG level.

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -230,7 +230,14 @@ func (l Logger) IsInitialized() bool {
 // Reconciles is meant to be used for the logger initialization for controllers.
 // It is a wrapper for WithName(name).WithValues(lc.KeyReconciledResourceKind, reconciledResource).
 func (l Logger) Reconciles(name, reconciledResource string) Logger {
-	return l.WithName(name).WithValues(lc.KeyReconciledResourceKind, reconciledResource)
+	log := l
+	if len(name) != 0 {
+		log = log.WithName(name)
+	}
+	if len(reconciledResource) != 0 {
+		log = log.WithValues(lc.KeyReconciledResourceKind, reconciledResource)
+	}
+	return log
 }
 
 // Logr returns the internal logr.Logger.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

**What this PR contains**
- logging refactoring of the deployer lib
- logging refactoring of the container deployer
- unifying the logger names for all deployers (e.g. "deployer.helm" for the helm deployer, "deployer.k8sManifest" for the manifest deployer, ...)

**What this PR does not contain**
- logging refactoring of the helm deployer
- logging refactoring of the manifest deployer
- logging refactoring of the mock deployer

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
