### PR TITLE
Trigger int tests in PR

### DIFF
--- a/.ci/int-test
+++ b/.ci/int-test
@@ -6,11 +6,15 @@
 
 # Helper script executing the integration tests in the context of a Gardener Concours pipeline job with access to the cc-config.
 # It is called by the scripts integration-test and integration-test-new and installs some required software and calls
-# .../hack/integration-test.py
+# .../hack/integration-test.py. The script requires an ID for $1 which is integrated in the name of the test shoot cluster.
+# The cluster name has the format it-pr$PR_ID-<4-digits>.
 
 set -o errexit
 set -o nounset
 set -o pipefail
+
+PR_ID=$1
+export PR_ID
 
 SOURCE_PATH="$(dirname $0)/.."
 cd "${SOURCE_PATH}"

--- a/.ci/int-test-helper/create-shoot-cluster
+++ b/.ci/int-test-helper/create-shoot-cluster
@@ -14,6 +14,7 @@ TMP=$3
 MAX_NUM_CLUSTERS=$4
 NUM_CLUSTERS_START_DELETE_OLDEST=$5
 DURATION_FOR_CLUSTER_DELETION=$6
+PR_ID=$7
 
 SOURCE_PATH="$(dirname $0)/../.."
 cd "${SOURCE_PATH}"
@@ -27,4 +28,5 @@ go run -mod=vendor ./hack/testcluster shootcluster create \
     --cluster-auth=$TMP \
     --max-num-cluster=$MAX_NUM_CLUSTERS \
     --num-clusters-start-delete-oldest=$NUM_CLUSTERS_START_DELETE_OLDEST \
-    --duration-for-cluster-deletion=$DURATION_FOR_CLUSTER_DELETION
+    --duration-for-cluster-deletion=$DURATION_FOR_CLUSTER_DELETION \
+    --pr-id=$PR_ID

--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -5,7 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Script executing the integration tests in the context of a Gardener Concours pipeline job with access to the cc-config.
-# It is called in case of a head-update of the master branch and a new release.
+# It is called in case of a head-update of the master branch and a new release. The parameter "1", when calling ./.ci/int-test,
+# is integrated in the test cluster name indicating that the tests were triggered by a head update commit or a new release.
+# The cluster name has the format it-pr1-<4-digits>.
 
 set -o errexit
 set -o nounset
@@ -16,5 +18,5 @@ cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"
 export SOURCE_PATH
 
-./.ci/int-test
+./.ci/int-test "1"
 

--- a/.ci/integration-test-new
+++ b/.ci/integration-test-new
@@ -4,11 +4,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Script executed in case of a PR. Currently this does nothing but it is planned to let it trigger the integration tests
-# if the PR has some particular label.
+# Script executed in case of a commit to a PR. The script checks if the comment of the commit contains "run-int-tests".
+# In that case, the integration tests are executed by calling ./.ci/int-test. The parameter $PR_ID is integrated in the
+# test cluster name. The cluster name has the format it-pr$PR_ID-<4-digits>.
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "Fake integration tests started"
+echo "check if integration tests should be started"
+
+if ! which git 1>/dev/null; then
+  echo "Installing git... "
+  apk add --no-cache --no-progress git
+fi
+
+PR_ID=$(git config -f pull-request-gardener.landscaper-pr.master/.git/config pullrequest.id)
+echo "PR_ID: " $PR_ID
+
+SOURCE_PATH="$(dirname $0)/.."
+cd "${SOURCE_PATH}"
+SOURCE_PATH="$(pwd)"
+export SOURCE_PATH
+
+GIT_COMMENT=$(git show -s --format=%s)
+echo "git comment: " $GIT_COMMENT
+
+if git show -s --format=%s | grep run-int-tests; then
+    echo "integration tests should be started"
+    ./.ci/int-test $PR_ID
+else
+    echo "integration tests are skipped"
+fi

