### PR TITLE
move env secret (run-int-tests)

### DIFF
--- a/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
+++ b/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
@@ -343,6 +343,10 @@
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
+        "landscaperNamespace": {
+          "description": "LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the deployers are stored. Defaults to ls-system",
+          "type": "string"
+        },
         "name": {
           "description": "Name is the name for the agent and environment. This name has to be landscaper globally unique.",
           "type": "string",

--- a/apis/config/types_agent_config.go
+++ b/apis/config/types_agent_config.go
@@ -28,4 +28,10 @@ type AgentConfiguration struct {
 	// TargetSelectors defines the target selector that is applied to all installed deployers
 	// +optional
 	TargetSelectors []lsv1alpha1.TargetSelector `json:"targetSelectors,omitempty"`
+
+	// LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the
+	// deployers are stored.
+	// Defaults to ls-system
+	// +optional
+	LandscaperNamespace string `json:"landscaperNamespace,omitempty"`
 }

--- a/apis/config/v1alpha1/defaults.go
+++ b/apis/config/v1alpha1/defaults.go
@@ -71,6 +71,9 @@ func SetDefaults_LandscaperConfiguration(obj *LandscaperConfiguration) {
 	if len(obj.DeployerManagement.Agent.Namespace) == 0 {
 		obj.DeployerManagement.Agent.Namespace = obj.DeployerManagement.Namespace
 	}
+	if len(obj.DeployerManagement.Agent.LandscaperNamespace) == 0 {
+		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Namespace
+	}
 	if obj.DeployerManagement.Agent.OCI == nil {
 		obj.DeployerManagement.Agent.OCI = obj.Registry.OCI
 	}
@@ -107,6 +110,9 @@ func SetDefaults_CommonControllerConfig(obj *CommonControllerConfig) {
 func SetDefaults_AgentConfiguration(obj *AgentConfiguration) {
 	if len(obj.Namespace) == 0 {
 		obj.Namespace = "ls-system"
+	}
+	if len(obj.LandscaperNamespace) == 0 {
+		obj.LandscaperNamespace = "ls-system"
 	}
 }
 

--- a/apis/config/v1alpha1/defaults.go
+++ b/apis/config/v1alpha1/defaults.go
@@ -72,7 +72,7 @@ func SetDefaults_LandscaperConfiguration(obj *LandscaperConfiguration) {
 		obj.DeployerManagement.Agent.Namespace = obj.DeployerManagement.Namespace
 	}
 	if len(obj.DeployerManagement.Agent.LandscaperNamespace) == 0 {
-		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Namespace
+		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Agent.Namespace
 	}
 	if obj.DeployerManagement.Agent.OCI == nil {
 		obj.DeployerManagement.Agent.OCI = obj.Registry.OCI

--- a/apis/config/v1alpha1/types_agent_config.go
+++ b/apis/config/v1alpha1/types_agent_config.go
@@ -28,4 +28,10 @@ type AgentConfiguration struct {
 	// TargetSelectors defines the target selector that is applied to all installed deployers
 	// +optional
 	TargetSelectors []lsv1alpha1.TargetSelector `json:"targetSelectors,omitempty"`
+
+	// LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the
+	// deployers are stored.
+	// Defaults to ls-system
+	// +optional
+	LandscaperNamespace string `json:"landscaperNamespace,omitempty"`
 }

--- a/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/apis/config/v1alpha1/zz_generated.conversion.go
@@ -268,6 +268,7 @@ func autoConvert_v1alpha1_AgentConfiguration_To_config_AgentConfiguration(in *Ag
 	out.Namespace = in.Namespace
 	out.OCI = (*config.OCIConfiguration)(unsafe.Pointer(in.OCI))
 	out.TargetSelectors = *(*[]corev1alpha1.TargetSelector)(unsafe.Pointer(&in.TargetSelectors))
+	out.LandscaperNamespace = in.LandscaperNamespace
 	return nil
 }
 
@@ -281,6 +282,7 @@ func autoConvert_config_AgentConfiguration_To_v1alpha1_AgentConfiguration(in *co
 	out.Namespace = in.Namespace
 	out.OCI = (*OCIConfiguration)(unsafe.Pointer(in.OCI))
 	out.TargetSelectors = *(*[]corev1alpha1.TargetSelector)(unsafe.Pointer(&in.TargetSelectors))
+	out.LandscaperNamespace = in.LandscaperNamespace
 	return nil
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -1118,6 +1118,13 @@ func schema_gardener_landscaper_apis_config_AgentConfiguration(ref common.Refere
 							},
 						},
 					},
+					"landscaperNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the deployers are stored. Defaults to ls-system",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -1668,6 +1675,13 @@ func schema_gardener_landscaper_apis_config_LandscaperAgentConfiguration(ref com
 							},
 						},
 					},
+					"landscaperNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the deployers are stored. Defaults to ls-system",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"disable", "name"},
 			},
