### PR TITLE
make the landscaper deployments container name configurable

### DIFF
--- a/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
@@ -46,6 +46,8 @@ deployItems:
         image: {}
 
         controller:
+          name: landscaper-controller
+
           landscaperKubeconfig:
             kubeconfig: |
 {{ .imports.landscaperControllerKubeconfigYaml | indent 14 }}
@@ -63,6 +65,8 @@ deployItems:
             pullPolicy: IfNotPresent
 
         webhooksServer:
+          name: landscaper-webhooks
+
           landscaperKubeconfig:
             kubeconfig: |
 {{ .imports.landscaperWebhooksKubeconfigYaml | indent 14}}

--- a/charts/landscaper/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/charts/landscaper/templates/_helpers.tpl
@@ -39,6 +39,22 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "landscaper.controller.containerName" -}}
+{{- if .Values.controller.containerName -}}
+{{- .Values.controller.containerName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- print "landscaper-controller" }}
+{{- end }}
+{{- end }}
+
+{{- define "landscaper.webhooks.containerName" -}}
+{{- if .Values.webhooksServer.containerName -}}
+{{- .Values.webhooksServer.containerName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- print "landscaper-webhooks" }}
+{{- end }}
+{{- end }}
+
 {{/*
 Common labels
 */}}

--- a/charts/landscaper/charts/landscaper/templates/deployment-controller.yaml
+++ b/charts/landscaper/charts/landscaper/templates/deployment-controller.yaml
@@ -33,7 +33,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "landscaper.controller.containerName" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ include "landscaper-image" . }}"

--- a/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
@@ -35,7 +35,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "landscaper.webhooks.containerName" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ include "landscaper-webhook-image" . }}"

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -83,6 +83,9 @@ image: {}
 #  tag: ""
 
 controller:
+  # Overrides the controller container name. Default is "landscaper-controller".
+  containerName: landscaper-controller
+
   # Allows to target a different cluster than the hosting cluster of the controller instance.
   # Provide the kubeconfig to access the remote Landscaper cluster here (inline or via secretRef).
   # When providing a secretRef, see ./templates/cluster-kubeconfig-secret.yaml for the correct secret format.
@@ -100,6 +103,8 @@ controller:
     #tag: ""
 
 webhooksServer:
+  # Overrides the controller container name. Default is "landscaper-webhooks".
+  containerName: landscaper-webhooks
   # Allows to target a different cluster than the hosting cluster of the webhooks server instance.
   # Provide the kubeconfig to access the remote Landscaper cluster here (inline or via secretRef).
   # When providing a secretRef, see ./templates/cluster-kubeconfig-secret.yaml for the correct secret format.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Currently the container names of the landscaper chart are derived from the chart name.
This means both the controller and webhook server container name are identical. This leads to confusion when analyzing logs.
This PR makes the container names configurable.
The default for the landscaper controller is: `landscaper-controller`
The dfault for the landscaper webhooks server is: `landscaper-webhooks`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The landscaper deployment container names are now configurable in the Helm chart.
```
