### PR TITLE
Upgrade golang and golanci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 run:
   concurrency: 4
   deadline: 10m
-  go: '1.17'
+  go: '1.19'
 
   skip-files:
   - "zz_generated.*\\.go$"

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/landscaper/apis
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gardener/component-spec/bindings-go v0.0.41

--- a/apis/hack/generate-schemes/app/app.go
+++ b/apis/hack/generate-schemes/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -72,7 +71,7 @@ func (g *SchemaGenerator) Run(schemaDir, crdDir string) error {
 
 		// write file
 		file := filepath.Join(schemaDir, generators.ParsePackageVersionName(defName).String()+".json")
-		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
+		if err := os.WriteFile(file, data, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to write jsonschema for %q to %q: %w", file, generators.ParsePackageVersionName(defName).String(), err)
 		}
 
@@ -120,7 +119,7 @@ func (g *SchemaGenerator) Run(schemaDir, crdDir string) error {
 
 		// write file
 		file := filepath.Join(outDir, fmt.Sprintf("%s_%s.yaml", crd.CRD.Spec.Group, crd.CRD.Spec.Names.Plural))
-		if err := ioutil.WriteFile(file, data, os.ModePerm); err != nil {
+		if err := os.WriteFile(file, data, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to write crd for %q to %q: %w", file, crd.CRD.Name, err)
 		}
 
@@ -146,7 +145,7 @@ func prepareExportDir(exportDir string) error {
 		return fmt.Errorf("unable to to create export directory %q: %w", exportDir, err)
 	}
 	// cleanup previous files
-	files, err := ioutil.ReadDir(exportDir)
+	files, err := os.ReadDir(exportDir)
 	if err != nil {
 		return fmt.Errorf("unable to read files from export directory: %w", err)
 	}

--- a/cmd/landscaper-agent/app/options.go
+++ b/cmd/landscaper-agent/app/options.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lsutils "github.com/gardener/landscaper/pkg/utils"
@@ -80,7 +80,7 @@ func (o *options) Complete() error {
 		return fmt.Errorf("unable to setup manager")
 	}
 
-	data, err := ioutil.ReadFile(o.landscaperKubeconfigPath)
+	data, err := os.ReadFile(o.landscaperKubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("unable to read landscaper kubeconfig from %s: %w", o.landscaperKubeconfigPath, err)
 	}
@@ -106,7 +106,7 @@ func (o *options) parseConfigurationFile() (config.AgentConfiguration, error) {
 	if len(o.configPath) == 0 {
 		return config.AgentConfiguration{}, nil
 	}
-	data, err := ioutil.ReadFile(o.configPath)
+	data, err := os.ReadFile(o.configPath)
 	if err != nil {
 		return config.AgentConfiguration{}, err
 	}

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -7,7 +7,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
@@ -107,7 +106,7 @@ func (o *Options) run(ctx context.Context) error {
 
 	lsMgr := hostMgr
 	if len(o.landscaperKubeconfigPath) > 0 {
-		data, err := ioutil.ReadFile(o.landscaperKubeconfigPath)
+		data, err := os.ReadFile(o.landscaperKubeconfigPath)
 		if err != nil {
 			return fmt.Errorf("unable to read landscaper kubeconfig from %s: %w", o.landscaperKubeconfigPath, err)
 		}

--- a/cmd/landscaper-controller/app/options.go
+++ b/cmd/landscaper-controller/app/options.go
@@ -7,7 +7,7 @@ package app
 import (
 	"context"
 	goflag "flag"
-	"io/ioutil"
+	"os"
 
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -75,7 +75,7 @@ func (o *Options) parseConfigurationFile(ctx context.Context) (*config.Landscape
 	configv1alpha1 := &v1alpha1.LandscaperConfiguration{}
 
 	if len(o.ConfigPath) != 0 {
-		data, err := ioutil.ReadFile(o.ConfigPath)
+		data, err := os.ReadFile(o.ConfigPath)
 		if err != nil {
 			return nil, err
 		}

--- a/controller-utils/go.mod
+++ b/controller-utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/landscaper/controller-utils
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000

--- a/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/controller-utils/pkg/kubernetes/kubernetes.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -429,28 +429,28 @@ func GenerateKubeconfig(restConfig *rest.Config) (clientcmdapi.Config, error) {
 		bearerToken = restConfig.BearerToken
 	)
 	if len(restConfig.TLSClientConfig.CAFile) != 0 {
-		data, err := ioutil.ReadFile(restConfig.TLSClientConfig.CAFile)
+		data, err := os.ReadFile(restConfig.TLSClientConfig.CAFile)
 		if err != nil {
 			return clientcmdapi.Config{}, fmt.Errorf("unable to read ca from %q: %w", restConfig.TLSClientConfig.CAFile, err)
 		}
 		caData = data
 	}
 	if len(restConfig.TLSClientConfig.CertFile) != 0 {
-		data, err := ioutil.ReadFile(restConfig.TLSClientConfig.CertFile)
+		data, err := os.ReadFile(restConfig.TLSClientConfig.CertFile)
 		if err != nil {
 			return clientcmdapi.Config{}, fmt.Errorf("unable to read cert from %q: %w", restConfig.TLSClientConfig.CertFile, err)
 		}
 		certData = data
 	}
 	if len(restConfig.TLSClientConfig.KeyFile) != 0 {
-		data, err := ioutil.ReadFile(restConfig.TLSClientConfig.KeyFile)
+		data, err := os.ReadFile(restConfig.TLSClientConfig.KeyFile)
 		if err != nil {
 			return clientcmdapi.Config{}, fmt.Errorf("unable to read key from %q: %w", restConfig.TLSClientConfig.KeyFile, err)
 		}
 		keyData = data
 	}
 	if len(restConfig.BearerTokenFile) != 0 {
-		data, err := ioutil.ReadFile(restConfig.BearerTokenFile)
+		data, err := os.ReadFile(restConfig.BearerTokenFile)
 		if err != nil {
 			return clientcmdapi.Config{}, fmt.Errorf("unable to read bearer token from %q: %w", restConfig.BearerTokenFile, err)
 		}

--- a/controller-utils/pkg/webhook/certificates.go
+++ b/controller-utils/pkg/webhook/certificates.go
@@ -7,7 +7,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -198,10 +197,10 @@ func writeCertificates(certDir string, caCert, serverCert *certificates.Certific
 	if err := os.MkdirAll(certDir, 0755); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(serverKeyPath, serverCert.PrivateKeyPEM, 0666); err != nil {
+	if err := os.WriteFile(serverKeyPath, serverCert.PrivateKeyPEM, 0666); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(serverCertPath, serverCert.CertificatePEM, 0666); err != nil {
+	if err := os.WriteFile(serverCertPath, serverCert.CertificatePEM, 0666); err != nil {
 		return nil, err
 	}
 

--- a/controller-utils/pkg/webhook/certificates/certificates.go
+++ b/controller-utils/pkg/webhook/certificates/certificates.go
@@ -11,9 +11,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -426,7 +426,7 @@ const TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern = "self-generated
 // The function will return the *Certificate object as well as the path of the temporary directory where the
 // certificates are stored.
 func SelfGenerateTLSServerCertificate(name string, dnsNames []string) (*Certificate, string, error) {
-	tempDir, err := ioutil.TempDir("", TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern)
+	tempDir, err := os.MkdirTemp("", TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern)
 	if err != nil {
 		return nil, "", err
 	}
@@ -440,10 +440,10 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string) (*Certific
 	if err != nil {
 		return nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyCertificateCA), caCertificate.CertificatePEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificateCA), caCertificate.CertificatePEM, 0644); err != nil {
 		return nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyPrivateKeyCA), caCertificate.PrivateKeyPEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKeyCA), caCertificate.PrivateKeyPEM, 0644); err != nil {
 		return nil, "", err
 	}
 
@@ -458,10 +458,10 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string) (*Certific
 	if err != nil {
 		return nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyCertificate), certificate.CertificatePEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificate), certificate.CertificatePEM, 0644); err != nil {
 		return nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyPrivateKey), certificate.PrivateKeyPEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKey), certificate.PrivateKeyPEM, 0644); err != nil {
 		return nil, "", err
 	}
 

--- a/controller-utils/vendor/modules.txt
+++ b/controller-utils/vendor/modules.txt
@@ -22,7 +22,7 @@ github.com/fsnotify/fsnotify
 github.com/gardener/component-spec/bindings-go/apis/v2
 github.com/gardener/component-spec/bindings-go/utils/selector
 # github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000 => ../apis
-## explicit; go 1.18
+## explicit; go 1.19
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/core
 github.com/gardener/landscaper/apis/core/v1alpha1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/landscaper
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
@@ -32,6 +32,7 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	helm.sh/helm/v3 v3.9.4
 	k8s.io/api v0.24.3
 	k8s.io/apiextensions-apiserver v0.24.3
@@ -141,7 +142,6 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220524220425-1d687d428aca // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -21,4 +21,4 @@ chmod +x ${PROJECT_ROOT}/tmp/test/registry/registry
 
 GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 
-curl -sfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+curl -sfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b $(go env GOPATH)/bin v1.49.0

--- a/hack/testcluster/app.go
+++ b/hack/testcluster/app.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -65,7 +65,7 @@ func (o *CommonOptions) Complete() error {
 
 	if len(o.ID) == 0 {
 		// statefile should be defined as it is already checked by the calling function
-		data, err := ioutil.ReadFile(o.StateFile)
+		data, err := os.ReadFile(o.StateFile)
 		if err != nil {
 			return fmt.Errorf("unable to read state file %q: %w", o.StateFile, err)
 		}

--- a/hack/testcluster/pkg/cluster.go
+++ b/hack/testcluster/pkg/cluster.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -237,7 +236,7 @@ func CreateCluster(ctx context.Context, logger utils.Logger, args CreateClusterA
 		if err != nil {
 			return fmt.Errorf("unable to marshal state: %w", err)
 		}
-		if err := ioutil.WriteFile(stateFile, data, os.ModePerm); err != nil {
+		if err := os.WriteFile(stateFile, data, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to write statefile to %q: %w", stateFile, err)
 		}
 		logger.Logfln("Successfully written state to %q", stateFile)
@@ -250,7 +249,7 @@ func CreateCluster(ctx context.Context, logger utils.Logger, args CreateClusterA
 	if err := os.MkdirAll(filepath.Dir(exportKubeconfigPath), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to create export directory %q: %w", filepath.Dir(exportKubeconfigPath), err)
 	}
-	if err := ioutil.WriteFile(exportKubeconfigPath, kubeconfigBytes, os.ModePerm); err != nil {
+	if err := os.WriteFile(exportKubeconfigPath, kubeconfigBytes, os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write kubeconfig to %q: %w", exportKubeconfigPath, err)
 	}
 	logger.Logfln("Successfully written kubeconfig to %q", exportKubeconfigPath)

--- a/hack/testcluster/pkg/registry.go
+++ b/hack/testcluster/pkg/registry.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -244,7 +243,7 @@ func CreateRegistry(ctx context.Context,
 		if err != nil {
 			return fmt.Errorf("unable to marshal state: %w", err)
 		}
-		if err := ioutil.WriteFile(stateFile, data, os.ModePerm); err != nil {
+		if err := os.WriteFile(stateFile, data, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to write statefile to %q: %w", stateFile, err)
 		}
 		logger.Logfln("Successfully written state to %q", stateFile)
@@ -301,7 +300,7 @@ func CreateRegistry(ctx context.Context,
 	if err := os.MkdirAll(filepath.Dir(exportRegistryCreds), os.ModePerm); err != nil {
 		return fmt.Errorf("unable to create export directory %q: %w", filepath.Dir(exportRegistryCreds), err)
 	}
-	if err := ioutil.WriteFile(exportRegistryCreds, dockerconfigBytes, os.ModePerm); err != nil {
+	if err := os.WriteFile(exportRegistryCreds, dockerconfigBytes, os.ModePerm); err != nil {
 		return fmt.Errorf("unable to write docker auth config to %q: %w", exportRegistryCreds, err)
 	}
 	logger.Logfln("Successfully written docker auth config to %q", exportRegistryCreds)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -7,7 +7,7 @@ package agent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -298,7 +298,7 @@ func GenerateClusterRestConfig(restConfig *rest.Config) (lsv1alpha1.ClusterRestC
 	// the ca data has to be read from file for in-cluster configs
 	caData := restConfig.CAData
 	if len(restConfig.TLSClientConfig.CAFile) != 0 {
-		data, err := ioutil.ReadFile(restConfig.TLSClientConfig.CAFile)
+		data, err := os.ReadFile(restConfig.TLSClientConfig.CAFile)
 		if err != nil {
 			return lsv1alpha1.ClusterRestConfig{}, fmt.Errorf("unable to read ca data from %q: %w", restConfig.TLSClientConfig.CAFile, err)
 		}

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/gardener/component-cli/ociclient/credentials"
@@ -467,7 +467,7 @@ func (c *Container) parseAndSyncSecrets(ctx context.Context, defaultLabels map[s
 
 	if c.Configuration.OCI != nil {
 		for _, secretFileName := range c.Configuration.OCI.ConfigFiles {
-			secretFileContent, err := ioutil.ReadFile(secretFileName)
+			secretFileContent, err := os.ReadFile(secretFileName)
 			if err != nil {
 				log.Debug("Unable to read auth config from file, skipping", lc.KeyFileName, secretFileName, lc.KeyError, err.Error())
 				continue

--- a/pkg/deployer/container/init/e2e_test.go
+++ b/pkg/deployer/container/init/e2e_test.go
@@ -6,7 +6,6 @@ package init
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -88,7 +87,7 @@ var _ = Describe("Init e2e", func() {
 
 		utils.ExpectNoError(s.Backup(ctx))
 
-		file, err := ioutil.ReadFile("./testdata/00-di-simple.yaml")
+		file, err := os.ReadFile("./testdata/00-di-simple.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(resFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())

--- a/pkg/deployer/container/init/init_suite_test.go
+++ b/pkg/deployer/container/init/init_suite_test.go
@@ -7,7 +7,6 @@ package init
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,7 +67,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/00-di-simple.yaml")
+		file, err := os.ReadFile("./testdata/00-di-simple.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -89,7 +88,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/01-di-blueprint.yaml")
+		file, err := os.ReadFile("./testdata/01-di-blueprint.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -109,7 +108,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/02-di-inline-blueprint.yaml")
+		file, err := os.ReadFile("./testdata/02-di-inline-blueprint.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -129,7 +128,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/01-di-blueprint.yaml")
+		file, err := os.ReadFile("./testdata/01-di-blueprint.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -151,7 +150,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/03-di-inline-cd.yaml")
+		file, err := os.ReadFile("./testdata/03-di-inline-cd.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -173,7 +172,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/04-di-inline-bp-no-cd.yaml")
+		file, err := os.ReadFile("./testdata/04-di-inline-bp-no-cd.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -193,7 +192,7 @@ var _ = Describe("Constructor", func() {
 		opts.Complete()
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/05-di-inline-bp-inline-cd.yaml")
+		file, err := os.ReadFile("./testdata/05-di-inline-bp-inline-cd.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())
@@ -220,7 +219,7 @@ var _ = Describe("Constructor", func() {
 		opts.RegistrySecretBasePath = "/unexisting/path"
 		memFs := memoryfs.New()
 
-		file, err := ioutil.ReadFile("./testdata/01-di-blueprint.yaml")
+		file, err := os.ReadFile("./testdata/01-di-blueprint.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(memFs.MkdirAll(filepath.Dir(container.ConfigurationPath), os.ModePerm)).To(Succeed())
 		Expect(vfs.WriteFile(memFs, container.ConfigurationPath, file, os.ModePerm)).To(Succeed())

--- a/pkg/deployer/container/wait/sidecar.go
+++ b/pkg/deployer/container/wait/sidecar.go
@@ -6,7 +6,6 @@ package wait
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -72,7 +71,7 @@ func withTerminationLog(log logging.Logger, err error) error {
 		return nil
 	}
 
-	if err := ioutil.WriteFile("/dev/termination-log", []byte(err.Error()), os.ModePerm); err != nil {
+	if err := os.WriteFile("/dev/termination-log", []byte(err.Error()), os.ModePerm); err != nil {
 		log.Error(err, "Unable to write termination message")
 	}
 	return err

--- a/pkg/deployer/container/wait/uploadexport.go
+++ b/pkg/deployer/container/wait/uploadexport.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +41,7 @@ func UploadExport(ctx context.Context, kubeClient client.Client, deployItemKey l
 		return fmt.Errorf("main container exists with %d", mainContainerStatus.State.Terminated.ExitCode)
 	}
 
-	exportData, err := ioutil.ReadFile(exportFilePath)
+	exportData, err := os.ReadFile(exportFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Info("No export config found. Skip upload.")

--- a/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
+++ b/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gardener/component-cli/ociclient"
@@ -97,7 +97,7 @@ var _ = Describe("GetChart", func() {
 		ociClient, err := ociclient.NewClient(logr.Discard())
 		Expect(err).ToNot(HaveOccurred())
 
-		file, err := ioutil.ReadFile("./testdata/01-component-descriptor.yaml")
+		file, err := os.ReadFile("./testdata/01-component-descriptor.yaml")
 		Expect(err).ToNot(HaveOccurred())
 
 		inline := &cdv2.ComponentDescriptor{}

--- a/pkg/deployer/helm/helmchartrepo/helm_chart_repo_client.go
+++ b/pkg/deployer/helm/helmchartrepo/helm_chart_repo_client.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -247,7 +247,7 @@ func (c *HelmChartRepoClient) readResponseBody(ctx context.Context, res *http.Re
 		err := fmt.Errorf("request failed with status code %v", res.StatusCode)
 
 		if logger.Enabled(logging.DEBUG) {
-			body, bodyReadErr := ioutil.ReadAll(res.Body)
+			body, bodyReadErr := io.ReadAll(res.Body)
 			if bodyReadErr != nil {
 				logger.Error(err, err.Error(), "response status code without body", res.StatusCode)
 				return nil, err
@@ -259,7 +259,7 @@ func (c *HelmChartRepoClient) readResponseBody(ctx context.Context, res *http.Re
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not read response body: %w", err)
 	}

--- a/pkg/deployer/lib/cmd/default.go
+++ b/pkg/deployer/lib/cmd/default.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lsutils "github.com/gardener/landscaper/pkg/utils"
@@ -81,7 +81,7 @@ func (o *DefaultOptions) Complete() error {
 	o.LsMgr = o.HostMgr
 
 	if len(o.LsKubeconfig) != 0 {
-		data, err := ioutil.ReadFile(o.LsKubeconfig)
+		data, err := os.ReadFile(o.LsKubeconfig)
 		if err != nil {
 			return fmt.Errorf("unable to read landscaper kubeconfig from %s: %w", o.LsKubeconfig, err)
 		}
@@ -137,7 +137,7 @@ func (o *DefaultOptions) GetConfig(obj runtime.Object) error {
 	if len(o.configPath) == 0 {
 		return nil
 	}
-	data, err := ioutil.ReadFile(o.configPath)
+	data, err := os.ReadFile(o.configPath)
 	if err != nil {
 		return fmt.Errorf("uable to read config from %q: %w", o.configPath, err)
 	}

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck_test.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck_test.go
@@ -6,7 +6,7 @@ package readinesscheck
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -215,7 +215,7 @@ var _ = Describe("Custom health checks", func() {
 })
 
 func loadSingleObjectFromFile(fileName string) ([]*unstructured.Unstructured, []lsv1alpha1.TypedObjectReference) {
-	testObjectsRaw, err := ioutil.ReadFile(filepath.Join(testdataDir, fileName))
+	testObjectsRaw, err := os.ReadFile(filepath.Join(testdataDir, fileName))
 	Expect(err).ToNot(HaveOccurred())
 	testObjects, err := kutil.DecodeObjects(logging.Discard(), fileName, testObjectsRaw)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/deployer/lib/readinesscheck/readiness_suite_test.go
+++ b/pkg/deployer/lib/readinesscheck/readiness_suite_test.go
@@ -6,7 +6,7 @@ package readinesscheck
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -58,12 +58,12 @@ var _ = AfterSuite(func() {
 
 func loadObjectsIntoTestEnv(dirname string, c client.Client, s *envtest.State) ([]lsv1alpha1.TypedObjectReference, error) {
 	decoder := serializer.NewCodecFactory(c.Scheme()).UniversalDecoder()
-	files, err := ioutil.ReadDir(dirname)
+	files, err := os.ReadDir(dirname)
 	Expect(err).ToNot(HaveOccurred())
 
 	objectRefs := make([]lsv1alpha1.TypedObjectReference, len(files))
 	for i, n := range files {
-		raw, err := ioutil.ReadFile(filepath.Join(dirname, n.Name()))
+		raw, err := os.ReadFile(filepath.Join(dirname, n.Name()))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/deployermanagement/config/options.go
+++ b/pkg/deployermanagement/config/options.go
@@ -6,7 +6,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -66,7 +66,7 @@ func (o *Options) parseDeployersConfigurationFile() error {
 	if len(o.DeployersConfigPath) == 0 {
 		return nil
 	}
-	data, err := ioutil.ReadFile(o.DeployersConfigPath)
+	data, err := os.ReadFile(o.DeployersConfigPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/landscaper/blueprints/bputils/utils.go
+++ b/pkg/landscaper/blueprints/bputils/utils.go
@@ -7,7 +7,7 @@ package bputils
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
@@ -73,7 +73,7 @@ func BuildNewBlueprintConfig(cache cache.Cache, fs vfs.FileSystem, path string) 
 		Size:      int64(len(data)),
 	}
 
-	if err := cache.Add(desc, ioutil.NopCloser(bytes.NewBuffer(data))); err != nil {
+	if err := cache.Add(desc, io.NopCloser(bytes.NewBuffer(data))); err != nil {
 		return ocispecv1.Descriptor{}, err
 	}
 	return desc, nil

--- a/pkg/landscaper/installations/executions/template/template_test.go
+++ b/pkg/landscaper/installations/executions/template/template_test.go
@@ -7,7 +7,6 @@ package template_test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,7 +60,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 	Context("TemplateSubinstallationExecutions", func() {
 		It("should return the raw template if no templating funcs are defined", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-20.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-20.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -81,7 +80,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use imports to template installations", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-21.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-21.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -104,7 +103,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 	Context("TemplateDeployExecutions", func() {
 		It("should return the raw template if no templating funcs are defined", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-01.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-01.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -124,7 +123,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use the import values to template", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-02.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-02.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -145,7 +144,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should read the content of a file to template", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-03.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-03.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -169,7 +168,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use a resource from the component descriptor", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-04.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-04.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -219,7 +218,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use a resource from the component descriptor's referenced component", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-10.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-10.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -293,7 +292,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should throw an error when the template tries to template a undefined value", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-08.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-08.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -309,7 +308,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use the state to template", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-09.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-09.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -336,7 +335,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use the blueprint information", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-11.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-11.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -384,7 +383,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should generate an image vector", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-12.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -393,7 +392,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			blue.DeployExecutions = exec
 			op := template.New(gotemplate.New(nil, stateHandler), spiff.New(stateHandler))
 
-			cdRaw, err := ioutil.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
+			cdRaw, err := os.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			cd := &cdv2.ComponentDescriptor{}
 			Expect(yaml.Unmarshal(cdRaw, cd)).ToNot(HaveOccurred())
@@ -408,7 +407,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			config := make(map[string]interface{})
 			Expect(yaml.Unmarshal(res[0].Configuration.Raw, &config)).ToNot(HaveOccurred())
 
-			result, err := ioutil.ReadFile(filepath.Join(sharedTestdataDir, "result-12.yaml"))
+			result, err := os.ReadFile(filepath.Join(sharedTestdataDir, "result-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			resultString := string(result)
 
@@ -424,7 +423,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use a parsed oci ref to template", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-13.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-13.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -453,7 +452,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 	Context("TemplateExportExecutions", func() {
 		It("should return the raw template if no templating funcs are defined", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-05.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-05.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -469,7 +468,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should use the export values to template", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-06.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-06.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -486,7 +485,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 		})
 
 		It("should read the content of a file to template", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-07.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-07.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -514,7 +513,7 @@ func runTestSuiteGoTemplate(testdataDir, sharedTestdataDir string) {
 		stateHandler template.GenericStateHandler
 
 		executeTemplate = func(templateFile string, imports map[string]interface{}) ([]template.DeployItemSpecification, error) {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, templateFile))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, templateFile))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -524,7 +523,7 @@ func runTestSuiteGoTemplate(testdataDir, sharedTestdataDir string) {
 
 			op := template.New(gotemplate.New(nil, stateHandler), spiff.New(stateHandler))
 
-			cdRaw, err := ioutil.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
+			cdRaw, err := os.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			cd := &cdv2.ComponentDescriptor{}
 			Expect(yaml.Unmarshal(cdRaw, cd)).ToNot(HaveOccurred())
@@ -684,7 +683,7 @@ func runTestSuiteSpiff(testdataDir, sharedTestdataDir string) {
 
 	Context("Error Messages", func() {
 		It("should handle template execution errors", func() {
-			tmpl, err := ioutil.ReadFile(filepath.Join(testdataDir, "template-22.yaml"))
+			tmpl, err := os.ReadFile(filepath.Join(testdataDir, "template-22.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			exec := make([]lsv1alpha1.TemplateExecutor, 0)
 			Expect(yaml.Unmarshal(tmpl, &exec)).ToNot(HaveOccurred())
@@ -701,7 +700,7 @@ func runTestSuiteSpiff(testdataDir, sharedTestdataDir string) {
 			}
 			op := template.New(gotemplate.New(nil, stateHandler), spiff.New(stateHandler))
 
-			cdRaw, err := ioutil.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
+			cdRaw, err := os.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			cd := &cdv2.ComponentDescriptor{}
 			Expect(yaml.Unmarshal(cdRaw, cd)).ToNot(HaveOccurred())

--- a/pkg/landscaper/registry/components/local.go
+++ b/pkg/landscaper/registry/components/local.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -331,7 +330,7 @@ func (res *BaseFilesystemBlobResolver) ResolveFromFs(blobpath string) (*ctf.Blob
 			MediaType: "",
 			Digest:    digest.FromBytes(data.Bytes()).String(),
 			Size:      int64(data.Len()),
-		}, ioutil.NopCloser(&data), nil
+		}, io.NopCloser(&data), nil
 	}
 	file, err := res.fs.Open(blobpath)
 	if err != nil {

--- a/pkg/landscaper/registry/components/oci_test.go
+++ b/pkg/landscaper/registry/components/oci_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/gardener/component-spec/bindings-go/codec"
@@ -74,7 +74,7 @@ var _ = Describe("Registry", func() {
 
 		ociClient.EXPECT().GetManifest(ctx, "example.com/component-descriptors/example.com/my-comp:0.0.1").Return(manifest, nil)
 		ociClient.EXPECT().Fetch(ctx, "example.com/component-descriptors/example.com/my-comp:0.0.1", cdConfigLayerDesc, gomock.Any()).Return(nil).Do(func(ctx context.Context, ref string, desc ocispecv1.Descriptor, writer io.Writer) {
-			data, err := ioutil.ReadFile("./testdata/comp1/config.json")
+			data, err := os.ReadFile("./testdata/comp1/config.json")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = io.Copy(writer, bytes.NewBuffer(data))
 			Expect(err).ToNot(HaveOccurred())
@@ -115,13 +115,13 @@ var _ = Describe("Registry", func() {
 
 		ociClient.EXPECT().GetManifest(ctx, "example.com/component-descriptors/example.com/my-comp:0.0.1").Return(manifest, nil)
 		ociClient.EXPECT().Fetch(ctx, "example.com/component-descriptors/example.com/my-comp:0.0.1", cdConfigLayerDesc, gomock.Any()).Return(nil).Do(func(ctx context.Context, ref string, desc ocispecv1.Descriptor, writer io.Writer) {
-			data, err := ioutil.ReadFile("./testdata/comp1/config.json")
+			data, err := os.ReadFile("./testdata/comp1/config.json")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = io.Copy(writer, bytes.NewBuffer(data))
 			Expect(err).ToNot(HaveOccurred())
 		})
 		ociClient.EXPECT().Fetch(ctx, "example.com/component-descriptors/example.com/my-comp:0.0.1", cdLayerDesc, gomock.Any()).Return(nil).Do(func(ctx context.Context, ref string, desc ocispecv1.Descriptor, writer io.Writer) {
-			data, err := ioutil.ReadFile("./testdata/comp1/component-descriptor.yaml")
+			data, err := os.ReadFile("./testdata/comp1/component-descriptor.yaml")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = io.Copy(writer, bytes.NewBuffer(data))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/utils/tar/tar.go
+++ b/pkg/utils/tar/tar.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -195,7 +194,7 @@ func BuildTarGzipLayer(cache cache.Cache, fs vfs.FileSystem, path string, annota
 		Annotations: annotations,
 	}
 
-	if err := cache.Add(desc, ioutil.NopCloser(&blob)); err != nil {
+	if err := cache.Add(desc, io.NopCloser(&blob)); err != nil {
 		return ocispecv1.Descriptor{}, err
 	}
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -11,8 +11,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -162,7 +162,7 @@ func New(logger utils2.Logger, cfg *Options) (*Framework, error) {
 	}
 
 	if len(cfg.DockerConfigPath) != 0 {
-		data, err := ioutil.ReadFile(cfg.DockerConfigPath)
+		data, err := os.ReadFile(cfg.DockerConfigPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read docker config file: %w", err)
 		}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -7,6 +7,8 @@ package integration_test
 import (
 	"context"
 	"flag"
+	"testing"
+
 	"github.com/gardener/landscaper/test/integration/core"
 	"github.com/gardener/landscaper/test/integration/dependencies"
 	"github.com/gardener/landscaper/test/integration/deployitems"
@@ -17,7 +19,6 @@ import (
 	"github.com/gardener/landscaper/test/integration/targets"
 	"github.com/gardener/landscaper/test/integration/tutorial"
 	"github.com/gardener/landscaper/test/integration/webhook"
-	"testing"
 
 	"github.com/gardener/landscaper/test/integration/deployers"
 

--- a/test/utils/charts.go
+++ b/test/utils/charts.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/gomega"
@@ -22,7 +21,7 @@ import (
 func ReadChartFrom(path string) ([]byte, func()) {
 	chart, err := chartloader.LoadDir(path)
 	Expect(err).ToNot(HaveOccurred())
-	tempDir, err := ioutil.TempDir(os.TempDir(), "chart-")
+	tempDir, err := os.MkdirTemp("", "chart-")
 	Expect(err).ToNot(HaveOccurred())
 	closer := func() {
 		Expect(os.RemoveAll(tempDir)).To(Succeed())
@@ -31,7 +30,7 @@ func ReadChartFrom(path string) ([]byte, func()) {
 	chartPath, err := chartutil.Save(chart, tempDir)
 	Expect(err).ToNot(HaveOccurred())
 
-	chartBytes, err := ioutil.ReadFile(chartPath)
+	chartBytes, err := os.ReadFile(chartPath)
 	Expect(err).ToNot(HaveOccurred())
 	return chartBytes, closer
 }
@@ -39,7 +38,7 @@ func ReadChartFrom(path string) ([]byte, func()) {
 // ReadValuesFromFile reads Helm values from a file and returns them as JSON raw message
 func ReadValuesFromFile(path string) json.RawMessage {
 	var values json.RawMessage
-	in, err := ioutil.ReadFile(path)
+	in, err := os.ReadFile(path)
 	Expect(err).ToNot(HaveOccurred())
 	values, err = yaml.YAMLToJSON(in)
 	Expect(err).ToNot(HaveOccurred())

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -147,7 +146,7 @@ func parseResources(path string, state *State) ([]client.Object, error) {
 			return nil
 		}
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read file %s", path)
 		}

--- a/test/utils/envtest/fake_client.go
+++ b/test/utils/envtest/fake_client.go
@@ -7,7 +7,6 @@ package envtest
 import (
 	"bytes"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -33,7 +32,7 @@ func NewFakeClientFromPath(path string) (client.Client, *State, error) {
 				return nil
 			}
 
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				return errors.Wrapf(err, "unable to read file %s", path)
 			}

--- a/test/utils/resources.go
+++ b/test/utils/resources.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
@@ -89,7 +89,7 @@ func LocalRemoteBlueprintRef(resourceName string) lsv1alpha1.BlueprintDefinition
 
 // ReadResourceFromFile reads a file and parses it to the given object
 func ReadResourceFromFile(obj runtime.Object, testfile string) error {
-	data, err := ioutil.ReadFile(testfile)
+	data, err := os.ReadFile(testfile)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func ReadResourceFromFile(obj runtime.Object, testfile string) error {
 
 // ReadBlueprintFromFile reads a file and parses it to a Blueprint
 func ReadBlueprintFromFile(testfile string) (*lsv1alpha1.Blueprint, error) {
-	data, err := ioutil.ReadFile(testfile)
+	data, err := os.ReadFile(testfile)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -168,7 +168,7 @@ github.com/gardener/component-spec/bindings-go/utils/selector
 ## explicit; go 1.16
 github.com/gardener/image-vector/pkg
 # github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000 => ./apis
-## explicit; go 1.18
+## explicit; go 1.19
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/config/install
 github.com/gardener/landscaper/apis/config/v1alpha1
@@ -204,7 +204,7 @@ github.com/gardener/landscaper/apis/errors
 github.com/gardener/landscaper/apis/mediatype
 github.com/gardener/landscaper/apis/schema
 # github.com/gardener/landscaper/controller-utils v0.0.0-00010101000000-000000000000 => ./controller-utils
-## explicit; go 1.18
+## explicit; go 1.19
 github.com/gardener/landscaper/controller-utils/pkg/crdmanager
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes/mock


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind technical-debt
/priority 3

**What this PR does / why we need it**:
Upgrades golang to `v1.19` and golangci-lint to `v1.49.0`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Upgrade golang to `v1.19`
```
```other dependency
Upgrade golangci-lint to `v1.49.0`
```