@@ -1992,6 +2006,13 @@ func schema_landscaper_apis_config_v1alpha1_AgentConfiguration(ref common.Refere
 									},
 								},
 							},
+						},
+					},
+					"landscaperNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the deployers are stored. Defaults to ls-system",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -2538,6 +2559,13 @@ func schema_landscaper_apis_config_v1alpha1_LandscaperAgentConfiguration(ref com
 									},
 								},
 							},
+						},
+					},
+					"landscaperNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the deployers are stored. Defaults to ls-system",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/charts/landscaper-agent/templates/_helpers.tpl
+++ b/charts/landscaper-agent/templates/_helpers.tpl
@@ -83,6 +83,9 @@ kind: AgentConfiguration
 
 name: {{ default .Release.Name .Values.agent.name }}
 namespace: {{default .Release.Namespace .Values.agent.namespace }}
+{{- if .Values.agent.landscaperNamespace }}
+landscaperNamespace: {{ .Values.agent.landscaperNamespace }}
+{{ end }}
 {{- if .Values.agent.registryConfig }}
 oci:
   allowPlainHttp: {{ .Values.agent.registryConfig.allowPlainHttpRegistries | default false }}

--- a/charts/landscaper-agent/values.yaml
+++ b/charts/landscaper-agent/values.yaml
@@ -27,7 +27,7 @@ agent:
 #   insecureSkipVerify: false
 #   secrets: {}
 ##    <name>: <docker config json
-
+#  landscaperNamespace: "" # namespace of installations for the default deployer (helm, manifest ...)
 
 image:
   repository: eu.gcr.io/gardener-project/landscaper/landscaper-agent

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/config/types_agent_config.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/config/types_agent_config.go
@@ -28,4 +28,10 @@ type AgentConfiguration struct {
 	// TargetSelectors defines the target selector that is applied to all installed deployers
 	// +optional
 	TargetSelectors []lsv1alpha1.TargetSelector `json:"targetSelectors,omitempty"`
+
+	// LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the
+	// deployers are stored.
+	// Defaults to ls-system
+	// +optional
+	LandscaperNamespace string `json:"landscaperNamespace,omitempty"`
 }

--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -6,7 +6,10 @@ The description follows the kubernetes controller approach:
 
 The task of a Blueprint is to provide deployitem descriptions based on its input and outputs based on the input and the state of the deployment.
 
-The rendered deployitems are then handled by independent kubernetes controllers, which perform the real deployment tasks. This way, the Blueprint does not execute deployment actions, but provides the target state of formally described deployitems. The actions described by the Blueprint itself are therefore restricted to YAML-based manifest rendering. These actions are described by [template executions](./Templating.md).
+The rendered deployitems are then handled by independent kubernetes controllers, which perform the real deployment tasks. 
+This way, the Blueprint does not execute deployment actions, but provides the target state of formally described 
+deployitems. The actions described by the Blueprint itself are therefore restricted to YAML-based manifest rendering. 
+These actions are described by [template executions](./Templating.md).
 
 A Blueprint is a filesystem structure that contains the blueprint definition at `/blueprint.yaml`. Any other additional file can be referred to in the blueprint.yaml for JSON schema definitions and templates.
 