--- a/.ci/local-integration-test-with-cluster-creation
+++ b/.ci/local-integration-test-with-cluster-creation
@@ -17,7 +17,10 @@ set -o pipefail
 
 # - create-shoot-cluster: Creates a new test shoot cluster in the Gardener Canary Landscape in the namespace provided
 #   with $2 (e.g. garden-laas) using the kubeconfig located at the file system path provided by $1. The names of all
-#   test shoot clusters starts with the prefix "it-".
+#   test shoot clusters have the format it-pr$4-<4-digits>, whereby
+#   - $4==0 indicates that the script was triggered locally
+#   - $4==1 indicates that the script was triggered by a commit to a head update or a new release
+#   - otherwise, indicates that the script was triggered by a commit to a PR whereby $4 contains the ID of the PR.
 #
 # - local-integration-test: calls a script which executes the integration tests on the just created shoot cluster
 #
@@ -31,8 +34,10 @@ set -o pipefail
 #
 # Before a new test shoot cluster is created, the already existing test clusters in the namespace are checked and
 # potentially deleted according to the following strategy:
+#
 # - If the maximal number of test clusters is larger or equal to $MAX_NUM_CLUSTERS, the script fails and it is required
 #   that the test clusters are deleted manually.
+# - If the test was triggered by a PR, all existing clusters with a name prefix it-pr$4- are deleted.
 # - $DURATION_FOR_CLUSTER_DELETION provides a duration according to the format expected by
 #   time.ParseDuration (https://pkg.go.dev/time#ParseDuration). All test clusters older than this duration are deleted.
 # - If there are still X test clusters with 'X >= $NUM_CLUSTERS_START_DELETE_OLDEST', the oldest
@@ -43,6 +48,7 @@ set -o pipefail
 GARDENER_KUBECONFIG_PATH=$1
 NAMESPACE=$2
 VERSION=$3
+PR_ID=$4
 
 MAX_NUM_CLUSTERS=20
 NUM_CLUSTERS_START_DELETE_OLDEST=15
@@ -69,7 +75,8 @@ echo "Config directory: ${TMP}"
   $TMP \
   $MAX_NUM_CLUSTERS \
   $NUM_CLUSTERS_START_DELETE_OLDEST \
-  $DURATION_FOR_CLUSTER_DELETION
+  $DURATION_FOR_CLUSTER_DELETION \
+  $PR_ID
 
 KUBECONFIG_PATH=$TMP/kubeconfig.yaml
 echo "Test cluster kubeconfig path: ${KUBECONFIG_PATH}"

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ integration-test:
 
 .PHONY: integration-test-with-cluster-creation
 integration-test-with-cluster-creation:
-	@$(REPO_ROOT)/.ci/local-integration-test-with-cluster-creation $(KUBECONFIG_PATH) garden-laas $(EFFECTIVE_VERSION)
+	@$(REPO_ROOT)/.ci/local-integration-test-with-cluster-creation $(KUBECONFIG_PATH) garden-laas $(EFFECTIVE_VERSION) 0
 
 .PHONY: verify
 verify: check

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -42,7 +42,13 @@ In both cases the [script](../../.ci/integration-test) is executed, which
 
 For a commit to a PR the [script](../../.ci/integration-test-new) is executed. It starts the integration tests 
 if the comment of the commit contains a string *run-int-tests*, e.g. `git commit -m "some changes (run-int-tests)`. 
-Otherwise, the tests are skipped. 
+Otherwise, the tests are skipped. If you have pushed a commit with a message not containing *run-int-tests* you could just 
+add a commit without changes but the right message to trigger the integration tests, e.g.:
+
+```
+git commit --allow-empty -m "some text (run-int-tests)"
+git push
+```
 
 The integration test scripts clean up old test shoot clusters. More details about the cleanup strategy and further 
 program details can be found in the corresponding script files.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -35,13 +35,22 @@ Integration tests are tests that use a k8s-conformance-compliant cluster and opt
 The tests are by default executed on every head-update of the main git branch and in case of a new release.
 In both cases the [script](../../.ci/integration-test) is executed, which 
 
