### PR TITLE
make integration tests more robust (run-int-tests)

### DIFF
--- a/test/integration/rootinstallations/rootinstallations.go
+++ b/test/integration/rootinstallations/rootinstallations.go
@@ -60,14 +60,10 @@ func RootInstallationTests(f *framework.Framework) {
 			utils.ExpectNoError(utils.CreateInstallationFromFile(ctx, state.State, inst2, path.Join(testdataDir, "installation-root-trigger", "installation-2.yaml")))
 
 			By("Trigger 1st root installation")
-			instOld1 := &lsv1alpha1.Installation{}
-			utils.ExpectNoError(f.Client.Get(ctx, client.ObjectKeyFromObject(inst1), instOld1))
-			inst1 = &lsv1alpha1.Installation{}
-			utils.ExpectNoError(utils.ReadResourceFromFile(inst1, path.Join(testdataDir, "installation-root-trigger", "installation-1.yaml")))
-			utils.SetInstallationNamespace(inst1, state.Namespace)
+			utils.ExpectNoError(f.Client.Get(ctx, client.ObjectKeyFromObject(inst1), inst1))
+			instOld1 := inst1.DeepCopy()
 			metav1.SetMetaDataAnnotation(&inst1.ObjectMeta, lsv1alpha1.OperationAnnotation, string(lsv1alpha1.ReconcileOperation))
-			inst1.ObjectMeta.ResourceVersion = instOld1.ObjectMeta.ResourceVersion
-			utils.ExpectNoError(state.Update(ctx, inst1))
+			utils.ExpectNoError(state.Client.Patch(ctx, inst1, client.MergeFrom(instOld1)))
 
 			By("Wait for 1st installation to finish")
 			utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst1, lsv1alpha1.InstallationPhaseSucceeded, 2*time.Minute))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 2

**What this PR does / why we need it**:
Fixes an integration test which often fails.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
