### PR TITLE
Fix readiness check helm deployer

### DIFF
--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -92,6 +92,7 @@ func (h *Helm) ApplyFiles(ctx context.Context, files, crds map[string]string, ex
 			if err != nil {
 				return err
 			}
+			h.ProviderStatus.ManagedResources = managedResourceStatusList
 		}
 	}
 

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -12,13 +12,11 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
-
 	"k8s.io/client-go/util/jsonpath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -61,7 +59,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady() error {
 	}
 
 	timeout := c.Timeout.Duration
-	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject); err != nil {
+	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject, c.isCheckRelevant, true); err != nil {
 		return lserror.NewWrappedError(err,
 			c.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}
@@ -112,6 +110,10 @@ func (c *CustomReadinessCheck) CheckObject(u *unstructured.Unstructured) error {
 		}
 	}
 	return nil
+}
+
+func (d *CustomReadinessCheck) isCheckRelevant(_ *unstructured.Unstructured) bool {
+	return true
 }
 
 func matchResourceConditions(object interface{}, values []interface{}, operator selection.Operator) (bool, error) {

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -59,7 +59,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady() error {
 	}
 
 	timeout := c.Timeout.Duration
-	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject, c.isCheckRelevant, true); err != nil {
+	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject); err != nil {
 		return lserror.NewWrappedError(err,
 			c.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}
@@ -110,10 +110,6 @@ func (c *CustomReadinessCheck) CheckObject(u *unstructured.Unstructured) error {
 		}
 	}
 	return nil
