### PR TITLE
landscaper service blueprint updates

### DIFF
--- a/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
@@ -40,6 +40,12 @@ imports:
     schema:
       type: string
 
+  - name: shootSecretBindingName
+    required: true
+    type: data
+    schema:
+      type: string
+
   - name: shootLabels
     required: false
     type: data
@@ -66,6 +72,14 @@ imports:
       description: |
         The landscaper deployment configuration.
       $ref: "cd://resources/landscaper-config-definition"
+
+  - name: webhooksHostName
+    required: true
+    type: data
+    schema:
+      description: |
+        The host name which is used to create the landscaper webhooks ingress.
+      type: string
 
 exports:
   - name: landscaperClusterEndpoint

--- a/.landscaper/landscaper-service/blueprint/installation/landscaper-deployment-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/landscaper-deployment-subinst.yaml
@@ -23,3 +23,5 @@ imports:
       dataRef: registryConfig
     - name: landscaperConfig
       dataRef: landscaperConfig
+    - name: webhooksHostName
+      dataRef: webhooksHostName

--- a/.landscaper/landscaper-service/blueprint/installation/shoot-cluster-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/shoot-cluster-subinst.yaml
@@ -18,6 +18,8 @@ imports:
       dataRef: shootNamespace
     - name: labels
       dataRef: shootLabels
+    - name: secretBindingName
+      dataRef: shootSecretBindingName
     - name: shootConfig
       dataRef: shootConfig
 

--- a/.landscaper/landscaper-service/blueprint/landscaper/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/landscaper/blueprint.yaml
@@ -40,6 +40,12 @@ imports:
     schema:
       $ref: "cd://resources/landscaper-config-definition"
 
+  - name: webhooksHostName
+    required: true
+    type: data
+    schema:
+      type: string
+
 deployExecutions:
   - name: deploy-execution
     file: /deploy-execution.yaml

--- a/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
@@ -85,6 +85,9 @@ deployItems:
           disableWebhooks: []
           certificatesNamespace: {{ .imports.targetClusterNamespace }}
 
+          ingress:
+            host: {{ .imports.webhooksHostName }}
+
         service:
           type: ClusterIP
           port: 80

--- a/.landscaper/landscaper-service/blueprint/shoot/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/shoot/blueprint.yaml
@@ -18,6 +18,12 @@ imports:
     schema:
       type: string
 
+  - name: secretBindingName
+    required: true
+    type: data
+    schema:
+      type: string
+
   - name: labels
     required: false
     type: data

--- a/.landscaper/landscaper-service/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/shoot/deploy-execution.yaml
@@ -10,6 +10,7 @@ deployItems:
       name: shoot-cluster
       updateStrategy: mergeOverwrite
       readinessChecks:
+        disableDefault: true
         custom:
           - name: APIServerAvailable
             timeout: 30m
@@ -36,7 +37,7 @@ deployItems:
                 values:
                   - value: "True"
 
-      deleteTimeout: 120m
+      deleteTimeout: 30m
 
       manifests:
         - policy: manage
@@ -48,6 +49,8 @@ deployItems:
             metadata:
               name: {{ .imports.name }}
               namespace: {{ .imports.namespace }}
+              annotations:
+                shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds: '30'
             {{ if .imports.labels }}
               labels:
 {{ toYaml .imports.labels | indent 16 }}
@@ -89,11 +92,11 @@ deployItems:
                 services: 100.64.0.0/13
               cloudProfileName: {{ .imports.shootConfig.provider.type }}
               region: {{ .imports.shootConfig.region }}
-              secretBindingName: {{ .imports.shootConfig.secretBindingName }}
+              secretBindingName: {{ .imports.secretBindingName }}
               kubernetes:
                 version: {{ .imports.shootConfig.kubernetes.version }}
+                enableStaticTokenKubeconfig: true
               purpose: production
-              enableStaticTokenKubeconfig: true
               maintenance:
                 timeWindow:
                   begin: {{ dig "shootConfig" "maintenance" "timeWindow" "begin" "050000+0200" .imports }}
@@ -103,7 +106,7 @@ deployItems:
                   machineImageVersion: {{ dig "shootConfig" "maintenance" "autoUpdate" "machineImageVersion" true .imports }}
 
       exports:
