### PR TITLE
handle missing schema key in data imports gracefully

### DIFF
--- a/pkg/landscaper/installations/imports/constructor.go
+++ b/pkg/landscaper/installations/imports/constructor.go
@@ -152,6 +152,9 @@ func (c *Constructor) constructImports(
 				}
 				return nil, installations.NewImportNotFoundErrorf(nil, "blueprint defines import %q of type %s, which is not satisfied", def.Name, lsv1alpha1.ImportTypeData)
 			}
+			if def.Schema == nil {
+				return nil, installations.NewErrorf(installations.SchemaValidationFailed, fmt.Errorf("schema is nil"), "%s: no schema defined", defPath.String())
+			}
 			validator, err := c.JSONSchemaValidator(def.Schema.RawMessage)
 			if err != nil {
 				return imports, installations.NewErrorf(installations.SchemaValidationFailed, err, "%s: validator creation failed", defPath.String())

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -180,6 +180,18 @@ var _ = Describe("Constructor", func() {
 			err = c.Construct(ctx, nil)
 			Expect(installations.IsSchemaValidationFailedError(err)).To(BeTrue())
 		})
+
+		It("should handle missing schema definition in import gracefully", func() {
+			ctx := context.Background()
+			inInstJ, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), fakeInstallations["test12/j"])
+			Expect(err).ToNot(HaveOccurred())
+			op.Inst = inInstJ
+			Expect(op.ResolveComponentDescriptors(ctx)).To(Succeed())
+			Expect(op.SetInstallationContext(ctx)).To(Succeed())
+
+			c := imports.NewConstructor(op)
+			Expect(c.Construct(ctx, nil)).ToNot(Succeed())
+		})
 	})
 
 	Context("Targets", func() {

--- a/pkg/landscaper/installations/imports/testdata/state/test12/00-j.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test12/00-j.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: j
+  namespace: test12
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: res-j
+
+  importDataMappings:
+    a.b: test

--- a/pkg/landscaper/installations/testdata/registry/blobs/j/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/j/blueprint.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+annotations:
+  local/name: a
+  local/version: 1.0.0
+
+imports:
+- name: a.b
+  type: data

--- a/pkg/landscaper/installations/testdata/registry/component-descriptor.yaml
+++ b/pkg/landscaper/installations/testdata/registry/component-descriptor.yaml
@@ -107,6 +107,14 @@ component:
       type: localFilesystemBlob
       mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
       filename: f
+  - name: res-j
+    type: blueprint
+    version: 1.0.0
+    relation: local
+    access:
+      type: localFilesystemBlob
+      mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
+      filename: j
   - name: root-cond
     type: blueprint
     version: 1.0.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

When the schema key is missing in data imports, the landscaper crashes:

```
{"level":"info","ts":"2022-09-01T07:17:39.590Z","logger":"controllers.installation","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","reconciledResourceKind":"Installation","reconcileID":"d473944e-8cc2-4cbe-ae38-3c5257eea7f4"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b96b4a]

goroutine 977 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x1ddcf20, 0x3567f20})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/gardener/landscaper/pkg/landscaper/installations/imports.(*Constructor).constructImports(0xc000ab56d8, {0xc00100e2c0, 0x6, 0x20b66f0}, 0x18, 0xc000694940, 0x2, 0x2, 0xc000ab56f8, 0xc00054ec60, ...)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/installations/imports/constructor.go:155 +0x74a
github.com/gardener/landscaper/pkg/landscaper/installations/imports.(*Constructor).Construct(0xc000ab56d8, {0x23e2580, 0xc000c1f710}, 0xc000a09d40)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/installations/imports/constructor.go:115 +0x12a
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).CreateImportsAndSubobjects(0xc0003d6580, {0x23e2580, 0xc000c1f710}, 0xc00063e400, 0x5)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/reconcile.go:584 +0x99
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).handlePhaseInit(0xc000cb37f8, {0x23e2580, 0xc000c1f710}, 0xc000b558c0)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/reconcile.go:174 +0xca
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).handleReconcilePhase(0xc0003d6580, {0x23e2580, 0xc000c1f710}, 0xc000b558c0)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/reconcile.go:52 +0x217
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).reconcileNew(0xc0003d6580, {0x23e2580, 0xc000c1f530}, {{{0xc000b38c30, 0x10000c000bb9d38}, {0xc000b38c28, 0x30}}})
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/controller.go:170 +0x797
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).Reconcile(0x30, {0x23e2580, 0xc000c1f530}, {{{0xc000b38c30, 0xc000bb9d38}, {0xc000b38c28, 0x40d407}}})
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/controller.go:104 +0x36
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x23e24d8, {0x23e2580, 0xc000c1f530}, {{{0xc000b38c30, 0x1fa92c0}, {0xc000b38c28, 0x10}}})
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:121 +0xd1
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0007b7040, {0x23e24d8, 0xc00089cfc0}, {0x1e77ea0, 0xc000145220})
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:320 +0x33c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0007b7040, {0x23e24d8, 0xc00089cfc0})
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:230 +0x36f
```

This pr adds graceful handling of the missing schema key,

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Handle missing schema key in data imports gracefully.
```
