### PR TITLE
add new manifest deployer update strategies

### DIFF
--- a/apis/deployer/manifest/types_provider.go
+++ b/apis/deployer/manifest/types_provider.go
@@ -47,8 +47,10 @@ type ProviderConfiguration struct {
 type UpdateStrategy string
 
 const (
-	UpdateStrategyUpdate UpdateStrategy = "update"
-	UpdateStrategyPatch  UpdateStrategy = "patch"
+	UpdateStrategyUpdate         UpdateStrategy = "update"
+	UpdateStrategyPatch          UpdateStrategy = "patch"
+	UpdateStrategyMerge          UpdateStrategy = "merge"
+	UpdateStrategyMergeOverwrite UpdateStrategy = "mergeOverwrite"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/apis/deployer/manifest/v1alpha2/types_provider.go
+++ b/apis/deployer/manifest/v1alpha2/types_provider.go
@@ -47,8 +47,10 @@ type ProviderConfiguration struct {
 type UpdateStrategy string
 
 const (
-	UpdateStrategyUpdate UpdateStrategy = "update"
-	UpdateStrategyPatch  UpdateStrategy = "patch"
+	UpdateStrategyUpdate         UpdateStrategy = "update"
+	UpdateStrategyPatch          UpdateStrategy = "patch"
+	UpdateStrategyMerge          UpdateStrategy = "merge"
+	UpdateStrategyMergeOverwrite UpdateStrategy = "mergeOverwrite"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -30,7 +30,7 @@ spec:
     apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
-    updateStrategy: update | patch # optional; defaults to update
+    updateStrategy: update | patch | merge | mergeOverwrite # optional; defaults to update
 
     # Configuration of the readiness checks for the resources.
     # optional
@@ -132,6 +132,12 @@ spec:
           kind: Secret
           jsonPath: ".data.somekey" # points to the value in the resource that is being exported
 ```
+__Update Strategy__:
+
+- `update`: ...
+- `patch`: ...
+- `merge`: ...
+- `mergeOverwrite`: ...
 
 __Policy__:
 

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -134,10 +134,12 @@ spec:
 ```
 __Update Strategy__:
 
-- `update`: ...
-- `patch`: ...
-- `merge`: ...
-- `mergeOverwrite`: ...
+The update strategy defines the behavior of the manifest deployer when a resource for a rendered manifest already exists on the target cluster.
+
+- `update`: The resources on the cluster will be updated with the results of the rendered manifests (default). Any changes to the resources, applied externally on the cluster, may be lost after the update.
+- `patch`: The manifest deployer will calculate a JSON diff between the resources on the cluster and the rendered manifests. The diff will be applied as a patch. Any changes to the resources, applied externally on the cluster, may be lost after the update.
+- `merge`: The manifest deployer will merge the results of the rendered manifests into the resources on the cluster. Fields that already exist in the resources on the cluster, will not be overwritten.
+- `mergeOverwrite`: The manifest deployer will merge the results of the rendered manifests into the resources on the cluster. Fields that already exist in the resources on the cluster, will be overwritten when the rendered field is not empty.
 
 __Policy__:
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/imdario/mergo v0.3.12
 	github.com/mandelsoft/spiff v1.5.0
 	github.com/mandelsoft/vfs v0.0.0-20210530103237-5249dc39ce91
 	github.com/onsi/ginkgo v1.16.5
@@ -94,7 +95,6 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/deployer/lib/resourcemanager/objectapplier.go
+++ b/pkg/deployer/lib/resourcemanager/objectapplier.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/imdario/mergo"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/imdario/mergo"
 
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/types_provider.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/types_provider.go
@@ -47,8 +47,10 @@ type ProviderConfiguration struct {
 type UpdateStrategy string
 
 const (
-	UpdateStrategyUpdate UpdateStrategy = "update"
-	UpdateStrategyPatch  UpdateStrategy = "patch"
+	UpdateStrategyUpdate         UpdateStrategy = "update"
+	UpdateStrategyPatch          UpdateStrategy = "patch"
+	UpdateStrategyMerge          UpdateStrategy = "merge"
+	UpdateStrategyMergeOverwrite UpdateStrategy = "mergeOverwrite"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2/types_provider.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2/types_provider.go
@@ -47,8 +47,10 @@ type ProviderConfiguration struct {
 type UpdateStrategy string
 
 const (
-	UpdateStrategyUpdate UpdateStrategy = "update"
-	UpdateStrategyPatch  UpdateStrategy = "patch"
+	UpdateStrategyUpdate         UpdateStrategy = "update"
+	UpdateStrategyPatch          UpdateStrategy = "patch"
+	UpdateStrategyMerge          UpdateStrategy = "merge"
+	UpdateStrategyMergeOverwrite UpdateStrategy = "mergeOverwrite"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area manifest-deployer
/kind enhancement
/priority 3

**What this PR does / why we need it**:

The previously available manifest deployer update strategies `update` and `patch` were not sufficient for resources that are being modified by a kubernetes controller after being created (like Gardener Shoots). The available strategies would always overwrite these modfications.

This PR introduces two new update strategies to accomodate the use case scenarios:

* `merge`: The manifest deployer will merge the results of the rendered manifests into the resources on the cluster. Fields that already exist in the resources on the cluster, will not be overwritten.
* `mergeOverwrite`: The manifest deployer will merge the results of the rendered manifests into the resources on the cluster. Fields that already exist in the resources on the cluster, will be overwritten when the rendered field is not empty.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add manifest deployer update strategies "merge" and "mergeOverwrite".
```