-        defaultTimeout: 120m
+        defaultTimeout: 30m
         exports:
           - key: shootClusterKubeconfig
             jsonPath: .data.kubeconfig

--- a/.landscaper/landscaper-service/definition/shoot-configuration.json
+++ b/.landscaper/landscaper-service/definition/shoot-configuration.json
@@ -14,9 +14,6 @@
     "region": {
       "type": "string"
     },
-    "secretBindingName": {
-      "type": "string"
-    },
     "kubernetes": {
       "$ref": "#definitions/kubernetesConfig"
     },

--- a/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
@@ -43,7 +43,11 @@ spec:
           args:
           {{- if .Values.webhooksServer.landscaperKubeconfig }}
           - "--kubeconfig=/app/ls/landscaper-cluster-kubeconfig/kubeconfig"
+          {{- if .Values.webhooksServer.ingress }}
+          - --webhook-url=https://{{ .Values.webhooksServer.ingress.host }}
+          {{- else }}
           - --webhook-url=https://{{ include "landscaper.webhooks.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.webhooksServer.servicePort }}
+          {{- end }}
           - --certificates-namespace={{ .Values.webhooksServer.certificatesNamespace }}
           {{- else }}
           - --webhook-service={{ .Release.Namespace }}/{{ include "landscaper.webhooks.fullname" . }}

--- a/charts/landscaper/charts/landscaper/templates/ingress.yaml
+++ b/charts/landscaper/charts/landscaper/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.webhooksServer.ingress }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "landscaper.webhooks.fullname" . }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+  labels:
+    {{- include "landscaper.labels" . | nindent 4 }}
+spec:
+  rules:
+    - host: {{ .Values.webhooksServer.ingress.host }}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "landscaper.webhooks.fullname" . }}
+                port:
+                  number: {{ .Values.webhooksServer.servicePort }}
+{{- end }}

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -127,6 +127,11 @@ webhooksServer:
   # Required when "landscaperKubeconfig" is defined.
   certificatesNamespace: ""
 
+  # Specify to create a webhooks server ingress in combination with "landscaperKubeconfig".
+  # This is needed when the webhooks server pod is placed on a different cluster than the landscaper resources.
+  # ingress:
+  #  host: webhooks.ingress.mydomain.net
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/test/landscaper/landscaper_service_blueprints/testdata/imports-installation.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/imports-installation.yaml
@@ -64,6 +64,7 @@ imports:
 
   shootName: test-shoot
   shootNamespace: garden-test
+  shootSecretBindingName: shoot-cluster-gcp-secret
   shootLabels:
     landscaper-service.gardener.cloud.tenantid: "12345"
     landscaper-service.gardener.cloud.deploymentid: "00001"
@@ -73,7 +74,6 @@ imports:
       type: gcp
       zone: europe-west1-c
     region: europe-west1
-    secretBindingName: shoot-cluster-gcp-secret
     kubernetes:
       version: 1.24.6
 
@@ -106,3 +106,4 @@ imports:
       manifest:
         resources: {}
 
+  webhooksHostName: lswh.ingress.shoot.external

--- a/test/landscaper/landscaper_service_blueprints/testdata/imports-landscaper.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/imports-landscaper.yaml
@@ -65,3 +65,5 @@ imports:
       manifest:
         resources: {}
 
+  webhooksHostName: lswh.ingress.shoot.external
+

--- a/test/landscaper/landscaper_service_blueprints/testdata/imports-shoot.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/imports-shoot.yaml
@@ -33,6 +33,7 @@ imports:
 
   name: test-shoot
   namespace: garden-test
+  secretBindingName: shoot-cluster-gcp-secret
   labels:
     landscaper-service.gardener.cloud.tenantid: "12345"
     landscaper-service.gardener.cloud.deploymentid: "00001"
@@ -42,6 +43,5 @@ imports:
       type: gcp
       zone: europe-west1-c
     region: europe-west1
-    secretBindingName: shoot-cluster-gcp-secret
     kubernetes:
       version: 1.24.6


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 3

**What this PR does / why we need it**:

* Add an optional ingress resource for the landscaper webhooks server in the landscaper chart.
* Refactoring of the landscaper service blueprint.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add an optional ingress resource for the landscaper webhooks server in the landscaper chart.
```