-}
-
-func (d *CustomReadinessCheck) isCheckRelevant(_ *unstructured.Unstructured) bool {
-	return true
 }
 
 func matchResourceConditions(object interface{}, values []interface{}, operator selection.Operator) (bool, error) {

--- a/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/kyaml/sets"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lserror "github.com/gardener/landscaper/apis/errors"
@@ -22,11 +23,12 @@ import (
 
 // DefaultReadinessCheck contains all the data and methods required to kick off a default readiness check
 type DefaultReadinessCheck struct {
-	Context          context.Context
-	Client           client.Client
-	CurrentOp        string
-	Timeout          *lsv1alpha1.Duration
-	ManagedResources []lsv1alpha1.TypedObjectReference
+	Context             context.Context
+	Client              client.Client
+	CurrentOp           string
+	Timeout             *lsv1alpha1.Duration
+	ManagedResources    []lsv1alpha1.TypedObjectReference
+	FailOnMissingObject bool
 }
 
 // CheckResourcesReady implements the default readiness check for Kubernetes manifests
@@ -43,7 +45,7 @@ func (d *DefaultReadinessCheck) CheckResourcesReady() error {
 	}
 
 	timeout := d.Timeout.Duration
-	if err := WaitForObjectsReady(d.Context, timeout, d.Client, objects, d.CheckObject); err != nil {
+	if err := WaitForObjectsReady(d.Context, timeout, d.Client, objects, d.CheckObject, d.isCheckRelevant, d.FailOnMissingObject); err != nil {
 		return lserror.NewWrappedError(err,
 			d.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}
@@ -95,6 +97,12 @@ func (d *DefaultReadinessCheck) CheckObject(u *unstructured.Unstructured) error 
 	default:
 		return nil
 	}
+}
+
+func (d *DefaultReadinessCheck) isCheckRelevant(u *unstructured.Unstructured) bool {
+	checkRelevant := sets.String{}
+	checkRelevant.Insert("Pod", "Deployment.apps", "ReplicaSet.apps", "StatefulSet.apps", "DaemonSet.apps", "ReplicationController")
+	return checkRelevant.Has(u.GroupVersionKind().GroupKind().String())
 }
 
 func outdatedGeneration(current, expected int64) error {

--- a/pkg/deployer/lib/readinesscheck/readiness.go
+++ b/pkg/deployer/lib/readinesscheck/readiness.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimacherrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,9 +33,13 @@ type StatusType string
 // checkObjectFunc is a function to perform the actual readiness check
 type checkObjectFunc func(*unstructured.Unstructured) error
 
+// isCheckRelevantFunc is a function that determines the check relevance of an object
+type isCheckRelevantFunc func(*unstructured.Unstructured) bool
+
 // WaitForObjectsReady waits for objects to be heatlhy and
 // returns an error if all the objects are not ready after the timeout.
-func WaitForObjectsReady(ctx context.Context, timeout time.Duration, kubeClient client.Client, objects []*unstructured.Unstructured, fn checkObjectFunc) error {
+func WaitForObjectsReady(ctx context.Context, timeout time.Duration, kubeClient client.Client,
+	objects []*unstructured.Unstructured, fn checkObjectFunc, isCheckRelevant isCheckRelevantFunc, failOnMissingObject bool) error {
 	var (
 		wg  sync.WaitGroup
 		try int32 = 1
@@ -57,7 +62,7 @@ func WaitForObjectsReady(ctx context.Context, timeout time.Duration, kubeClient 
 			go func(obj *unstructured.Unstructured) {
 				defer wg.Done()
 
-				if err := IsObjectReady(ctx, kubeClient, obj, fn); err != nil {
+				if err := IsObjectReady(ctx, kubeClient, obj, fn, isCheckRelevant, failOnMissingObject); err != nil {
 					switch err.(type) {
 					case *ObjectNotReadyError:
 						notReadyErrs = append(notReadyErrs, err)
@@ -108,18 +113,25 @@ func (e *ObjectNotReadyError) Error() string {
 }
 
 // IsObjectReady gets an updated version of an object and checks if it is ready.
-func IsObjectReady(ctx context.Context, kubeClient client.Client, obj *unstructured.Unstructured, checkObject checkObjectFunc) error {
+func IsObjectReady(ctx context.Context, kubeClient client.Client, obj *unstructured.Unstructured,
+	checkObject checkObjectFunc, isCheckRelevant isCheckRelevantFunc, failOnMissingObject bool) error {
 	objLog, ctx := logging.FromContextOrNew(ctx, nil,
 		lc.KeyGroupVersionKind, obj.GroupVersionKind().String(),
 		lc.KeyResource, kutil.ObjectKey(obj.GetName(), obj.GetNamespace()).String())
 
+	if !isCheckRelevant(obj) && !failOnMissingObject {
+		return nil
+	}
+
 	key := kutil.ObjectKey(obj.GetName(), obj.GetNamespace())
 	if err := kubeClient.Get(ctx, key, obj); err != nil {
-		objLog.Debug("Resource status", lc.KeyStatus, StatusUnknown)
-		return fmt.Errorf("unable to get %s %s/%s: %w",
-			obj.GroupVersionKind().String(),
-			obj.GetName(), obj.GetNamespace(),
-			err)
+		if !errors.IsNotFound(err) || isCheckRelevant(obj) || failOnMissingObject {
+			objLog.Debug("Resource status", lc.KeyStatus, StatusUnknown)
+			return fmt.Errorf("unable to get %s %s/%s: %w",
+				obj.GroupVersionKind().String(),
+				obj.GetName(), obj.GetNamespace(),
+				err)
+		}
 	}
 
 	objLog.Debug("Getting resource status")

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -8,30 +8,24 @@ import (
 	"context"
 	"errors"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
-
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	deployerlib "github.com/gardener/landscaper/pkg/deployer/lib"
-
-	"github.com/gardener/landscaper/pkg/deployer/lib/resourcemanager"
-
-	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
-
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
+	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
 	lserrors "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+	deployerlib "github.com/gardener/landscaper/pkg/deployer/lib"
 	health "github.com/gardener/landscaper/pkg/deployer/lib/readinesscheck"
+	"github.com/gardener/landscaper/pkg/deployer/lib/resourcemanager"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
 func (m *Manifest) Reconcile(ctx context.Context) error {
@@ -125,11 +119,12 @@ func (m *Manifest) CheckResourcesReady(ctx context.Context, client client.Client
 	managedresources := m.ProviderStatus.ManagedResources.TypedObjectReferenceList()
 	if !m.ProviderConfiguration.ReadinessChecks.DisableDefault {
 		defaultReadinessCheck := health.DefaultReadinessCheck{
-			Context:          ctx,
-			Client:           client,
-			CurrentOp:        "DefaultCheckResourcesReadinessManifest",
-			Timeout:          m.ProviderConfiguration.ReadinessChecks.Timeout,
-			ManagedResources: managedresources,
+			Context:             ctx,
+			Client:              client,
+			CurrentOp:           "DefaultCheckResourcesReadinessManifest",
+			Timeout:             m.ProviderConfiguration.ReadinessChecks.Timeout,
+			ManagedResources:    managedresources,
+			FailOnMissingObject: true,
 		}
 		err := defaultReadinessCheck.CheckResourcesReady()
 		if err != nil {

--- a/test/integration/deployers/helmdeployer/helm_deployer_tests.go
+++ b/test/integration/deployers/helmdeployer/helm_deployer_tests.go
@@ -204,7 +204,7 @@ func HelmDeployerTests(f *framework.Framework) {
 
 				removeDeployItemAndWaitForSuccess(ctx, f, state.State, di)
 			}
-			XIt("with real helm deployer", func() {
+			It("with real helm deployer", func() {
 				testFunc(true)
 			})
 			It("with helm templating and manifest apply", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area helm-deployer
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind bug
/priority 3

**What this PR does / why we need it**:
Fixes the malfunctioning readiness check when using the real helm deployer #600 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- fix readiness check not working when using the real helm deployer 
```
