### PR TITLE
New logging for helm, manifest and mock deployer

### DIFF
--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -77,6 +77,10 @@ const (
 	KeyReason = "reason"
 	// KeyPhase is for a generic phase. For the phases of Installations, Executions, or DeployItems, use the more specific constants.
 	KeyPhase = "phase"
+	// KeyExportKey is for the key that the value from JSONPath is exported to.
+	KeyExportKey = "exportKey"
+	// KeyManagedResourcePolicy is for the manage policy of a resource.
+	KeyManagedResourcePolicy = "managedResourcePolicy"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/pkg/deployer/container/add.go
+++ b/pkg/deployer/container/add.go
@@ -17,10 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/go-logr/logr"
+
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	deployerlib "github.com/gardener/landscaper/pkg/deployer/lib"
 	"github.com/gardener/landscaper/pkg/version"
-	"github.com/go-logr/logr"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	containerv1alpha1 "github.com/gardener/landscaper/apis/deployer/container/v1alpha1"

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -622,7 +622,7 @@ func (c *Container) SyncConfiguration(ctx context.Context, defaultLabels map[str
 // SyncExport syncs the export secret from the wait container to the deploy item export.
 func (c *Container) SyncExport(ctx context.Context) error {
 	log, ctx := logging.FromContextOrNew(ctx, nil)
-	log.Debug("Sync export to landscaper cluster", lc.KeyResource)
+	log.Debug("Sync export to landscaper cluster")
 	secret := &corev1.Secret{}
 	key := kutil.ObjectKey(ExportSecretName(c.DeployItem.Namespace, c.DeployItem.Name), c.Configuration.Namespace)
 	if err := c.directHostClient.Get(ctx, key, secret); err != nil {

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -622,7 +622,7 @@ func (c *Container) SyncConfiguration(ctx context.Context, defaultLabels map[str
 // SyncExport syncs the export secret from the wait container to the deploy item export.
 func (c *Container) SyncExport(ctx context.Context) error {
 	log, ctx := logging.FromContextOrNew(ctx, nil)
-	log.Debug("Sync export to landscaper cluster", "deployitem", kutil.ObjectKey(c.DeployItem.Name, c.DeployItem.Namespace).String())
+	log.Debug("Sync export to landscaper cluster", lc.KeyResource)
 	secret := &corev1.Secret{}
 	key := kutil.ObjectKey(ExportSecretName(c.DeployItem.Namespace, c.DeployItem.Name), c.Configuration.Namespace)
 	if err := c.directHostClient.Get(ctx, key, secret); err != nil {

--- a/pkg/deployer/container/garbage_collector.go
+++ b/pkg/deployer/container/garbage_collector.go
@@ -10,8 +10,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -130,7 +131,7 @@ func (gc *GarbageCollector) cleanupRBACResources(obj client.Object) reconcile.Re
 			if apierrors.IsNotFound(err) {
 				return reconcile.Result{}, nil
 			}
-			gc.log.Error(err, "Rnable to get resource")
+			gc.log.Error(err, "unable to get resource")
 			return reconcile.Result{}, err
 		}
 		shouldGC, err := gc.shouldGarbageCollect(ctx, obj)

--- a/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
+++ b/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GetChart", func() {
 
 	Context("FromOCIRegistry", func() {
 		It("should resolve a chart from public readable helm ociClient artifact", func() {
-			ctx := context.Background()
+			ctx := logging.NewContext(context.Background(), logging.Discard())
 			defer ctx.Done()
 			ociClient, err := ociclient.NewClient(logr.Discard())
 			Expect(err).ToNot(HaveOccurred())
@@ -47,13 +47,13 @@ var _ = Describe("GetChart", func() {
 				Ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:3.29.0",
 			}
 
-			chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+			chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(chart.Metadata.Name).To(Equal("ingress-nginx"))
 		})
 
 		It("should resolve a legacy chart from public readable helm ociClient artifact", func() {
-			ctx := context.Background()
+			ctx := logging.NewContext(context.Background(), logging.Discard())
 			defer ctx.Done()
 			ociClient, err := ociclient.NewClient(logr.Discard())
 			Expect(err).ToNot(HaveOccurred())
@@ -62,14 +62,14 @@ var _ = Describe("GetChart", func() {
 				Ref: "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v3.29.0",
 			}
 
-			chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+			chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(chart.Metadata.Name).To(Equal("ingress-nginx"))
 		})
 	})
 
 	It("should resolve a chart from a public readable component descriptor", func() {
-		ctx := context.Background()
+		ctx := logging.NewContext(context.Background(), logging.Discard())
 		defer ctx.Done()
 		ociClient, err := ociclient.NewClient(logr.Discard())
 		Expect(err).ToNot(HaveOccurred())
@@ -86,13 +86,13 @@ var _ = Describe("GetChart", func() {
 			FromResource: ref,
 		}
 
-		chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+		chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(chart.Metadata.Name).To(Equal("ingress-nginx"))
 	})
 
 	It("should resolve a chart from an inline component descriptor", func() {
-		ctx := context.Background()
+		ctx := logging.NewContext(context.Background(), logging.Discard())
 		defer ctx.Done()
 		ociClient, err := ociclient.NewClient(logr.Discard())
 		Expect(err).ToNot(HaveOccurred())
@@ -112,13 +112,13 @@ var _ = Describe("GetChart", func() {
 			FromResource: ref,
 		}
 
-		chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+		chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(chart.Metadata.Name).To(Equal("ingress-nginx"))
 	})
 
 	It("should resolve a chart as base64 encoded file", func() {
-		ctx := context.Background()
+		ctx := logging.NewContext(context.Background(), logging.Discard())
 		ociClient, err := ociclient.NewClient(logr.Discard())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -131,7 +131,7 @@ var _ = Describe("GetChart", func() {
 			},
 		}
 
-		chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+		chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(chart.Metadata.Name).To(Equal("testchart"))
 	})
@@ -150,7 +150,7 @@ var _ = Describe("GetChart", func() {
 		})
 
 		It("should resolve a chart from a webserver", func() {
-			ctx := context.Background()
+			ctx := logging.NewContext(context.Background(), logging.Discard())
 			defer ctx.Done()
 			ociClient, err := ociclient.NewClient(logr.Discard())
 			Expect(err).ToNot(HaveOccurred())
@@ -171,13 +171,13 @@ var _ = Describe("GetChart", func() {
 				},
 			}
 
-			chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+			chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(chart.Metadata.Name).To(Equal("testchart"))
 		})
 
 		It("should not try to load a chart for non-success http status codes", func() {
-			ctx := context.Background()
+			ctx := logging.NewContext(context.Background(), logging.Discard())
 			defer ctx.Done()
 			ociClient, err := ociclient.NewClient(logr.Discard())
 			Expect(err).ToNot(HaveOccurred())
@@ -197,7 +197,7 @@ var _ = Describe("GetChart", func() {
 				},
 			}
 
-			chart, err := chartresolver.GetChart(ctx, logging.Discard(), ociClient, nil, chartAccess)
+			chart, err := chartresolver.GetChart(ctx, ociClient, nil, chartAccess)
 			Expect(chart).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(http.StatusText(401)))

--- a/pkg/deployer/helm/deployer.go
+++ b/pkg/deployer/helm/deployer.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"time"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	"github.com/gardener/component-cli/ociclient/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -65,7 +67,7 @@ type deployer struct {
 }
 
 func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, target, lsCtx, d.sharedCache)
+	helm, err := New(d.config, d.lsClient, d.hostClient, di, target, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
@@ -86,7 +88,7 @@ func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di 
 }
 
 func (d *deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, target, lsCtx, d.sharedCache)
+	helm, err := New(d.config, d.lsClient, d.hostClient, di, target, lsCtx, d.sharedCache)
 	if err != nil {
 		return err
 	}
@@ -103,7 +105,8 @@ func (d *deployer) ForceReconcile(ctx context.Context, lsCtx *lsv1alpha1.Context
 }
 
 func (d *deployer) Abort(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	d.log.Info("abort is not yet implemented")
+	logger, _ := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "Abort"})
+	logger.Info("abort is not yet implemented")
 	return nil
 }
 
@@ -113,7 +116,7 @@ func (d *deployer) ExtensionHooks() extension.ReconcileExtensionHooks {
 
 func (d *deployer) NextReconcile(ctx context.Context, last time.Time, di *lsv1alpha1.DeployItem) (*time.Time, error) {
 	// todo: directly parse deploy items
-	helm, err := New(d.log, d.config, d.lsClient, d.hostClient, di, nil, nil, d.sharedCache)
+	helm, err := New(d.config, d.lsClient, d.hostClient, di, nil, nil, d.sharedCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/helm/deployer.go
+++ b/pkg/deployer/helm/deployer.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"time"
 
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
-
 	"github.com/gardener/component-cli/ociclient/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -105,8 +103,7 @@ func (d *deployer) ForceReconcile(ctx context.Context, lsCtx *lsv1alpha1.Context
 }
 
 func (d *deployer) Abort(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	logger, _ := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "Abort"})
-	logger.Info("abort is not yet implemented")
+	d.log.Info("abort is not yet implemented")
 	return nil
 }
 

--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -81,7 +81,7 @@ func (h *Helm) ApplyFiles(ctx context.Context, files, crds map[string]string, ex
 		// apply helm
 		// convert manifests in ManagedResourceStatusList
 		realHelmDeployer := realhelmdeployer.NewRealHelmDeployer(ch, h.ProviderConfiguration,
-			h.TargetRestConfig, targetClientSet, h.log)
+			h.TargetRestConfig, targetClientSet)
 		deployErr = realHelmDeployer.Deploy(ctx)
 		if deployErr == nil {
 			managedResourceStatusList, err = realHelmDeployer.GetManagedResourcesStatus(ctx, manifests)
@@ -328,7 +328,7 @@ func (h *Helm) deleteManifestsWithRealHelmDeployer(ctx context.Context) error {
 	}
 
 	realHelmDeployer := realhelmdeployer.NewRealHelmDeployer(nil, h.ProviderConfiguration,
-		h.TargetRestConfig, targetClientSet, h.log)
+		h.TargetRestConfig, targetClientSet)
 
 	err = realHelmDeployer.Undeploy(ctx)
 	if err == nil {

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -13,6 +13,8 @@ import (
 
 	"helm.sh/helm/v3/pkg/chart"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/deployer/helm/helmchartrepo"
 
 	"github.com/gardener/component-cli/ociclient"
@@ -41,7 +43,6 @@ import (
 	"github.com/gardener/landscaper/pkg/utils"
 
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 )
 
 const (
@@ -62,7 +63,6 @@ func NewDeployItemBuilder() *utils.DeployItemBuilder {
 
 // Helm is the internal representation of a DeployItem of Type Helm
 type Helm struct {
-	log            logging.Logger
 	lsKubeClient   client.Client
 	hostKubeClient client.Client
 	Configuration  helmv1alpha1.Configuration
@@ -80,8 +80,7 @@ type Helm struct {
 }
 
 // New creates a new internal helm item
-func New(log logging.Logger,
-	helmconfig helmv1alpha1.Configuration,
+func New(helmconfig helmv1alpha1.Configuration,
 	lsKubeClient client.Client,
 	hostKubeClient client.Client,
 	item *lsv1alpha1.DeployItem,
@@ -112,7 +111,6 @@ func New(log logging.Logger,
 	}
 
 	return &Helm{
-		log:                   log.WithValues("deployitem", kutil.ObjectKey(item.Name, item.Namespace)),
 		lsKubeClient:          lsKubeClient,
 		hostKubeClient:        hostKubeClient,
 		Configuration:         helmconfig,
@@ -139,7 +137,6 @@ func (h *Helm) Template(ctx context.Context) (map[string]string, map[string]stri
 	// todo: do caching of charts
 
 	ociClient, err := createOCIClient(ctx,
-		h.log,
 		h.lsKubeClient,
 		append(lib.GetRegistryPullSecretsFromContext(h.Context), h.DeployItem.Spec.RegistryPullSecrets...),
 		h.Configuration,
@@ -261,7 +258,9 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 	return nil, nil, nil, errors.New("neither a target nor kubeconfig are defined")
 }
 
-func createOCIClient(ctx context.Context, log logging.Logger, client client.Client, registryPullSecrets []lsv1alpha1.ObjectReference, config helmv1alpha1.Configuration, sharedCache cache.Cache) (ociclient.Client, error) {
+func createOCIClient(ctx context.Context, client client.Client, registryPullSecrets []lsv1alpha1.ObjectReference, config helmv1alpha1.Configuration, sharedCache cache.Cache) (ociclient.Client, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "lsHealthCheckController.check"})
+
 	// resolve all pull secrets
 	secrets, err := kutil.ResolveSecrets(ctx, client, registryPullSecrets)
 	if err != nil {
@@ -273,7 +272,7 @@ func createOCIClient(ctx context.Context, log logging.Logger, client client.Clie
 	if config.OCI != nil {
 		ociConfigFiles = config.OCI.ConfigFiles
 	}
-	ociKeyring, err := credentials.NewBuilder(log.WithName("ociKeyring").Logr()).
+	ociKeyring, err := credentials.NewBuilder(logger.WithName("ociKeyring").Logr()).
 		WithFS(osfs.New()).
 		FromConfigFiles(ociConfigFiles...).
 		FromPullSecrets(secrets...).
@@ -281,7 +280,7 @@ func createOCIClient(ctx context.Context, log logging.Logger, client client.Clie
 	if err != nil {
 		return nil, err
 	}
-	ociClient, err := ociclient.NewClient(log.Logr(),
+	ociClient, err := ociclient.NewClient(logger.Logr(),
 		utils.WithConfiguration(config.OCI),
 		ociclient.WithKeyring(ociKeyring),
 		ociclient.WithCache(sharedCache),

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -153,8 +153,7 @@ func (h *Helm) Template(ctx context.Context) (map[string]string, map[string]stri
 		return nil, nil, nil, nil, err
 	}
 
-	ch, err := chartresolver.GetChart(ctx, h.log.WithName("chartresolver"), ociClient, helmChartRepoClient,
-		&h.ProviderConfiguration.Chart)
+	ch, err := chartresolver.GetChart(ctx, ociClient, helmChartRepoClient, &h.ProviderConfiguration.Chart)
 	if err != nil {
 		return nil, nil, nil, nil, lserrors.NewWrappedError(err, currOp, "GetHelmChart", err.Error())
 	}

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -148,7 +148,7 @@ func (h *Helm) Template(ctx context.Context) (map[string]string, map[string]stri
 		return nil, nil, nil, nil, lserrors.NewWrappedError(err, currOp, "BuildOCIClient", err.Error())
 	}
 
-	helmChartRepoClient, err := helmchartrepo.NewHelmChartRepoClient(h.log, h.Context)
+	helmChartRepoClient, err := helmchartrepo.NewHelmChartRepoClient(h.Context)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -62,7 +62,7 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("Template", func() {
 	It("should ignore non-kubernetes manifests that are valid yaml", func() {
-		ctx := context.Background()
+		ctx := logging.NewContext(context.Background(), logging.Discard())
 
 		kubeconfig, err := kutil.GenerateKubeconfigJSONBytes(testenv.Env.Config)
 		Expect(err).ToNot(HaveOccurred())
@@ -84,7 +84,7 @@ var _ = Describe("Template", func() {
 		lsCtx := &lsv1alpha1.Context{}
 		lsCtx.Name = lsv1alpha1.DefaultContextName
 		lsCtx.Namespace = item.Namespace
-		h, err := helm.New(logging.Discard(), helmv1alpha1.Configuration{}, testenv.Client, testenv.Client, item, nil, lsCtx, nil)
+		h, err := helm.New(helmv1alpha1.Configuration{}, testenv.Client, testenv.Client, item, nil, lsCtx, nil)
 		Expect(err).ToNot(HaveOccurred())
 		files, crds, _, _, err := h.Template(ctx)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/deployer/lib/resourcemanager/exporter.go
+++ b/pkg/deployer/lib/resourcemanager/exporter.go
@@ -88,7 +88,7 @@ func (e *Exporter) Export(ctx context.Context, exports *managedresource.Exports)
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(ctx, export.Timeout.Duration)
 			defer cancel()
-			log2 := log.WithValues("key", export.Key)
+			log2 := log.WithValues(lc.KeyExportKey, export.Key)
 
 			backoff := wait.Backoff{
 				Jitter: 1.15,

--- a/pkg/deployer/lib/resourcemanager/objectapplier.go
+++ b/pkg/deployer/lib/resourcemanager/objectapplier.go
@@ -289,7 +289,7 @@ func (a *ManifestApplier) cleanupOrphanedResources(ctx context.Context, managedR
 		logger2 := logger.WithValues(lc.KeyResource, types.NamespacedName{Namespace: mr.Resource.Namespace, Name: mr.Resource.Name}.String(), lc.KeyResourceKind, mr.Resource.Kind)
 		logger2.Debug("Checking resource")
 		if mr.Policy == managedresource.IgnorePolicy || mr.Policy == managedresource.KeepPolicy {
-			logger2.Debug("Ignoring resource due to policy", "policy", string(mr.Policy))
+			logger2.Debug("Ignoring resource due to policy", lc.KeyManagedResourcePolicy, string(mr.Policy))
 			continue
 		}
 		ref := mr.Resource

--- a/pkg/deployer/manifest/controller.go
+++ b/pkg/deployer/manifest/controller.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
@@ -48,8 +46,7 @@ type deployer struct {
 }
 
 func (d *deployer) Reconcile(ctx context.Context, _ *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace}.String())
-	manifest, err := New(logger, d.lsClient, d.hostClient, &d.config, di, target)
+	manifest, err := New(d.lsClient, d.hostClient, &d.config, di, target)
 	if err != nil {
 		return err
 	}
@@ -57,8 +54,7 @@ func (d *deployer) Reconcile(ctx context.Context, _ *lsv1alpha1.Context, di *lsv
 }
 
 func (d deployer) Delete(ctx context.Context, _ *lsv1alpha1.Context, di *lsv1alpha1.DeployItem, target *lsv1alpha1.Target) error {
-	logger := d.log.WithValues("resource", types.NamespacedName{Name: di.Name, Namespace: di.Namespace}.String())
-	manifest, err := New(logger, d.lsClient, d.hostClient, &d.config, di, target)
+	manifest, err := New(d.lsClient, d.hostClient, &d.config, di, target)
 	if err != nil {
 		return err
 	}
@@ -83,7 +79,7 @@ func (d *deployer) ExtensionHooks() extension.ReconcileExtensionHooks {
 }
 
 func (d *deployer) NextReconcile(ctx context.Context, last time.Time, di *lsv1alpha1.DeployItem) (*time.Time, error) {
-	manifest, err := New(d.log, d.lsClient, d.hostClient, &d.config, di, nil)
+	manifest, err := New(d.lsClient, d.hostClient, &d.config, di, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -8,6 +8,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +34,8 @@ import (
 
 func (m *Manifest) Reconcile(ctx context.Context) error {
 	currOp := "ReconcileManifests"
+	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, currOp})
+
 	m.DeployItem.Status.Phase = lsv1alpha1.ExecutionPhaseProgressing
 
 	_, targetClient, targetClientSet, err := m.TargetClient(ctx)
@@ -69,7 +74,7 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 		var err2 error
 		m.DeployItem.Status.ProviderStatus, err2 = kutil.ConvertToRawExtension(m.ProviderStatus, Scheme)
 		if err2 != nil {
-			m.log.Error(err, "unable to encode status")
+			logger.Error(err, "unable to encode status")
 		}
 		return err
 	}

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -28,8 +28,6 @@ import (
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 
 	manifestvalidation "github.com/gardener/landscaper/apis/deployer/manifest/validation"
-	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/api"
 )
 
@@ -46,7 +44,6 @@ func init() {
 
 // Manifest is the internal representation of a DeployItem of Type Manifest
 type Manifest struct {
-	log            logging.Logger
 	lsKubeClient   client.Client
 	hostKubeClient client.Client
 	Configuration  *manifestv1alpha2.Configuration
@@ -67,8 +64,7 @@ func NewDeployItemBuilder() *utils.DeployItemBuilder {
 }
 
 // New creates a new internal manifest item
-func New(log logging.Logger,
-	lsKubeClient client.Client,
+func New(lsKubeClient client.Client,
 	hostKubeClient client.Client,
 	configuration *manifestv1alpha2.Configuration,
 	item *lsv1alpha1.DeployItem,
@@ -97,7 +93,6 @@ func New(log logging.Logger,
 	}
 
 	return &Manifest{
-		log:                   log.WithValues("deployitem", kutil.ObjectKey(item.Name, item.Namespace)),
 		lsKubeClient:          lsKubeClient,
 		hostKubeClient:        hostKubeClient,
 		Configuration:         configuration,

--- a/pkg/deployer/manifest/manifest_suite_test.go
+++ b/pkg/deployer/manifest/manifest_suite_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Reconcile", func() {
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
+		ctx := logging.NewContext(context.Background(), logging.Discard())
 		var err error
 		state, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -98,7 +98,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, item)).To(Succeed())
 
-		m, err := manifest.New(logging.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(m.Reconcile(ctx)).To(Succeed())
@@ -144,7 +144,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, item)).To(Succeed())
 
-		m, err := manifest.New(logging.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(m.Reconcile(ctx)).To(Succeed())
@@ -180,7 +180,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, item)).To(Succeed())
 
-		m, err := manifest.New(logging.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(m.Reconcile(ctx)).To(Succeed())
@@ -190,7 +190,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(cmRes.Data).To(HaveKeyWithValue("key", "val"))
 
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(item), item)).To(Succeed())
-		m, err = manifest.New(logging.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		m, err = manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m.Delete(ctx)).To(HaveOccurred())
 		Expect(m.Delete(ctx)).To(Succeed())
@@ -228,7 +228,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, item)).To(Succeed())
 
-		m, err := manifest.New(logging.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(m.Reconcile(ctx)).To(Succeed())
@@ -238,7 +238,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(cmRes.Data).To(HaveKeyWithValue("key", "val"))
 
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(item), item)).To(Succeed())
-		m, err = manifest.New(logging.Discard(), testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		m, err = manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m.Delete(ctx)).To(HaveOccurred())
 		Expect(m.Delete(ctx)).To(Succeed())

--- a/pkg/deployer/manifest/manifest_suite_test.go
+++ b/pkg/deployer/manifest/manifest_suite_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Reconcile", func() {
 	)
 
 	BeforeEach(func() {
-		ctx := logging.NewContext(context.Background(), logging.Discard())
+		ctx = context.Background()
 		var err error
 		state, err = testenv.InitState(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -101,7 +101,8 @@ var _ = Describe("Reconcile", func() {
 		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(m.Reconcile(ctx)).To(Succeed())
+		mctx := logging.NewContext(ctx, logging.Discard())
+		Expect(m.Reconcile(mctx)).To(Succeed())
 
 		cmRes := &corev1.ConfigMap{}
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes)).To(Succeed())
@@ -147,7 +148,8 @@ var _ = Describe("Reconcile", func() {
 		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(m.Reconcile(ctx)).To(Succeed())
+		mctx := logging.NewContext(ctx, logging.Discard())
+		Expect(m.Reconcile(mctx)).To(Succeed())
 
 		cmRes := &corev1.ConfigMap{}
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes)).To(Succeed())
@@ -183,7 +185,8 @@ var _ = Describe("Reconcile", func() {
 		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(m.Reconcile(ctx)).To(Succeed())
+		mctx := logging.NewContext(ctx, logging.Discard())
+		Expect(m.Reconcile(mctx)).To(Succeed())
 
 		cmRes := &corev1.ConfigMap{}
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes)).To(Succeed())
@@ -193,7 +196,7 @@ var _ = Describe("Reconcile", func() {
 		m, err = manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m.Delete(ctx)).To(HaveOccurred())
-		Expect(m.Delete(ctx)).To(Succeed())
+		Expect(m.Delete(mctx)).To(Succeed())
 
 		cmRes = &corev1.ConfigMap{}
 		Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes))).To(BeTrue())
@@ -231,7 +234,8 @@ var _ = Describe("Reconcile", func() {
 		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(m.Reconcile(ctx)).To(Succeed())
+		mctx := logging.NewContext(ctx, logging.Discard())
+		Expect(m.Reconcile(mctx)).To(Succeed())
 
 		cmRes := &corev1.ConfigMap{}
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes)).To(Succeed())
@@ -240,8 +244,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(item), item)).To(Succeed())
 		m, err = manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(m.Delete(ctx)).To(HaveOccurred())
-		Expect(m.Delete(ctx)).To(Succeed())
+		Expect(m.Delete(mctx)).To(HaveOccurred())
+		Expect(m.Delete(mctx)).To(Succeed())
 
 		cmRes = &corev1.ConfigMap{}
 		Expect(apierrors.IsNotFound(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes))).To(BeTrue())

--- a/pkg/deployer/mock/controller.go
+++ b/pkg/deployer/mock/controller.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"time"
 
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 
 	corev1 "k8s.io/api/core/v1"
@@ -151,9 +153,11 @@ func (d *deployer) ensureExport(ctx context.Context, item *lsv1alpha1.DeployItem
 }
 
 func (d *deployer) getConfig(ctx context.Context, item *lsv1alpha1.DeployItem) (*mockv1alpha1.ProviderConfiguration, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "getConfig"})
+
 	config := &mockv1alpha1.ProviderConfiguration{}
 	if _, _, err := Decoder.Decode(item.Spec.Configuration.Raw, nil, config); err != nil {
-		d.log.Error(err, "unable to unmarshal config")
+		logger.Error(err, "unable to unmarshal config")
 		item.Status.Conditions = lsv1alpha1helper.CreateOrUpdateConditions(item.Status.Conditions, lsv1alpha1.DeployItemValidationCondition, lsv1alpha1.ConditionFalse,
 			"FailedUnmarshal", err.Error())
 		_ = d.Writer().UpdateDeployItemStatus(ctx, read_write_layer.W000053, item)

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -77,6 +77,10 @@ const (
 	KeyReason = "reason"
 	// KeyPhase is for a generic phase. For the phases of Installations, Executions, or DeployItems, use the more specific constants.
 	KeyPhase = "phase"
+	// KeyExportKey is for the key that the value from JSONPath is exported to.
+	KeyExportKey = "exportKey"
+	// KeyManagedResourcePolicy is for the manage policy of a resource.
+	KeyManagedResourcePolicy = "managedResourcePolicy"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

New logging for helm, manifest and mock deployer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
