### PR TITLE
Use image with preinstalled software for integration tests

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -73,14 +73,14 @@ landscaper:
           - integration-test
           trait_depends:
           - publish
-          image: 'golang:1.18.5-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
           output_dir: 'integration_test'
     pull-request:
       steps:
         integration_test:
           depends:
           - publish
-          image: 'golang:1.18.5-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
           execute:
           - integration-test-new
           output_dir: 'integration_test'
@@ -107,7 +107,7 @@ landscaper:
           - integration-test
           trait_depends:
           - publish
-          image: 'golang:1.18.5-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
           output_dir: 'integration_test'
         update_release:
           inputs:


### PR DESCRIPTION
…ests)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Use image with preinstalled software for integration tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
