### PR TITLE
update verbosity type in landscaper-service component

### DIFF
--- a/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
@@ -19,7 +19,7 @@ deployItems:
         fullnameOverride: landscaper-{{ .imports.hostingClusterNamespace }}
 
         landscaper:
-          verbosity: {{ .imports.landscaperConfig.landscaper.verbosity | default 2 }}
+          verbosity: {{ .imports.landscaperConfig.landscaper.verbosity | default "info" }}
           crdManagement:
             deployCrd: true
             forceUpdate: true

--- a/.landscaper/landscaper-service/definition/landscaper-configuration.json
+++ b/.landscaper/landscaper-service/definition/landscaper-configuration.json
@@ -25,8 +25,8 @@
     "landscaperConfig" : {
       "properties": {
         "verbosity": {
-          "type": "integer",
-          "format": "int32"
+          "type": "string",
+          "enum": ["error", "info", "debug", "Error", "Info", "Debug", "ERROR", "INFO", "DEBUG"]
         },
         "replicas": {
           "type:": "integer",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area laas
/kind bug
/priority 3

**What this PR does / why we need it**:

The verbosity flag "-v" type has changed from integer type to a string type.
This change needs to be reflected in the landscaper-service component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
