### PR TITLE
fix the continuous custom readiness check

### DIFF
--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -77,14 +77,14 @@ func (c *CustomReadinessCheck) CheckObject(u *unstructured.Unstructured) error {
 
 		if fieldDoesNotExist(fields) {
 			if requirement.Operator == selection.DoesNotExist {
-				return nil
+				continue
 			}
-			return lserror.NewError(c.CurrentOp, "object check", fmt.Sprintf("field with JSON path %s does not exist", requirement.JsonPath))
+			return NewObjectNotReadyError(u, lserror.NewError(c.CurrentOp, "object check", fmt.Sprintf("field with JSON path %s does not exist", requirement.JsonPath)))
 		}
 
 		if requirement.Operator == selection.Exists {
 			// field exists and that is all we need to know for selection.Exists
-			return nil
+			continue
 		}
 
 		requirementValues, err := parseRequirementValues(requirement.Value)
@@ -100,11 +100,8 @@ func (c *CustomReadinessCheck) CheckObject(u *unstructured.Unstructured) error {
 				}
 
 				if !ok {
-					return lserror.NewError(c.CurrentOp, "check object values",
-						fmt.Sprintf("resource %s %s/%s does not fulfil resource condition field %s", u.GroupVersionKind().String(),
-							u.GetName(),
-							u.GetNamespace(),
-							requirement.JsonPath))
+					return NewObjectNotReadyError(u, lserror.NewError(c.CurrentOp, "check object values",
+						fmt.Sprintf("resource requirement is not fulfiled for field %s", requirement.JsonPath)))
 				}
 			}
 		}

--- a/pkg/deployer/lib/readinesscheck/testdata/04-configmap.yaml
+++ b/pkg/deployer/lib/readinesscheck/testdata/04-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+data:
+  mykey: myval


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

The custom readiness check was not continously check for the readiness requirements to be fulfilled until the timeout was exceeded.
Instead the readiness check was aborted once the first requirement was not fulfilled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix the custom readiness check for the Helm and Manifest deployers to wait for all contitions to be fulfilled until the timeout is exceeded.
```