--- a/docs/usage/Targets.md
+++ b/docs/usage/Targets.md
@@ -2,6 +2,8 @@
 
 Targets are a specific type of import and contain additional information that is interpreted by deployers.
 The concept of a Target is to define the environment where a deployer installs/deploys software.
-This means that targets could contain additional information about that environment (e.g. that the target cluster is in a fenced environment and needs to be handled by another deployer instance).
+This means that targets could contain additional information about that environment (e.g. that the target cluster is in 
+a fenced environment and needs to be handled by another deployer instance).
 
-The configuration structure of targets is defined by their type (currently the type is only for identification but later we plan to add some type registration with checks.)
+The configuration structure of targets is defined by their type (currently the type is only for identification but later 
+we plan to add some type registration with checks.)

--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -16,9 +16,9 @@ spec:
     controlPlaneConfig:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
       kind: ControlPlaneConfig
-      zone: europe-west1-c
+      zone: europe-west1-b
     workers:
-      - name: worker-l8llm
+      - name: worker-r27th
         minimum: 1
         maximum: 2
         maxSurge: 1
@@ -26,9 +26,10 @@ spec:
           type: n1-standard-2
           image:
             name: gardenlinux
-            version: 576.11.0
+            version: 576.12.0
+          architecture: amd64
         zones:
-          - europe-west1-c
+          - europe-west1-b
         cri:
           name: containerd
         volume:
@@ -41,7 +42,7 @@ spec:
   region: europe-west1
   secretBindingName: shoot-cluster-canary-sap-gcp-k8s-wm-canary
   kubernetes:
-    version: 1.24.2
+    version: 1.24.6
   purpose: evaluation
   addons:
     kubernetesDashboard:

--- a/pkg/agent/add.go
+++ b/pkg/agent/add.go
@@ -54,7 +54,7 @@ func AddToManager(ctx context.Context, logger logging.Logger, lsMgr manager.Mana
 	if _, err := agent.EnsureLandscaperResources(ctx, lsClient, hostClient); err != nil {
 		return fmt.Errorf("unable to ensure landscaper resources: %w", err)
 	}
-	if _, err := agent.EnsureHostResources(ctx, hostClient); err != nil {
+	if _, err := agent.EnsureHostResources(ctx, hostClient, lsClient); err != nil {
 		return fmt.Errorf("unable to ensure host resources: %w", err)
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -71,7 +71,7 @@ func (a *Agent) EnsureLandscaperResources(ctx context.Context, lsClient, hostCli
 		SecretRef(&lsv1alpha1.SecretReference{
 			ObjectReference: lsv1alpha1.ObjectReference{
 				Name:      a.TargetSecretName(),
-				Namespace: a.config.Namespace,
+				Namespace: a.config.LandscaperNamespace,
 			},
 			Key: lsv1alpha1.DefaultKubeconfigKey,
 		}).Build()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Agent", func() {
 				Namespace: state.Namespace,
 				Token:     "test-token",
 			})
-			_, err := ag.EnsureHostResources(ctx, testenv.Client)
+			_, err := ag.EnsureHostResources(ctx, testenv.Client, testenv.Client)
 			testutils.ExpectNoError(err)
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKey(agent.DeployerClusterRoleName, ""), &rbacv1.ClusterRole{})).To(Succeed())

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Agent", func() {
 		agConfig = &config.AgentConfiguration{}
 		agConfig.Name = "testenv"
 		agConfig.Namespace = state.Namespace
