### PR TITLE
remove the check for an manifest/helm export to be a managed resource

### DIFF
--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -130,45 +130,39 @@ spec:
     createNamespace: true
     # Values to template the chart
     # optional
-    values: {}
+    values:
+      KeyA: valA
 
-    # Define exports that are read from the manifests and exported so 
-    # that is can be used by other deployitems.
-    # The exports are read form the deployed resources so status and other runtime attributes
-    # are available and can be exported.
+    # Define exports that are read from the kubernetes resources or helm values,
+    # so they can be used by other deployitems or installations.
+    # The deployer tries to read the export values until either the global or the specific timeout is exceeded.
     exports:
-      defaultTimeout: 5m
+      defaultTimeout: 5m # global default timeout that is used when no specific timeout is set
       exports:
-      # Describes one export that is read from the templates values or a templated resource.
-      # The value will be by default read from the values if fromResource is not specified.
-      # The specified jsonPath value is written with the given key to the exported configuration.
-      - key: KeyA # value is read from the values file
-        jsonPath: .Values.keyA
-      - key: KeyB # value is read from secret
+      - key: KeyA # value is read from the helm values
+        jsonPath: .Values.keyA # points to the key in the helm values 
+      - key: KeyB # value is read from a secret and exported with name "KeyB"
         timeout: 10m # optional specific timeout
-        jsonPath: .spec.config
-        fromResource:
-          apiVersion: v1
+        jsonPath: .data.somekey # points to the value in the resource that is being exported
+        fromResource: # required
+          apiVersion: v1 # specification of the resource type
           kind: Secret
-          name: my-secret
-          namespace: a
-      - key: KeyC # value is read from secret that is referenced by a service account
+          name: my-secret # name of the resource
+          namespace: a # namespace of the resource
+      - key: KeyC # value is read from secret that is referenced by a service account and exported with name "KeyC"
         timeout: 10m # optional specific timeout
-        jsonPath: .secrets[0] # points to a object ref that consists of a name and namespace
+        jsonPath: .secrets[0] # points to an object reference that consists of a name and namespace
         fromResource:
-          apiVersion: v1
+          apiVersion: v1 # specification of the resource type
           kind: ServiceAccount
-          name: my-user
-          namespace: a
+          name: my-user # name of the resource
+          namespace: a # namespace of the resource
         # Defines the referenced objects kind and version. 
-        # The name and namespace is taken from the resource defined in "fromResource".
-        fromObjectRef: 
+        # The name and namespace is taken from the jsonPath defined in "fromResource".
+        fromObjectRef:
           apiVersion: v1
           kind: Secret
-          jsonPath: ".data.somekey" # jsonpath in the secret
-
-    
-    exportsFromManifests: [] # same as exports.exports but deprecated
+          jsonPath: ".data.somekey" # points to the value in the resource that is being exported
 ```
 
 Exports can be defined in `exportsFromManifests` by specifying the exported key to export.

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -103,38 +103,34 @@ spec:
           config: abc
     - ...
     
-    # Define exports that are read from the manifests and exported so 
-    # that is can be used by other deployitems.
-    # The exports are read form the deployed resources so status and other runtime attributes
-    # are available and can be exported.
+    # Define exports that are read from the kubernetes resources,
+    # so they can be used by other deployitems or installations.
+    # The deployer tries to read the export values until either the global or the specific timeout is exceeded.
     exports:
-      defaultTimeout: 5m
+      defaultTimeout: 5m # global default timeout that is used when no specific timeout is set
       exports:
-      # Describes one export that is read from the templates values or a templated resource.
-      # The value will be by default read from the values if fromResource is not specified.
-      # The specified jsonPath value is written with the given key to the exported configuration.
-      - key: KeyB # value is read from secret
+      - key: KeyA # value is read from a secret and exported with name "KeyA"
         timeout: 10m # optional specific timeout
-        jsonPath: .spec.config
+        jsonPath: .data.somekey # points to the value in the resource that is being exported
         fromResource: # required
-          apiVersion: v1
+          apiVersion: v1 # specification of the resource type
           kind: Secret
-          name: my-secret
-          namespace: a
-      - key: KeyC # value is read from secret that is referenced by a service account
+          name: my-secret # name of the resource
+          namespace: a # namespace of the resource
+      - key: KeyB # value is read from secret that is referenced by a service account and exported with name "KeyB"
         timeout: 10m # optional specific timeout
-        jsonPath: .secrets[0] # points to a object ref that consists of a name and namespace
+        jsonPath: .secrets[0] # points to an object reference that consists of a name and namespace
         fromResource:
-          apiVersion: v1
+          apiVersion: v1 # specification of the resource type
           kind: ServiceAccount
-          name: my-user
-          namespace: a
+          name: my-user # name of the resource
+          namespace: a # namespace of the resource
         # Defines the referenced objects kind and version. 
-        # The name and namespace is taken from the resource defined in "fromResource".
+        # The name and namespace is taken from the jsonPath defined in "fromResource".
         fromObjectRef:
           apiVersion: v1
           kind: Secret
-          jsonPath: ".data.somekey" # jsonpath in the secret
+          jsonPath: ".data.somekey" # points to the value in the resource that is being exported
 ```
 
 __Policy__:

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Template", func() {
 
 			Expect(testenv.Client.Get(ctx, item.Status.ExportReference.NamespacedName(), export)).ToNot(HaveOccurred())
 			Expect(export.Data).To(HaveKey("config"))
-			configRaw, _ := export.Data["config"]
+			configRaw := export.Data["config"]
 
 			var config map[string]interface{}
 			Expect(json.Unmarshal(configRaw, &config)).ToNot(HaveOccurred())

--- a/pkg/deployer/lib/resourcemanager/exporter_test.go
+++ b/pkg/deployer/lib/resourcemanager/exporter_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Exporter", func() {
 		}))
 	})
 
-	It("should refuse to export if the resource is not managed by the exporter", func() {
+	It("should not refuse to export if the resource is not managed by the exporter", func() {
 		ctx := context.Background()
 		cm := &corev1.ConfigMap{}
 		cm.Name = "my-data"
@@ -226,7 +226,7 @@ var _ = Describe("Exporter", func() {
 			DefaultTimeout: &timeout,
 			Objects:        managedresource.ManagedResourceStatusList{},
 		}).Export(ctx, exports)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("referenced resource", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Previously for exports in helm/manifest deployitems, the resource from which the value is exported, was checked for being managed by the deployer. This only worsens the usability without serving any valid use case.
This PR removes the check for being a manged resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Helm and Manifest Deployer can now epxport data from non-managed resources.
```
