### PR TITLE
add manifest deployer immutable policy

### DIFF
--- a/apis/deployer/utils/managedresource/types.go
+++ b/apis/deployer/utils/managedresource/types.go
@@ -27,6 +27,8 @@ const (
 	KeepPolicy ManifestPolicy = "keep"
 	// IgnorePolicy defines a policy where the resource is completely ignored by the deployer.
 	IgnorePolicy ManifestPolicy = "ignore"
+	// ImmutablePolicy defines a policy where the resource is created and deleted but never updated.
+	ImmutablePolicy ManifestPolicy = "immutable"
 )
 
 // Manifest defines a manifest that is managed by the deployer.

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -143,7 +143,7 @@ __Policy__:
 - `fallback`: The manifest will be created, updated and deleted (only if not already managed by someone else: check for annotation with landscaper identity, deployitem name + namespace)
 - `keep`: The manifest will be created, updated, but not deleted.
 - `ignore`: The manifest will be completely ignored.
-- `immutable`: The manifest be created and deleted, but never updated. 
+- `immutable`: The manifest will be created and deleted, but never updated. 
 
 ### Status
 

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -139,10 +139,11 @@ spec:
 
 __Policy__:
 
-- `manage`: create, update and delete (occupies already managed resources)
-- `fallback`: create, update and delete (only if not already managed by someone else: check for annotation with landscaper identity, deployitem name + namespace)
-- `keep`: create, update
-- `ignore`: forget
+- `manage`: The manifest will be created, updated and deleted (occupies already managed resources).
+- `fallback`: The manifest will be created, updated and deleted (only if not already managed by someone else: check for annotation with landscaper identity, deployitem name + namespace)
+- `keep`: The manifest will be created, updated, but not deleted.
+- `ignore`: The manifest will be completely ignored.
+- `immutable`: The manifest be created and deleted, but never updated. 
 
 ### Status
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/utils/managedresource/types.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/utils/managedresource/types.go
@@ -27,6 +27,8 @@ const (
 	KeepPolicy ManifestPolicy = "keep"
 	// IgnorePolicy defines a policy where the resource is completely ignored by the deployer.
 	IgnorePolicy ManifestPolicy = "ignore"
+	// ImmutablePolicy defines a policy where the resource is created and deleted but never updated.
+	ImmutablePolicy ManifestPolicy = "immutable"
 )
 
 // Manifest defines a manifest that is managed by the deployer.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area manifest-deployer
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Some Kubernetes resources are immutable (probably enforced by a validating webhook). To support this use case in the manifest deployer, this PR introduces a new `immutable` policy.
Manifests with this policy will be created and deleted, but never updated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add manifest deployer immutable manifest policy.
```