+		agConfig.LandscaperNamespace = state.Namespace
+
 		ag = agent.New(testenv.Client,
 			testenv.Env.Config,
 			api.LandscaperScheme,

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -226,7 +226,7 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 		var err error
 
 		if h.Target.Spec.SecretRef != nil {
-			kubeconfigBytes, err = lib.GetKubeconfigFromSecretRef(ctx, h.Target.Spec.SecretRef, h.lsKubeClient, h.hostKubeClient)
+			kubeconfigBytes, err = lib.GetKubeconfigFromSecretRef(ctx, h.Target.Spec.SecretRef, h.Target.Namespace, h.lsKubeClient)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -236,7 +236,7 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 				return nil, nil, nil, fmt.Errorf("unable to parse target confíguration: %w", err)
 			}
 
-			kubeconfigBytes, err = lib.GetKubeconfigFromTargetConfig(ctx, targetConfig, h.lsKubeClient, h.hostKubeClient)
+			kubeconfigBytes, err = lib.GetKubeconfigFromTargetConfig(ctx, targetConfig, h.Target.Namespace, h.lsKubeClient)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -141,7 +141,7 @@ func (m *Manifest) TargetClient(ctx context.Context) (*rest.Config, client.Clien
 		var err error
 
 		if m.Target.Spec.SecretRef != nil {
-			kubeconfigBytes, err = lib.GetKubeconfigFromSecretRef(ctx, m.Target.Spec.SecretRef, m.lsKubeClient, m.hostKubeClient)
+			kubeconfigBytes, err = lib.GetKubeconfigFromSecretRef(ctx, m.Target.Spec.SecretRef, m.Target.Namespace, m.lsKubeClient)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -151,7 +151,7 @@ func (m *Manifest) TargetClient(ctx context.Context) (*rest.Config, client.Clien
 				return nil, nil, nil, fmt.Errorf("unable to parse target confíguration: %w", err)
 			}
 
-			kubeconfigBytes, err = lib.GetKubeconfigFromTargetConfig(ctx, targetConfig, m.lsKubeClient, m.hostKubeClient)
+			kubeconfigBytes, err = lib.GetKubeconfigFromTargetConfig(ctx, targetConfig, m.Target.Namespace, m.lsKubeClient)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/deployer/manifest/misc_test.go
+++ b/pkg/deployer/manifest/misc_test.go
@@ -9,8 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -89,5 +89,60 @@ var _ = Describe("", func() {
 		cmRes := &corev1.ConfigMap{}
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(cm), cmRes)).To(Succeed())
 		Expect(cmRes.Data).To(HaveKeyWithValue("key", "val"))
+	})
+
+	It("should fail if the secret ref has another namespace than the target", func() {
+		secretNamespace := state.Namespace + "alt"
+		secretNamespaceObj := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: secretNamespace,
+			},
+		}
+		Expect(state.Create(ctx, secretNamespaceObj)).To(Succeed())
+
+		kubeconfigBytes, err := kutil.GenerateKubeconfigBytes(testenv.Env.Config)
+		Expect(err).ToNot(HaveOccurred())
+		kSecret := &corev1.Secret{}
+		kSecret.Name = "my-target"
+		kSecret.Namespace = secretNamespace
+		kSecret.Data = map[string][]byte{
+			lsv1alpha1.DefaultKubeconfigKey: kubeconfigBytes,
+		}
+		Expect(state.Create(ctx, kSecret)).To(Succeed())
+
+		target, err := utils.CreateKubernetesTargetFromSecret(state.Namespace, "my-target", kSecret)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(state.Create(ctx, target)).To(Succeed())
+
+		cm := &corev1.ConfigMap{}
+		cm.Name = "my-cm"
+		cm.Namespace = state.Namespace
+		cm.Data = map[string]string{
+			"key": "val",
+		}
+		rawCM, err := kutil.ConvertToRawExtension(cm, scheme.Scheme)
+		Expect(err).ToNot(HaveOccurred())
+
+		manifestConfig := &manifestv1alpha2.ProviderConfiguration{}
+		manifestConfig.Manifests = []managedresource.Manifest{
+			{
+				Policy:   managedresource.ManagePolicy,
+				Manifest: rawCM,
+			},
+		}
+		item, err := manifest.NewDeployItemBuilder().
+			Key(state.Namespace, "myitem").
+			ProviderConfig(manifestConfig).
+			Target(target.Namespace, target.Name).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(state.Create(ctx, item)).To(Succeed())
+
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, target)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(m.Reconcile(ctx)).NotTo(Succeed())
+
+		Expect(state.Client.Delete(ctx, secretNamespaceObj)).To(Succeed())
 	})
 })