-- creates a Gardener shoot cluster in the project *laas* on the Gardener Canary landscape. All such clusters have a name with the prefix *it-*.
+- creates a Gardener shoot cluster in the project *laas* on the Gardener Canary landscape
 - installs the landscaper on the shoot cluster
 - runs the tests
-- deletes the shoot cluster if all tests succeeded, otherwise it lets the cluster as it is for further investigations.
+- deletes the shoot cluster if all tests succeeded, otherwise it lets the cluster as it is for further investigations
 
-The test script also cleans up old test shoot clusters. More details about the program details can be found in the 
-corresponding script files.
+For a commit to a PR the [script](../../.ci/integration-test-new) is executed. It starts the integration tests 
+if the comment of the commit contains a string *run-int-tests*, e.g. `git commit -m "some changes (run-int-tests)`. 
+Otherwise, the tests are skipped. 
+
+The integration test scripts clean up old test shoot clusters. More details about the cleanup strategy and further 
+program details can be found in the corresponding script files.
+
+All test shoot clusters names have the format it-pr<someNumber>-<4-digits> (e.g. it-pr12-4652), whereby
+- <someNumber>==0 indicates that the script was triggered locally (see below)
+- <someNumber>==1 indicates that the script was triggered by a commit to a head update or a new release
+- otherwise, indicates that the script was triggered by a commit to a PR whereby <someNumber> contains the ID of the PR.
 
 The integration tests can be optionally executed on a PR by commenting that PR with `/test`.
 This will trigger the TestMachinery bot and will execute the integration tests for the PR in the TestMachinery.

--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -21,6 +21,7 @@ from subprocess import run
 
 version = os.environ["VERSION"]
 source_path = os.environ["SOURCE_PATH"]
+pr_id = os.environ["PR_ID"]
 
 factory = ctx().cfg_factory()
 print("Starting integration tests with version " + version + " in sourcepath " + source_path)
@@ -31,7 +32,7 @@ with utils.TempFileAuto(prefix="landscape_kubeconfig_") as kubeconfig_temp_file:
     kubeconfig_temp_file.write(yaml.safe_dump(landscape_kubeconfig.kubeconfig()))
     landscape_kubeconfig_path = kubeconfig_temp_file.switch()
 
-    command = [source_path + "/.ci/local-integration-test-with-cluster-creation", landscape_kubeconfig_path, "garden-laas ", version]
+    command = [source_path + "/.ci/local-integration-test-with-cluster-creation", landscape_kubeconfig_path, "garden-laas ", version, pr_id]
 
     print("Executing command")
     run = run(command)

--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -32,7 +32,7 @@ with utils.TempFileAuto(prefix="landscape_kubeconfig_") as kubeconfig_temp_file:
     kubeconfig_temp_file.write(yaml.safe_dump(landscape_kubeconfig.kubeconfig()))
     landscape_kubeconfig_path = kubeconfig_temp_file.switch()
 
-    command = [source_path + "/.ci/local-integration-test-with-cluster-creation", landscape_kubeconfig_path, "garden-laas ", version, pr_id]
+    command = [source_path + "/.ci/local-integration-test-with-cluster-creation", landscape_kubeconfig_path, "garden-laas", version, pr_id]
 
     print("Executing command")
     run = run(command)

--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -26,7 +26,7 @@ spec:
           type: n1-standard-2
           image:
             name: gardenlinux
-            version: 576.10.0
+            version: 576.11.0
         zones:
           - europe-west1-c
         cri:

--- a/hack/testcluster/shootcluster_create.go
+++ b/hack/testcluster/shootcluster_create.go
@@ -42,6 +42,7 @@ type CreateShootClusterOptions struct {
 	MaxNumOfClusters             int
 	NumClustersStartDeleteOldest int
 	DurationForClusterDeletion   string
+	PrID                         string
 }
 
 // AddFlags adds flags for the options to a flagset
