### PR TITLE
fix local integration tests

### DIFF
--- a/.ci/int-test-helper/create-registry
+++ b/.ci/int-test-helper/create-registry
@@ -47,4 +47,22 @@ go run -mod=vendor ./hack/testcluster registry create \
     --timeout=10m \
     --ls-run-on-shoot
 
+address=$(cat "$TMP/docker.config" | jq -r '.auths | to_entries | .[0].value.serveraddress')
+address=${address%:*} # remove port, if given
+echo "Waiting until registry address '$address' is routable ..."
+timeout=300
+start=$(date +%s)
+now=start
+while true; do
+  if nslookup "$address" >/dev/null; then
+    # successfully routed
+    break
+  elif [[ $(($now - $start)) -gt $timeout ]]; then
+    echo "Address '$address' did not become routable within $timeout seconds."
+    exit 1
+  fi
+  sleep 5
+  now=$(date +%s)
+done
 
+echo "Registry is running and reachable. Config is stored at '$TMP/docker.config'."

--- a/.ci/int-test-helper/create-registry
+++ b/.ci/int-test-helper/create-registry
@@ -43,7 +43,7 @@ go run -mod=vendor ./hack/testcluster registry create \
     --namespace=$REGISTRY_NS \
     --id=$ID \
     --registry-auth=$TMP/docker.config \
-    --address-format=ip \
+    --dns-format=external \
     --timeout=10m \
     --ls-run-on-shoot
 

--- a/.ci/int-test-helper/install-landscaper
+++ b/.ci/int-test-helper/install-landscaper
@@ -55,6 +55,6 @@ helm pull oci://eu.gcr.io/gardener-project/landscaper/charts/landscaper --versio
 
 echo "Upgrade landscaper"
 helm upgrade --kubeconfig=$KUBECONFIG_PATH --install --wait --create-namespace -n ls-system \
-  -f $TMP/values.yaml -f $TMP/registry-values.yaml landscaper $TMP_GEN/landscaper
+  -f $TMP/values.yaml -f $TMP/registry-values.yaml landscaper $TMP_GEN/landscaper --set "landscaper.image.tag=${VERSION}"
 
 

--- a/.ci/int-test-helper/run-tests
+++ b/.ci/int-test-helper/run-tests
@@ -9,7 +9,7 @@ set -o nounset
 set -o pipefail
 
 KUBECONFIG_PATH=$1
-REGISTRY_CONFIG=$2
+REGISTRY_CONFIG=$2 # if empty, registry tests and the checks whether the landscaper and the deployers are running will be skipped
 VERSION=$3
 
 # to disable set on 1
@@ -24,7 +24,7 @@ echo "Run integration tests in source path ${SOURCE_PATH}"
 go test -timeout=60m -mod=vendor ./test/integration \
     --v -ginkgo.v -ginkgo.progress -ginkgo.noColor -ginkgo.seed=17 -ginkgo.failFast \
     --kubeconfig $KUBECONFIG_PATH \
-    --registry-config=$REGISTRY_CONFIG \
+    ${REGISTRY_CONFIG:+"--registry-config="}${REGISTRY_CONFIG:-"--skip-waiting-for-system-components"} \
     --ls-namespace=ls-system \
     --ls-version=$VERSION \
     --ls-run-on-shoot \

--- a/.ci/local-integration-test-pure
+++ b/.ci/local-integration-test-pure
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Script executing the integration tests. Unlike 'local-integration-test', it will not install a registry or a landscaper.
+# Landscaper is expected to be already running in the cluster, using a registry is not supported at the moment.
+# This is useful e.g. if you want to debug a part of the landscaper and therefore run it locally, without the integration test script enabling the component in the cluster again.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBECONFIG_PATH=$1
+VERSION=$2
+SOURCE_PATH="$(dirname $0)/.."
+cd "${SOURCE_PATH}"
+SOURCE_PATH="$(pwd)"
+
+echo "Run integration tests without landscaper creation"
+echo "Source path: ${SOURCE_PATH}"
+echo "Test cluster kubeconfig path: ${KUBECONFIG_PATH}"
+
+TMP="${SOURCE_PATH}/tmp-int-test-core"
+rm -f -r $TMP
+mkdir -p $TMP
+echo "Config directory: ${TMP}"
+
+./.ci/int-test-helper/install-missing-software
+./.ci/int-test-helper/run-tests $KUBECONFIG_PATH "" ${VERSION}

--- a/.test-defs/create-registry.yaml
+++ b/.test-defs/create-registry.yaml
@@ -14,7 +14,7 @@ spec:
     --namespace=clusters
     --id=$TM_TESTRUN_ID
     --registry-auth=$TM_SHARED_PATH/docker.config