--- a/test/integration/deployers/management/dm_tests.go
+++ b/test/integration/deployers/management/dm_tests.go
@@ -123,6 +123,7 @@ func DeployerManagementTests(f *framework.Framework) {
 				})
 				testutil.ExpectNoError(err)
 
+				ginkgo.By("Adding agent with LandscaperNamespace: " + f.LsNamespace)
 				err = agent.AddToManager(ctx, logging.Discard(), mgr, mgr, config.AgentConfiguration{
 					Name:                "testenv",
 					Namespace:           state.Namespace,

--- a/test/integration/deployers/management/dm_tests.go
+++ b/test/integration/deployers/management/dm_tests.go
@@ -124,8 +124,9 @@ func DeployerManagementTests(f *framework.Framework) {
 				testutil.ExpectNoError(err)
 
 				err = agent.AddToManager(ctx, logging.Discard(), mgr, mgr, config.AgentConfiguration{
-					Name:      "testenv",
-					Namespace: state.Namespace,
+					Name:                "testenv",
+					Namespace:           state.Namespace,
+					LandscaperNamespace: f.LsNamespace,
 				})
 				testutil.ExpectNoError(err)
 

--- a/test/integration/deployers/management/dm_tests.go
+++ b/test/integration/deployers/management/dm_tests.go
@@ -65,6 +65,11 @@ func DeployerManagementTests(f *framework.Framework) {
 		})
 
 		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentSpecReport().Failed() {
+				ginkgo.By("Do not cleanup environments (outer loop)")
+				return
+			}
+
 			defer ctx.Done()
 			drList := &lsv1alpha1.DeployerRegistrationList{}
 			testutil.ExpectNoError(f.Client.List(ctx, drList))
@@ -134,6 +139,11 @@ func DeployerManagementTests(f *framework.Framework) {
 			})
 
 			ginkgo.AfterEach(func() {
+				if ginkgo.CurrentSpecReport().Failed() {
+					ginkgo.By("Do not cleanup environments (inner loop)")
+					return
+				}
+
 				// cancel mgr context to close the manager watches.
 				cancel()
 				wg.Wait()

--- a/test/integration/deployers/register.go
+++ b/test/integration/deployers/register.go
@@ -6,19 +6,15 @@ package deployers
 
 import (
 	"github.com/gardener/landscaper/test/framework"
-	"github.com/gardener/landscaper/test/integration/deployers/blueprints"
-	"github.com/gardener/landscaper/test/integration/deployers/container"
-	"github.com/gardener/landscaper/test/integration/deployers/helmcharts"
-	"github.com/gardener/landscaper/test/integration/deployers/helmdeployer"
 	"github.com/gardener/landscaper/test/integration/deployers/management"
 )
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	ManifestDeployerTestsForNewReconcile(f)
-	helmcharts.RegisterTests(f)
-	container.ContainerTests(f)
-	blueprints.RegisterTests(f)
+	// ManifestDeployerTestsForNewReconcile(f)
+	// helmcharts.RegisterTests(f)
+	// container.ContainerTests(f)
+	// blueprints.RegisterTests(f)
 	management.RegisterTests(f)
-	helmdeployer.RegisterTests(f)
+	// helmdeployer.RegisterTests(f)
 }

--- a/test/integration/deployers/register.go
+++ b/test/integration/deployers/register.go
@@ -6,15 +6,19 @@ package deployers
 
 import (
 	"github.com/gardener/landscaper/test/framework"
+	"github.com/gardener/landscaper/test/integration/deployers/blueprints"
+	"github.com/gardener/landscaper/test/integration/deployers/container"
+	"github.com/gardener/landscaper/test/integration/deployers/helmcharts"
+	"github.com/gardener/landscaper/test/integration/deployers/helmdeployer"
 	"github.com/gardener/landscaper/test/integration/deployers/management"
 )
 
 // RegisterTests registers all tests of this package
 func RegisterTests(f *framework.Framework) {
-	// ManifestDeployerTestsForNewReconcile(f)
-	// helmcharts.RegisterTests(f)
-	// container.ContainerTests(f)
-	// blueprints.RegisterTests(f)
+	ManifestDeployerTestsForNewReconcile(f)
+	helmcharts.RegisterTests(f)
+	container.ContainerTests(f)
+	blueprints.RegisterTests(f)
 	management.RegisterTests(f)
-	// helmdeployer.RegisterTests(f)
+	helmdeployer.RegisterTests(f)
 }

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -14,19 +14,7 @@ import (
 
 	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
 	"github.com/gardener/landscaper/test/framework"
-	"github.com/gardener/landscaper/test/integration/core"
-	"github.com/gardener/landscaper/test/integration/dependencies"
 	"github.com/gardener/landscaper/test/integration/deployers"
-	"github.com/gardener/landscaper/test/integration/deployitems"
-	"github.com/gardener/landscaper/test/integration/executions"
-	"github.com/gardener/landscaper/test/integration/importexport"
-	"github.com/gardener/landscaper/test/integration/inline"
-	"github.com/gardener/landscaper/test/integration/installations"
-	"github.com/gardener/landscaper/test/integration/rootinstallations"
-	"github.com/gardener/landscaper/test/integration/subinstallations"
-	"github.com/gardener/landscaper/test/integration/targets"
-	"github.com/gardener/landscaper/test/integration/tutorial"
-	"github.com/gardener/landscaper/test/integration/webhook"
 )
 
 var opts *framework.Options
@@ -72,19 +60,19 @@ func TestConfig(t *testing.T) {
 		}
 	}
 
-	importexport.RegisterTests(f)
-	rootinstallations.RegisterTests(f)
-	subinstallations.RegisterTests(f)
-	dependencies.RegisterTests(f)
-	targets.RegisterTests(f)
-	inline.RegisterTests(f)
-	tutorial.RegisterTests(f)
-	webhook.RegisterTests(f)
-	core.RegisterTests(f)
+	//importexport.RegisterTests(f)
+	//rootinstallations.RegisterTests(f)
+	//subinstallations.RegisterTests(f)
+	//dependencies.RegisterTests(f)
+	//targets.RegisterTests(f)
+	//inline.RegisterTests(f)
+	//tutorial.RegisterTests(f)
+	//webhook.RegisterTests(f)
+	//core.RegisterTests(f)
 	deployers.RegisterTests(f)
-	deployitems.RegisterTests(f)
-	installations.RegisterTests(f)
-	executions.RegisterTests(f)
+	//deployitems.RegisterTests(f)
+	//installations.RegisterTests(f)
+	//executions.RegisterTests(f)
 
 	AfterSuite(func() {
 		f.Log().Logfln("\nStart after suite cleanup")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -9,6 +9,19 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/gardener/landscaper/test/integration/core"
+	"github.com/gardener/landscaper/test/integration/dependencies"
+	"github.com/gardener/landscaper/test/integration/deployitems"
+	"github.com/gardener/landscaper/test/integration/executions"
+	"github.com/gardener/landscaper/test/integration/importexport"
+	"github.com/gardener/landscaper/test/integration/inline"
+	"github.com/gardener/landscaper/test/integration/installations"
+	"github.com/gardener/landscaper/test/integration/rootinstallations"
+	"github.com/gardener/landscaper/test/integration/subinstallations"
+	"github.com/gardener/landscaper/test/integration/targets"
+	"github.com/gardener/landscaper/test/integration/tutorial"
+	"github.com/gardener/landscaper/test/integration/webhook"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -60,19 +73,19 @@ func TestConfig(t *testing.T) {
 		}
 	}
 
-	//importexport.RegisterTests(f)
-	//rootinstallations.RegisterTests(f)
-	//subinstallations.RegisterTests(f)
-	//dependencies.RegisterTests(f)
-	//targets.RegisterTests(f)
-	//inline.RegisterTests(f)
-	//tutorial.RegisterTests(f)
-	//webhook.RegisterTests(f)
-	//core.RegisterTests(f)
+	importexport.RegisterTests(f)
+	rootinstallations.RegisterTests(f)
+	subinstallations.RegisterTests(f)
+	dependencies.RegisterTests(f)
+	targets.RegisterTests(f)
+	inline.RegisterTests(f)
+	tutorial.RegisterTests(f)
+	webhook.RegisterTests(f)
+	core.RegisterTests(f)
 	deployers.RegisterTests(f)
-	//deployitems.RegisterTests(f)
-	//installations.RegisterTests(f)
-	//executions.RegisterTests(f)
+	deployitems.RegisterTests(f)
+	installations.RegisterTests(f)
+	executions.RegisterTests(f)
 
 	AfterSuite(func() {
 		f.Log().Logfln("\nStart after suite cleanup")

--- a/vendor/github.com/gardener/landscaper/apis/config/types_agent_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/types_agent_config.go
@@ -28,4 +28,10 @@ type AgentConfiguration struct {
 	// TargetSelectors defines the target selector that is applied to all installed deployers
 	// +optional
 	TargetSelectors []lsv1alpha1.TargetSelector `json:"targetSelectors,omitempty"`
+
+	// LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the
+	// deployers are stored.
+	// Defaults to ls-system
+	// +optional
+	LandscaperNamespace string `json:"landscaperNamespace,omitempty"`
 }

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
@@ -71,6 +71,9 @@ func SetDefaults_LandscaperConfiguration(obj *LandscaperConfiguration) {
 	if len(obj.DeployerManagement.Agent.Namespace) == 0 {
 		obj.DeployerManagement.Agent.Namespace = obj.DeployerManagement.Namespace
 	}
+	if len(obj.DeployerManagement.Agent.LandscaperNamespace) == 0 {
+		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Namespace
+	}
 	if obj.DeployerManagement.Agent.OCI == nil {
 		obj.DeployerManagement.Agent.OCI = obj.Registry.OCI
 	}
@@ -107,6 +110,9 @@ func SetDefaults_CommonControllerConfig(obj *CommonControllerConfig) {
 func SetDefaults_AgentConfiguration(obj *AgentConfiguration) {
 	if len(obj.Namespace) == 0 {
 		obj.Namespace = "ls-system"
+	}
+	if len(obj.LandscaperNamespace) == 0 {
+		obj.LandscaperNamespace = "ls-system"
 	}
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_agent_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_agent_config.go
@@ -28,4 +28,10 @@ type AgentConfiguration struct {
 	// TargetSelectors defines the target selector that is applied to all installed deployers
 	// +optional
 	TargetSelectors []lsv1alpha1.TargetSelector `json:"targetSelectors,omitempty"`
+
+	// LandscaperNamespace is the namespace in the landscaper cluster where the installations and target for the
+	// deployers are stored.
+	// Defaults to ls-system
+	// +optional
+	LandscaperNamespace string `json:"landscaperNamespace,omitempty"`
 }

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/zz_generated.conversion.go
@@ -268,6 +268,7 @@ func autoConvert_v1alpha1_AgentConfiguration_To_config_AgentConfiguration(in *Ag
 	out.Namespace = in.Namespace
 	out.OCI = (*config.OCIConfiguration)(unsafe.Pointer(in.OCI))
 	out.TargetSelectors = *(*[]corev1alpha1.TargetSelector)(unsafe.Pointer(&in.TargetSelectors))
+	out.LandscaperNamespace = in.LandscaperNamespace
 	return nil
 }
 
@@ -281,6 +282,7 @@ func autoConvert_config_AgentConfiguration_To_v1alpha1_AgentConfiguration(in *co
 	out.Namespace = in.Namespace
 	out.OCI = (*OCIConfiguration)(unsafe.Pointer(in.OCI))
 	out.TargetSelectors = *(*[]corev1alpha1.TargetSelector)(unsafe.Pointer(&in.TargetSelectors))
+	out.LandscaperNamespace = in.LandscaperNamespace
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Move the secret to deploy deployer from host to landscaper cluster

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- Move the secret to deploy deployer from host to landscaper cluster
```
