### PR TITLE
add message to '.Error()' output for LsError

### DIFF
--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -31,7 +32,15 @@ type Error struct {
 // Error implements the error interface
 func (e Error) Error() string {
 	if e.err != nil {
-		return e.err.Error()
+		internalErr := e.err.Error()
+		if len(e.lsErr.Message) > 0 {
+			if !strings.HasSuffix(e.lsErr.Message, internalErr) {
+				// if the developer has not already included the original error in the message, let's add it
+				return fmt.Sprintf("%s: %s", e.lsErr.Message, internalErr)
+			}
+			return e.lsErr.Message
+		}
+		return internalErr
 	}
 	return fmt.Sprintf("Op: %s - Reason: %s - Message: %s", e.lsErr.Operation, e.lsErr.Reason, e.lsErr.Message)
 }

--- a/apis/errors/error.go
+++ b/apis/errors/error.go
@@ -31,18 +31,19 @@ type Error struct {
 
 // Error implements the error interface
 func (e Error) Error() string {
+	message := e.lsErr.Message
 	if e.err != nil {
 		internalErr := e.err.Error()
 		if len(e.lsErr.Message) > 0 {
 			if !strings.HasSuffix(e.lsErr.Message, internalErr) {
 				// if the developer has not already included the original error in the message, let's add it
-				return fmt.Sprintf("%s: %s", e.lsErr.Message, internalErr)
+				message = fmt.Sprintf("%s: %s", e.lsErr.Message, internalErr)
 			}
-			return e.lsErr.Message
+		} else {
+			message = internalErr
 		}
-		return internalErr
 	}
-	return fmt.Sprintf("Op: %s - Reason: %s - Message: %s", e.lsErr.Operation, e.lsErr.Reason, e.lsErr.Message)
+	return fmt.Sprintf("Op: %s - Reason: %s - Message: %s", e.lsErr.Operation, e.lsErr.Reason, message)
 }
 
 // LandscaperError returns the wrapped landscaper error.

--- a/vendor/github.com/gardener/landscaper/apis/errors/error.go
+++ b/vendor/github.com/gardener/landscaper/apis/errors/error.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -31,7 +32,15 @@ type Error struct {
 // Error implements the error interface
 func (e Error) Error() string {
 	if e.err != nil {
-		return e.err.Error()
+		internalErr := e.err.Error()
+		if len(e.lsErr.Message) > 0 {
+			if !strings.HasSuffix(e.lsErr.Message, internalErr) {
+				// if the developer has not already included the original error in the message, let's add it
+				return fmt.Sprintf("%s: %s", e.lsErr.Message, internalErr)
+			}
+			return e.lsErr.Message
+		}
+		return internalErr
 	}
 	return fmt.Sprintf("Op: %s - Reason: %s - Message: %s", e.lsErr.Operation, e.lsErr.Reason, e.lsErr.Message)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

**What this PR does / why we need it**:
When wrapping an `error` in an object of type `LsError`, a message can be specified. Calling `.Error()` on the LsError object returns only the original error message, though. If this LsError object is then again wrapped, neither `.Message`, nor `.Error()` called on the new object will return the message specified during the first wrapping. This results in a loss of potentially interesting information.

To fix this, the `.Error()` implementation of LsError has been enhanced in the `LsError` type: Instead of just returning `.Error()` of the internal `error`, it will now return a combination of `.Message` and `.Error()`. It also checks if former one already contains the latter one, to avoid duplicate errors.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Calling `.Error()` on a `LsError` object will now return a combination of the LsError's message and its internal error, instead of just returning the internal error's message.
```
