### PR TITLE
Test reconcile annotation

### DIFF
--- a/apis/config/v1alpha1/defaults.go
+++ b/apis/config/v1alpha1/defaults.go
@@ -71,7 +71,7 @@ func SetDefaults_LandscaperConfiguration(obj *LandscaperConfiguration) {
 		obj.DeployerManagement.Agent.Namespace = obj.DeployerManagement.Namespace
 	}
 	if len(obj.DeployerManagement.Agent.LandscaperNamespace) == 0 {
-		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Agent.Namespace
+		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Namespace
 	}
 	if obj.DeployerManagement.Agent.OCI == nil {
 		obj.DeployerManagement.Agent.OCI = obj.Registry.OCI

--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -195,14 +195,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
-	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
-	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
-	// (e.g. no predecessor is running).
-	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
+	// ReconcileOperation is an annotation for the landscaper to reconcile root installations.
+	// If set it triggers a reconciliation for all dependent resources.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation is an annotation for the landscaper to force the reconcile of  to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is currently not used.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.
@@ -212,6 +209,10 @@ const (
 	// installation and its subinstallations. It differs from abort by not waiting some time such that the responsible
 	// deployer could do some cleanup.
 	InterruptOperation Operation = "interrupt"
+
+	// TestReconcileOperation is only used for test purposes. If set at a DeployItem, it triggers a reconciliation
+	// of that DeployItem. It must not be used in a productive scenario.
+	TestReconcileOperation Operation = "test-reconcile"
 )
 
 // ObjectReference is the reference to a kubernetes object.

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -211,14 +211,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
-	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
-	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
-	// (e.g. no predecessor is running).
-	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
+	// ReconcileOperation is an annotation for the landscaper to reconcile root installations.
+	// If set it triggers a reconciliation for all dependent resources.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is currently not used.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.
@@ -228,6 +225,10 @@ const (
 	// installation and its subinstallations. It differs from abort by not waiting some time such that the responsible
 	// deployer could do some cleanup.
 	InterruptOperation Operation = "interrupt"
+
+	// TestReconcileOperation is only used for test purposes. If set at a DeployItem, it triggers a reconciliation
+	// of that DeployItem. It must not be used in a productive scenario.
+	TestReconcileOperation Operation = "test-reconcile"
 )
 
 // ObjectReference is the reference to a kubernetes object.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -195,14 +195,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
-	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
-	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
-	// (e.g. no predecessor is running).
-	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
+	// ReconcileOperation is an annotation for the landscaper to reconcile root installations.
+	// If set it triggers a reconciliation for all dependent resources.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation is an annotation for the landscaper to force the reconcile of  to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is currently not used.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.
@@ -212,6 +209,10 @@ const (
 	// installation and its subinstallations. It differs from abort by not waiting some time such that the responsible
 	// deployer could do some cleanup.
 	InterruptOperation Operation = "interrupt"
+
+	// TestReconcileOperation is only used for test purposes. If set at a DeployItem, it triggers a reconciliation
+	// of that DeployItem. It must not be used in a productive scenario.
+	TestReconcileOperation Operation = "test-reconcile"
 )
 
 // ObjectReference is the reference to a kubernetes object.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -211,14 +211,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
-	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
-	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
-	// (e.g. no predecessor is running).
-	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
+	// ReconcileOperation is an annotation for the landscaper to reconcile root installations.
+	// If set it triggers a reconciliation for all dependent resources.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is currently not used.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.
@@ -228,6 +225,10 @@ const (
 	// installation and its subinstallations. It differs from abort by not waiting some time such that the responsible
 	// deployer could do some cleanup.
 	InterruptOperation Operation = "interrupt"
+
+	// TestReconcileOperation is only used for test purposes. If set at a DeployItem, it triggers a reconciliation
+	// of that DeployItem. It must not be used in a productive scenario.
+	TestReconcileOperation Operation = "test-reconcile"
 )
 
 // ObjectReference is the reference to a kubernetes object.

--- a/docs/usage/Annotations.md
+++ b/docs/usage/Annotations.md
@@ -48,6 +48,16 @@ Afterwards the annotation is removed from the execution.
 
 Setting this annotation at a deploy item has no effect.
 
+## Test Reconcile Annotation
+
+**Annotation:** `landscaper.gardener.cloud/operation: test-reconcile`
+
+With this annotation the processing of a deploy item could be started. This annotation must be used only in test
+scenarios because it breaks the overall logic of the processing of installations and their sub-installations, executions
+and deploy items.
+
+This annotation has no effect at installations and executions.
+
 ## Delete-Without-Uninstall Annotation
 
 **Annotation:** `landscaper.gardener.cloud/delete-without-uninstall: true`
@@ -60,3 +70,5 @@ afterwards a deletion of the installation has the following effect:
   deploy items such that they could be deleted.
 
 Note that you have to add the annotation **before** you delete the installation.
+
+

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -188,7 +188,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 
-		logger.Error(nil, "generating a new jobID, because of a test-reconcile annotation")
+		logger.Info("generating a new jobID, because of a test-reconcile annotation")
 		di.Status.JobID = uuid.New().String()
 		if err := c.Writer().UpdateDeployItemStatus(ctx, read_write_layer.W000148, di); err != nil {
 			return reconcile.Result{}, err
@@ -313,7 +313,7 @@ func (c *controller) updateDiForNewReconcile(ctx context.Context, di *lsv1alpha1
 func (c *controller) removeTestReconcileAnnotation(ctx context.Context, di *lsv1alpha1.DeployItem) lserrors.LsError {
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(di).String()})
 
-	logger.Error(nil, "remove test-reconcile annotation: this is only an error if this happens on a productive system")
+	logger.Info("remove test-reconcile annotation")
 	delete(di.Annotations, lsv1alpha1.OperationAnnotation)
 	if err := c.Writer().UpdateDeployItem(ctx, read_write_layer.W000149, di); client.IgnoreNotFound(err) != nil {
 		return lserrors.NewWrappedError(err, "RemoveTestReconcileAnnotation", "UpdateDeployItem", err.Error())

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -312,7 +312,7 @@ func (c *controller) updateDiForNewReconcile(ctx context.Context, di *lsv1alpha1
 func (c *controller) removeTestReconcileAnnotation(ctx context.Context, di *lsv1alpha1.DeployItem) lserrors.LsError {
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(di).String()})
 
-	logger.Error(nil, "remove test-reconcile annotation")
+	logger.Error(nil, "remove test-reconcile annotation: this is only an error if this happens on a productive system")
 	delete(di.Annotations, lsv1alpha1.OperationAnnotation)
 	if err := c.Writer().UpdateDeployItem(ctx, read_write_layer.W000149, di); client.IgnoreNotFound(err) != nil {
 		return lserrors.NewWrappedError(err, "RemoveTestReconcileAnnotation", "UpdateDeployItem", err.Error())

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	lsutil "github.com/gardener/landscaper/pkg/utils"
 
 	"github.com/go-logr/logr"
@@ -180,6 +182,20 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, fmt.Errorf("unable to get landscaper context: %w", err)
 	}
 
+	if lsv1alpha1helper.HasOperation(di.ObjectMeta, lsv1alpha1.TestReconcileOperation) {
+
+		if err := c.removeTestReconcileAnnotation(ctx, di); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		di.Status.JobID = uuid.New().String()
+		if err := c.Writer().UpdateDeployItemStatus(ctx, read_write_layer.W000148, di); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
 	if di.Status.GetJobID() != di.Status.JobIDFinished {
 		if di.Status.DeployItemPhase == lsv1alpha1.DeployItemPhaseSucceeded ||
 			di.Status.DeployItemPhase == lsv1alpha1.DeployItemPhaseFailed ||
@@ -287,6 +303,18 @@ func (c *controller) updateDiForNewReconcile(ctx context.Context, di *lsv1alpha1
 
 	if err := c.Writer().UpdateDeployItemStatus(ctx, read_write_layer.W000004, di); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (c *controller) removeTestReconcileAnnotation(ctx context.Context, di *lsv1alpha1.DeployItem) lserrors.LsError {
+	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(di).String()})
+
+	logger.Error(nil, "remove test-reconcile annotation")
+	delete(di.Annotations, lsv1alpha1.OperationAnnotation)
+	if err := c.Writer().UpdateDeployItem(ctx, read_write_layer.W000149, di); client.IgnoreNotFound(err) != nil {
+		return lserrors.NewWrappedError(err, "RemoveTestReconcileAnnotation", "UpdateDeployItem", err.Error())
 	}
 
 	return nil

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -188,6 +188,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 
+		logger.Error(nil, "generating a new jobID, because of a test-reconcile annotation")
 		di.Status.JobID = uuid.New().String()
 		if err := c.Writer().UpdateDeployItemStatus(ctx, read_write_layer.W000148, di); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -222,6 +222,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		return reconcile.Result{}, c.handleReconcileResult(ctx, err, old, di)
 	} else {
+		logger.Info("deploy item not reconciled because no new job ID")
 		return reconcile.Result{}, nil
 	}
 }

--- a/pkg/landscaper/execution/helper.go
+++ b/pkg/landscaper/execution/helper.go
@@ -21,7 +21,6 @@ import (
 // ApplyDeployItemTemplate sets and updates the values defined by deploy item template on a deploy item.
 func ApplyDeployItemTemplate(di *lsv1alpha1.DeployItem, tmpl lsv1alpha1.DeployItemTemplate) {
 	lsv1alpha1helper.RemoveAbortOperationAndTimestamp(&di.ObjectMeta)
-	lsv1alpha1helper.SetOperation(&di.ObjectMeta, lsv1alpha1.ReconcileOperation)
 	lsv1alpha1helper.SetTimestampAnnotationNow(&di.ObjectMeta, lsv1alpha1helper.ReconcileTimestamp)
 	di.Spec.Type = tmpl.Type
 	di.Spec.Target = tmpl.Target

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/defaults.go
@@ -71,7 +71,7 @@ func SetDefaults_LandscaperConfiguration(obj *LandscaperConfiguration) {
 		obj.DeployerManagement.Agent.Namespace = obj.DeployerManagement.Namespace
 	}
 	if len(obj.DeployerManagement.Agent.LandscaperNamespace) == 0 {
-		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Agent.Namespace
+		obj.DeployerManagement.Agent.LandscaperNamespace = obj.DeployerManagement.Namespace
 	}
 	if obj.DeployerManagement.Agent.OCI == nil {
 		obj.DeployerManagement.Agent.OCI = obj.Registry.OCI

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -195,14 +195,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
-	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
-	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
-	// (e.g. no predecessor is running).
-	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
+	// ReconcileOperation is an annotation for the landscaper to reconcile root installations.
+	// If set it triggers a reconciliation for all dependent resources.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation is an annotation for the landscaper to force the reconcile of  to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is currently not used.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.
@@ -212,6 +209,10 @@ const (
 	// installation and its subinstallations. It differs from abort by not waiting some time such that the responsible
 	// deployer could do some cleanup.
 	InterruptOperation Operation = "interrupt"
+
+	// TestReconcileOperation is only used for test purposes. If set at a DeployItem, it triggers a reconciliation
+	// of that DeployItem. It must not be used in a productive scenario.
+	TestReconcileOperation Operation = "test-reconcile"
 )
 
 // ObjectReference is the reference to a kubernetes object.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -211,14 +211,11 @@ type Error struct {
 type Operation string
 
 const (
-	// ReconcileOperation is an annotation for the landscaper to reconcile resources (installations, subinstallations,
-	// executions, deploy items). If set at an installations/execution it triggers a reconcile for all dependent
-	// resources for which something has changed (spec or imports) or which are in a failed state with a save strategy
-	// (e.g. no predecessor is running).
-	// If set at a deploy item it triggers a reconcile even if nothing has changed or the phase is not failed.
+	// ReconcileOperation is an annotation for the landscaper to reconcile root installations.
+	// If set it triggers a reconciliation for all dependent resources.
 	ReconcileOperation Operation = "reconcile"
 
-	// ForceReconcileOperation forces the landscaper to not wait for children (executions nor subinstallations) to be completed.
+	// ForceReconcileOperation is currently not used.
 	ForceReconcileOperation Operation = "force-reconcile"
 
 	// AbortOperation is the annotation to let the landscaper abort all currently running children and itself.
@@ -228,6 +225,10 @@ const (
 	// installation and its subinstallations. It differs from abort by not waiting some time such that the responsible
 	// deployer could do some cleanup.
 	InterruptOperation Operation = "interrupt"
+
+	// TestReconcileOperation is only used for test purposes. If set at a DeployItem, it triggers a reconciliation
+	// of that DeployItem. It must not be used in a productive scenario.
+	TestReconcileOperation Operation = "test-reconcile"
 )
 
 // ObjectReference is the reference to a kubernetes object.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority 3

**What this PR does / why we need it**:

This pull request introduces the following annotation for DeployItems:

```yaml
metadata:
  annotations:
    landscaper.gardener.cloud/operation: test-reconcile
```

 If the annotation is set, the DeployItem will get a new `jobID` so that it will be reconciled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
