### PR TITLE
Handling of unfinished subobjects

### DIFF
--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -152,6 +152,8 @@ const (
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
+	// ErrorUnfinished indicates that there are unfinished sub-objects.
+	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
 )
 
 // Condition holds the information about the state of a resource.

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -159,6 +159,8 @@ const (
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
+	// ErrorUnfinished indicates that there are unfinished sub-objects.
+	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -152,6 +152,8 @@ const (
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
+	// ErrorUnfinished indicates that there are unfinished sub-objects.
+	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
 )
 
 // Condition holds the information about the state of a resource.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -159,6 +159,8 @@ const (
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
+	// ErrorUnfinished indicates that there are unfinished sub-objects.
+	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	lsutil "github.com/gardener/landscaper/pkg/utils"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +24,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/landscaper/execution"
 	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	lsutil "github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
@@ -308,7 +307,7 @@ func (c *controller) setExecutionPhaseAndUpdate(ctx context.Context, exec *lsv1a
 
 	exec.Status.LastError = lserrors.TryUpdateLsError(exec.Status.LastError, lsErr)
 
-	if lsErr != nil {
+	if lsErr != nil && !lserrors.ContainsErrorCode(lsErr, lsv1alpha1.ErrorUnfinished) {
 		logger.Error(lsErr, "setExecutionPhaseAndUpdate")
 	}
 

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -133,7 +133,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecPhaseFailed, err, read_write_layer.W000135)
 		} else if !deployItemClassification.AllSucceeded() {
 			// remain in progressing in all other cases
-			err = lserrors.NewError(op, "handlePhaseProgressing", "some running items")
+			err = lserrors.NewError(op, "handlePhaseProgressing", "some running items", lsv1alpha1.ErrorUnfinished)
 			return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000136)
 		} else {
 			// all succeeded; go to next phase

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -8,13 +8,8 @@ import (
 	"context"
 	"fmt"
 
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
-
-	"github.com/gardener/landscaper/pkg/landscaper/installations/executions"
-
-	"github.com/google/uuid"
-
 	"github.com/gardener/component-cli/ociclient/cache"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,22 +18,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	lserrors "github.com/gardener/landscaper/apis/errors"
-
-	"github.com/gardener/landscaper/pkg/utils"
-
-	"github.com/gardener/landscaper/pkg/api"
-	"github.com/gardener/landscaper/pkg/landscaper/registry/componentoverwrites"
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
-
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	lserrors "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions"
 	"github.com/gardener/landscaper/pkg/landscaper/operation"
+	"github.com/gardener/landscaper/pkg/landscaper/registry/componentoverwrites"
+	"github.com/gardener/landscaper/pkg/utils"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
 const (
@@ -259,7 +253,7 @@ func (c *Controller) setInstallationPhaseAndUpdate(ctx context.Context, inst *ls
 
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String()})
 
-	if lsError != nil {
+	if lsError != nil && !lserrors.ContainsErrorCode(lsError, lsv1alpha1.ErrorUnfinished) {
 		logger.Error(lsError, "setInstallationPhaseAndUpdate:"+lsError.Error())
 	}
 

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -403,7 +403,7 @@ func (c *Controller) handlePhaseProgressing(ctx context.Context, inst *lsv1alpha
 		if next.Status.JobIDFinished != next.Status.JobID {
 			// Hack: being unfinished should not be treated as an error
 			message := fmt.Sprintf("installation %s / %s is not finished yet", next.Namespace, next.Name)
-			return false, lserrors.NewError(currentOperation, "JobIDFinished", message)
+			return false, lserrors.NewError(currentOperation, "JobIDFinished", message, lsv1alpha1.ErrorUnfinished)
 		}
 
 		allSucceeded = allSucceeded && (next.Status.InstallationPhase == lsv1alpha1.InstallationPhaseSucceeded)
@@ -418,7 +418,7 @@ func (c *Controller) handlePhaseProgressing(ctx context.Context, inst *lsv1alpha
 
 		if exec.Status.JobIDFinished != exec.Status.JobID {
 			message := fmt.Sprintf("execution %s / %s is not finished yet", exec.Namespace, exec.Name)
-			return false, lserrors.NewError(currentOperation, "JobIDFinished", message)
+			return false, lserrors.NewError(currentOperation, "JobIDFinished", message, lsv1alpha1.ErrorUnfinished)
 		}
 
 		allSucceeded = allSucceeded && (exec.Status.ExecutionPhase == lsv1alpha1.ExecPhaseSucceeded)

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -152,6 +152,8 @@ const (
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
+	// ErrorUnfinished indicates that there are unfinished sub-objects.
+	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
 )
 
 // Condition holds the information about the state of a resource.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -159,6 +159,8 @@ const (
 	ErrorCyclicDependencies ErrorCode = "ERR_CYCLIC_DEPENDENCIES"
 	// ErrorWebhook indicates that there is an intermediate problem with the webhook.
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
+	// ErrorUnfinished indicates that there are unfinished sub-objects.
+	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request reduces the number of error log entries that are written when an Installation or Execution waits for its subobjects to finished.

Note that the current approach cannot avoid the error logs that are written by the controller runtime after a reconcile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
