### PR TITLE
Handle Failed Deletion of Subinstallations

### DIFF
--- a/pkg/landscaper/controllers/deployitem/reconcile.go
+++ b/pkg/landscaper/controllers/deployitem/reconcile.go
@@ -170,8 +170,6 @@ func (con *controller) writeAbortingTimeoutExceeded(ctx context.Context, di *lsv
 	logger = logger.WithValues(lc.KeyMethod, "writeAbortingTimeoutExceeded")
 	logger.Info("aborting timeout occurred")
 
-	lsv1alpha1helper.RemoveAbortOperationAndTimestamp(&di.ObjectMeta)
-
 	di.Status.DeployItemPhase = lsv1alpha1.DeployItemPhaseFailed
 	di.Status.JobIDFinished = di.Status.GetJobID()
 	di.Status.Phase = lsv1alpha1.ExecutionPhaseFailed
@@ -186,11 +184,6 @@ func (con *controller) writeAbortingTimeoutExceeded(ctx context.Context, di *lsv
 	if err := con.Writer().UpdateDeployItemStatus(ctx, read_write_layer.W000111, di); err != nil {
 		// we might need to expose this as event on the deploy item
 		logger.Error(err, "unable to set deployitem status")
-		return err
-	}
-
-	if err := con.Writer().UpdateDeployItem(ctx, read_write_layer.W000109, di); err != nil {
-		logger.Error(err, "unable to update deploy item")
 		return err
 	}
 

--- a/pkg/landscaper/controllers/execution/testdata/test3/00-execution.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test3/00-execution.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: exec-1
+  namespace:  {{ .Namespace }}
+  generation: 2
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  deployItems:
+    - name: a
+      type: landscaper.gardener.cloud/helm
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+
+status:
+  phase: Failed
+  jobID: job2
+  jobIDFinished: job1

--- a/pkg/landscaper/controllers/execution/testdata/test3/10-deploy-item.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test3/10-deploy-item.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-a
+  namespace:  {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/abort-time: "2022-11-10T17:12:34+01:00"
+    landscaper.gardener.cloud/operation: abort
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 2
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: a
+spec:
+  type: landscaper.gardener.cloud/helm
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+    my-val: val1
+
+status:
+  deployItemPhase: Failed
+  phase: Failed
+  jobID: job1
+  jobIDFinished: job1

--- a/pkg/landscaper/controllers/execution/testdata/test3/20-deploy-item.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test3/20-deploy-item.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-b
+  namespace:  {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/abort-time: "2022-11-10T17:12:34+01:00"
+    landscaper.gardener.cloud/operation: abort
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 2
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: b
+spec:
+  type: landscaper.gardener.cloud/helm
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+    my-val: val1
+
+status:
+  deployItemPhase: Failed
+  phase: Failed
+  jobID: job1
+  jobIDFinished: job1

--- a/pkg/landscaper/controllers/execution/testdata/test4/00-execution.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test4/00-execution.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Execution
+metadata:
+  name: exec-1
+  namespace:  {{ .Namespace }}
+  generation: 2
+  deletionTimestamp: "2022-11-10T13:59:00Z"
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  deployItems:
+    - name: a
+      type: landscaper.gardener.cloud/helm
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+
+status:
+  phase: DeleteFailed
+  jobID: job2
+  jobIDFinished: job1
+
+  observedGeneration: 2
+
+  deployItemRefs:
+  - name: a
+    ref:
+      name: di-a
+      namespace: test1
+      observedGeneration: 2
+
+  execGenerations:
+    - name: a
+      observedGeneration: 2

--- a/pkg/landscaper/controllers/execution/testdata/test4/10-deploy-item.yaml
+++ b/pkg/landscaper/controllers/execution/testdata/test4/10-deploy-item.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: di-a
+  namespace:  {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/abort-time: "2022-11-10T17:12:34+01:00"
+    landscaper.gardener.cloud/operation: abort
+  deletionTimestamp: "2022-11-10T13:59:00Z"
+  finalizers:
+    - finalizer.landscaper.gardener.cloud
+  generation: 2
+  labels:
+    execution.landscaper.gardener.cloud/managed-by: exec-1
+    execution.landscaper.gardener.cloud/name: a
+spec:
+  type: landscaper.gardener.cloud/helm
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+    kind: ProviderConfiguration
+    my-val: val1
+
+status:
+  deployItemPhase: Failed
+  phase: Failed
+  jobID: job1
+  jobIDFinished: job1

--- a/pkg/landscaper/controllers/installations/testdata/state/test8/00-root.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test8/00-root.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root
+  namespace: {{ .Namespace }}
+  deletionTimestamp: "2021-11-11T11:11:00Z"
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: root
+
+  imports:
+    data:
+    - name: root.a
+      dataRef: ext.a
+
+  exports:
+    data:
+    - name: root.y
+      dataRef: root.y
+    - name: root.z
+      dataRef: root.z
+
+status:
+  phase: Deleting
+  jobID: job2
+  jobIDFinished: job1
+  configGeneration: ""
+
+  imports:
+  - name: root.a
+    configGeneration: ""
+
+  installationRefs:
+  - name: a
+    ref:
+      name: a
+      namespace: {{ .Namespace }}
+  - name: b
+    ref:
+      name: b
+      namespace: {{ .Namespace }}
+
+  observedGeneration: 0

--- a/pkg/landscaper/controllers/installations/testdata/state/test8/10-a.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test8/10-a.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: a
+  namespace: {{ .Namespace }}
+  deletionTimestamp: "2021-11-11T11:11:00Z"
+  labels:
+    "landscaper.gardener.cloud/encompassed-by": root
+  annotations:
+    "landscaper.gardener.cloud/subinstallation-name": a
+  ownerReferences:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    kind: Installation
+    name: root
+    uid: abc-def-root
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: res-a
+
+  imports:
+    data:
+    - name: a.b
+      dataRef: root.a
+
+
+  exports:
+    data:
+    - name: a.x
+      dataRef: a.z
+
+status:
+  phase: InitDelete
+  jobID: job2
+  jobIDFinished: job1
+  configGeneration: ""
+
+  imports:
+  - name: a.b
+    configGeneration: ""

--- a/pkg/landscaper/controllers/installations/testdata/state/test8/11-b.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test8/11-b.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: b
+  namespace: {{ .Namespace }}
+  deletionTimestamp: "2021-11-11T11:11:00Z"
+  labels:
+    "landscaper.gardener.cloud/encompassed-by": root
+  annotations:
+    "landscaper.gardener.cloud/subinstallation-name": b
+  ownerReferences:
+  - apiVersion: landscaper.gardener.cloud/v1alpha1
+    kind: Installation
+    name: root
+    uid: abc-def-root
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: res-b
+
+  imports:
+    data:
+    - name: b.a
+      dataRef: a.z
+
+  exports:
+    data:
+    - name: b.y
+      dataRef: b.z
+
+status:
+  phase: DeleteFailed
+  jobID: job2
+  jobIDFinished: job2
+  configGeneration: ""
+
+  imports:
+  - name: b.a
+    configGeneration: ""
+


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

Suppose a root installation has two subinstallations A and B. Suppose B is a successor of A, i.e. B imports an export of A. Delete the root installation. Suppose the deletion of B fails (phase `DeleteFailed`). Then the deletion is stuck with A in phase  `InitDelete` and the root installation in phase `Deleting`. Neither an interrupt annotation, nor a reconcile annotation help.

The current pull request fixes this. If the deletion of B has failed, also A and the root installation will fail. Then the deletion can be repeated by adding a reconcile annotation at the root installation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