-    --address-format=ip
+    --dns-format=external
     --timeout=10m
 
   image: golang:1.18.4

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ test: setup-testenv
 integration-test:
 	@$(REPO_ROOT)/.ci/local-integration-test $(KUBECONFIG_PATH) $(EFFECTIVE_VERSION)
 
+.PHONY: integration-test-pure
+integration-test-pure:
+	@$(REPO_ROOT)/.ci/local-integration-test-pure $(KUBECONFIG_PATH) $(EFFECTIVE_VERSION)
+
 .PHONY: integration-test-with-cluster-creation
 integration-test-with-cluster-creation:
 	@$(REPO_ROOT)/.ci/local-integration-test-with-cluster-creation $(KUBECONFIG_PATH) garden-laas $(EFFECTIVE_VERSION) 0

--- a/hack/testcluster/pkg/registry.go
+++ b/hack/testcluster/pkg/registry.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	AddressFormatHostname = "hostname"
-	AddressFormatIP       = "ip"
+	DNSFormatInternal = "internal"
+	DNSFormatExternal = "external"
 )
 
 // see this issue for more discussions around min resources for a k8s cluster running in a pod.
@@ -120,7 +120,7 @@ func CreateRegistry(ctx context.Context,
 	id string,
 	stateFile string,
 	password string,
-	outputAddressFormat string,
+	dnsFormat string,
 	exportRegistryCreds string,
 	timeout time.Duration,
 	runOnShoot bool) (err error) {
@@ -256,10 +256,10 @@ func CreateRegistry(ctx context.Context,
 		Password:      password,
 		Auth:          base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))),
 	}
