### PR TITLE
Handle webhook errors

### DIFF
--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -150,6 +150,8 @@ const (
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
 	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
+	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
+	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 )
 
 // Condition holds the information about the state of a resource.

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -157,6 +157,8 @@ const (
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
 	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
+	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
+	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -188,6 +188,18 @@ func CollectErrorCodes(err error) []lsv1alpha1.ErrorCode {
 	return codes
 }
 
+func ContainsErrorCode(err error, code lsv1alpha1.ErrorCode) bool {
+	codes := CollectErrorCodes(err)
+
+	for _, next := range codes {
+		if next == code {
+			return true
+		}
+	}
+
+	return false
+}
+
 // UpdatedError updates the properties of a error.
 func UpdatedError(lastError *lsv1alpha1.Error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) *lsv1alpha1.Error {
 	if lastError == nil {
@@ -215,7 +227,7 @@ func UpdatedError(lastError *lsv1alpha1.Error, operation, reason, message string
 		newError.Codes = lastError.Codes
 	}
 
-	if !reflect.DeepEqual(lastError, newError){
+	if !reflect.DeepEqual(lastError, newError) {
 		newError.LastUpdateTime = metav1.Now()
 	}
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -150,6 +150,8 @@ const (
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
 	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
+	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
+	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 )
 
 // Condition holds the information about the state of a resource.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -157,6 +157,8 @@ const (
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
 	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
+	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
+	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -108,6 +108,9 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseInit {
 		if err := c.handlePhaseInit(ctx, exec); err != nil {
+			if lsutil.IsRecoverableError(err) {
+				return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000007)
+			}
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err, read_write_layer.W000131)
 		}
 
@@ -142,6 +145,9 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseCompleting {
 		if err := c.handlePhaseCompleting(ctx, exec); err != nil {
+			if lsutil.IsRecoverableError(err) {
+				return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000008)
+			}
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err, read_write_layer.W000138)
 		}
 
@@ -154,6 +160,9 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 
 	if exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseInitDelete {
 		if err := c.handlePhaseInitDelete(ctx, exec); err != nil {
+			if lsutil.IsRecoverableError(err) {
+				return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000010)
+			}
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseDeleteFailed, err, read_write_layer.W000140)
 		}
 

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	lsutil "github.com/gardener/landscaper/pkg/utils"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,8 +53,10 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 	if inst.Status.InstallationPhase == lsv1alpha1.InstallationPhaseInit {
 		fatalError, normalError := c.handlePhaseInit(ctx, inst)
 
-		if fatalError != nil {
+		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
 			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhaseFailed, fatalError, read_write_layer.W000087)
+		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000003)
 		} else if normalError != nil {
 			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000088)
 		}
@@ -94,8 +98,10 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 	if inst.Status.InstallationPhase == lsv1alpha1.InstallationPhaseCompleting {
 		fatalError, normalError := c.handlePhaseCompleting(ctx, inst)
 
-		if fatalError != nil {
+		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
 			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhaseFailed, fatalError, read_write_layer.W000120)
+		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000005)
 		} else if normalError != nil {
 			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000121)
 		}
@@ -111,8 +117,10 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		// trigger deletion of execution and sub installations
 		fatalError, normalError := c.handleDeletionPhaseInit(ctx, inst)
 
-		if fatalError != nil {
+		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
 			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhaseDeleteFailed, fatalError, read_write_layer.W000123)
+		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000006)
 		} else if normalError != nil {
 			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000124)
 		}

--- a/pkg/utils/lserrors.go
+++ b/pkg/utils/lserrors.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lserrors "github.com/gardener/landscaper/apis/errors"
+)
+
+func IsRecoverableError(err error) bool {
+	// currently there is only one intermediate error but this might change
+	return lserrors.ContainsErrorCode(err, lsv1alpha1.ErrorWebhook)
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -150,6 +150,8 @@ const (
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
 	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
+	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
+	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 )
 
 // Condition holds the information about the state of a resource.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -157,6 +157,8 @@ const (
 	ErrorTimeout ErrorCode = "ERR_TIMEOUT"
 	// ErrorCyclicDependencies indicates that there are cyclic dependencies between multiple installations/deployitems.
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
+	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
+	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/vendor/github.com/gardener/landscaper/apis/errors/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/errors/error.go
@@ -188,6 +188,18 @@ func CollectErrorCodes(err error) []lsv1alpha1.ErrorCode {
 	return codes
 }
 
+func ContainsErrorCode(err error, code lsv1alpha1.ErrorCode) bool {
+	codes := CollectErrorCodes(err)
+
+	for _, next := range codes {
+		if next == code {
+			return true
+		}
+	}
+
+	return false
+}
+
 // UpdatedError updates the properties of a error.
 func UpdatedError(lastError *lsv1alpha1.Error, operation, reason, message string, codes ...lsv1alpha1.ErrorCode) *lsv1alpha1.Error {
 	if lastError == nil {
@@ -215,7 +227,7 @@ func UpdatedError(lastError *lsv1alpha1.Error, operation, reason, message string
 		newError.Codes = lastError.Codes
 	}
 
-	if !reflect.DeepEqual(lastError, newError){
+	if !reflect.DeepEqual(lastError, newError) {
 		newError.LastUpdateTime = metav1.Now()
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Handle webhook errors

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