@@ -56,6 +57,7 @@ func (o *CreateShootClusterOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.MaxNumOfClusters, "max-num-cluster", 15, "maximal number of clusters")
 	fs.IntVar(&o.NumClustersStartDeleteOldest, "num-clusters-start-delete-oldest", 10, "number of clusters to start deletion of the oldest")
 	fs.StringVar(&o.DurationForClusterDeletion, "duration-for-cluster-deletion", "48h", "test cluster existing longer than this will be deleted")
+	fs.StringVar(&o.PrID, "pr-id", "0", "ID number of the PR, 0 if executed locally, 1 if triggered by head update")
 }
 
 func (o *CreateShootClusterOptions) Complete() error {
@@ -100,7 +102,7 @@ func (o *CreateShootClusterOptions) Run(ctx context.Context) error {
 	log := utils.NewLogger().WithTimestamp()
 
 	shootClusterManager, err := pkg.NewShootClusterManager(log, o.GardenClusterKubeconfigPath, o.Namespace,
-		o.AuthDirectoryPath, o.MaxNumOfClusters, o.NumClustersStartDeleteOldest, o.DurationForClusterDeletion)
+		o.AuthDirectoryPath, o.MaxNumOfClusters, o.NumClustersStartDeleteOldest, o.DurationForClusterDeletion, o.PrID)
 
 	if err != nil {
 		return err

--- a/hack/testcluster/shootcluster_delete.go
+++ b/hack/testcluster/shootcluster_delete.go
@@ -79,7 +79,7 @@ func (o *DeleteShootClusterOptions) Run(ctx context.Context) error {
 	log := utils.NewLogger().WithTimestamp()
 
 	shootClusterManager, err := pkg.NewShootClusterManager(log, o.GardenClusterKubeconfigPath, o.Namespace, o.AuthDirectoryPath,
-		0, 0, "1h")
+		0, 0, "1h", "0")
 
 	if err != nil {
 		return err

--- a/test/integration/webhook/webhook.go
+++ b/test/integration/webhook/webhook.go
@@ -110,7 +110,7 @@ func WebhookTest(f *framework.Framework) {
 
 			// apply root installation into cluster and wait for it to be succeeded
 			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
-			utils.ExpectNoError(state.Client.Create(ctx, inst))
+			utils.ExpectNoError(state.Create(ctx, inst))
 			Eventually(func() lsv1alpha1.InstallationPhase {
 				utils.ExpectNoError(state.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
 				return inst.Status.InstallationPhase

--- a/test/utils/kubernetes.go
+++ b/test/utils/kubernetes.go
@@ -133,10 +133,10 @@ func WaitForDeploymentToBeReady(ctx context.Context, logger utils.Logger, kubeCl
 
 // WaitForContextToBeReady waits for a context to be ready
 func WaitForContextToBeReady(ctx context.Context, logger utils.Logger, kubeClient client.Client, objKey types.NamespacedName, timeout time.Duration) error {
-	err := wait.PollImmediate(5*time.Second, timeout, func() (done bool, err error) {
+	err := wait.PollImmediate(1*time.Second, timeout, func() (done bool, err error) {
 		context := &v1alpha1.Context{}
 		if err := kubeClient.Get(ctx, objKey, context); err != nil {
-			logger.Logfln("failed to get context %q: %w - retried in 5 seconds", objKey.String(), err)
+			logger.Logfln("failed to get context %q: %w - retried in 1 second", objKey.String(), err)
 			return false, nil
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR adds a feature such that integration tests for a commit of a PR are only executed if the the comment of the commit contains the string run-int-tests. 

Additionally the PR contains:
- newer linux version for test shoot cluster
- PR id integrated in the test shoot cluster name
- improved deletion strategy for test shoot clusters, only one cluster for one PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