-	switch outputAddressFormat {
-	case AddressFormatHostname:
+	switch dnsFormat {
+	case DNSFormatInternal:
 		auth.ServerAddress = fmt.Sprintf("%s.%s:5000", svc.Name, svc.Namespace)
-	case AddressFormatIP:
+	case DNSFormatExternal:
 		if runOnShoot {
 			logger.Logln("Waiting for loadbalancer service to get ip/hostname ...")
 			err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (done bool, err error) {
@@ -286,7 +286,7 @@ func CreateRegistry(ctx context.Context,
 			auth.ServerAddress = fmt.Sprintf("%s:5000", svc.Spec.ClusterIP)
 		}
 	default:
-		return fmt.Errorf("unknown address format %q", outputAddressFormat)
+		return fmt.Errorf("unknown dns format %q", dnsFormat)
 	}
 
 	logger.Logln(fmt.Sprintf("using IP/hostname: %s", auth.ServerAddress))

--- a/hack/testcluster/registry_create.go
+++ b/hack/testcluster/registry_create.go
@@ -45,9 +45,10 @@ type CreateRegistryOptions struct {
 	// Will be generated if not provided
 	Password string
 
-	// OutputAddressFormat is the format of the output address for the registry
-	// Can be either hostname or ip
-	OutputAddressFormat string
+	// DNSFormat is the type of the output address for the registry
+	// Can be either internal or external
+	// internal will result in a hostname routable only via in-cluster-DNS, while external will result in a publicly routable IP or hostname.
+	DNSFormat string
 
 	RunOnShoot bool
 }
@@ -60,7 +61,7 @@ func (o *CreateRegistryOptions) AddFlags(fs *pflag.FlagSet) {
 	o.CommonOptions.AddFlags(fs)
 	fs.StringVar(&o.Password, "registry-password", "", "set the registry password")
 	fs.StringVar(&o.ExportRegistryCreds, "registry-auth", "", "path where the docker auth config is written to")
-	fs.StringVar(&o.OutputAddressFormat, "address-format", "hostname", "the format of the addresses in the generated output. Can be hostname or ip.")
+	fs.StringVar(&o.DNSFormat, "dns-format", "internal", "determines the type of address which is used for the registry service. Can be 'internal' (uses in-cluster-DNS) or 'external' (is publicly reachable).")
 	fs.BoolVar(&o.RunOnShoot, "ls-run-on-shoot", false, "runs on a shoot and not a k3s cluster")
 
 }
@@ -97,7 +98,7 @@ func (o *CreateRegistryOptions) Run(ctx context.Context) error {
 		o.ID,
 		o.StateFile,
 		o.Password,
-		o.OutputAddressFormat,
+		o.DNSFormat,
 		o.ExportRegistryCreds,
 		o.Timeout,
 		o.RunOnShoot)

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -52,15 +52,16 @@ var (
 const OpenSourceRepositoryContext = "eu.gcr.io/gardener-project/development"
 
 type Options struct {
-	fs                   *flag.FlagSet
-	KubeconfigPath       string
-	RootPath             string
-	LsNamespace          string
-	LsVersion            string
-	DockerConfigPath     string
-	DisableCleanup       bool
-	RunOnShoot           bool
-	DisableCleanupBefore bool
+	fs                             *flag.FlagSet
+	KubeconfigPath                 string
+	RootPath                       string
+	LsNamespace                    string
+	LsVersion                      string
+	DockerConfigPath               string
+	DisableCleanup                 bool
+	RunOnShoot                     bool
+	DisableCleanupBefore           bool
+	SkipWaitingForSystemComponents bool
 }
 
 // AddFlags registers the framework related flags
@@ -77,6 +78,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.DisableCleanup, "disable-cleanup", false, "skips the cleanup of resources.")
 	fs.BoolVar(&o.RunOnShoot, "ls-run-on-shoot", false, "runs on a shoot and not a k3s cluster")
 	fs.BoolVar(&o.DisableCleanupBefore, "ls-disable-cleanup-before", false, "disables cleanup of all namespaces with prefix `test` before the tests are started")
+	fs.BoolVar(&o.SkipWaitingForSystemComponents, "skip-waiting-for-system-components", false, "disables checking whether landscaper and the deployers are running in the cluster")
 	o.fs = fs
 }
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -7,6 +7,8 @@ package integration_test
 import (
 	"context"
 	"flag"
+	"testing"
+
 	"github.com/gardener/landscaper/test/integration/core"
 	"github.com/gardener/landscaper/test/integration/dependencies"
 	"github.com/gardener/landscaper/test/integration/deployitems"
@@ -17,7 +19,6 @@ import (
 	"github.com/gardener/landscaper/test/integration/targets"
 	"github.com/gardener/landscaper/test/integration/tutorial"
 	"github.com/gardener/landscaper/test/integration/webhook"
-	"testing"
 
 	"github.com/gardener/landscaper/test/integration/deployers"
 
@@ -52,14 +53,18 @@ func TestConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := framework.NewDumper(f.Log(), f.Client, f.ClientSet, f.LsNamespace)
-	f.Log().Logfln("waiting for system components")
-	err = f.WaitForSystemComponents(ctx)
-	if err != nil {
-		f.Log().Logfln("waiting for system components failed: %s", err.Error())
-		if derr := d.Dump(ctx); derr != nil {
-			f.Log().Logf("error during dump: %s", derr.Error())
+	if opts.SkipWaitingForSystemComponents {
+		f.Log().Logfln("Skipped waiting for system components")
+	} else {
+		f.Log().Logfln("Waiting for system components")
+		err = f.WaitForSystemComponents(ctx)
+		if err != nil {
+			f.Log().Logfln("Waiting for system components failed: %s", err.Error())
+			if derr := d.Dump(ctx); derr != nil {
+				f.Log().Logf("error during dump: %s", derr.Error())
+			}
+			t.Fatal(err)
 		}
-		t.Fatal(err)
 	}
 
 	if !opts.DisableCleanupBefore {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 3

**What this PR does / why we need it**:
This PR fixes some issues which prevented me from running the integration tests locally:
- The script which installs the landscaper didn't take the current version (including git hash) into account, causing it to deploy the landscaper with image version `v0.36.0-dev`, which doesn't exist, instead of `v0.36.0-dev-<hash>`, which is the version created by the Makefile.
- The script which creates the registry for integration tests can be configured to use a loadbalancer service for the registry, so that it is reachable from outside of the cluster. However, it only tried to fetch an IP from the service's status, but on AWS, loadbalancers don't have IPs but hostnames instead. This caused the script to fallback to an internal DNS name and made the registry integration tests unable to run locally when targeting a cluster running on AWS.
- At least for the AWS case with the loadbalancer hostname, the registry creation script has to wait until the DNS lookup for the newly generated loadbalancer works, otherwise the integration tests will fail because the registry cannot be reached.
- It's now possible to run the integration tests without installing Landscaper or registry and without checking whether the Landscaper pods are running. This is useful if one wants to debug e.g. a deployer and therefore run this deployer locally instead of in the cluster. This mode does not support tests which require a registry at the moment.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Improved the registry creation script which is used for the integration tests to be more robust.
```
```breaking developer
The `./hack/testcluster registry create` command, which is used for the integration tests, now takes a `--dns-format` argument with the possible values `internal` and `external`. This replaces the old `--address-format` argument. The old value `ip` corresponds to the new `external`, while the old `hostname` corresponds to the new `internal`. Note that, while the actual functionality didn't change too much, the new `external` mode will not always result in an IP, but might also result in a hostname (hence the name change).
```
```feature developer
A new make target `integration-test-pure` has been added. If run, it executes the integration tests, but it does neither deploy the Landscaper into the cluster (has to be there already), nor a registry (tests which require it are not supported currently). Also, the check whether the Landscaper pods are ready is skipped. This is intended for cases where a certain Landscaper component (e.g. a deployer) is run locally to debug into it and should therefore not be active in the cluster.
```
