### PR TITLE
enhance and document TargetList imports

### DIFF
--- a/apis/core/v1alpha1/helper/dataobjects.go
+++ b/apis/core/v1alpha1/helper/dataobjects.go
@@ -29,6 +29,8 @@ const InstallationPrefix = "Inst."
 // ExecutionPrefix is the prefix combined with execution name is used as label value. Do not change length.
 const ExecutionPrefix = "Exec."
 
+var subdomainRegex = regexp.MustCompile("^([a-z0-9]|([a-z0-9][a-z0-9.-]*[a-z0-9]))$")
+
 // GenerateDataObjectName generates the unique name for a data object exported or imported by a installation.
 // It returns a non contextified data name if the name starts with a "#".
 func GenerateDataObjectName(context string, name string) string {
@@ -36,7 +38,6 @@ func GenerateDataObjectName(context string, name string) string {
 		return strings.TrimPrefix(name, NonContextifiedPrefix)
 	}
 	// for backward compatibility, we need to hash names which are incompatible with the k8s resource naming scheme
-	subdomainRegex := regexp.MustCompile("^([a-z0-9]|([a-z0-9][a-z0-9.-]*[a-z0-9]))$")
 	if len(context) == 0 && subdomainRegex.MatchString(name) {
 		return name
 	}

--- a/apis/core/v1alpha1/types_dataobject.go
+++ b/apis/core/v1alpha1/types_dataobject.go
@@ -35,6 +35,9 @@ const DataObjectKeyLabel = "data.landscaper.gardener.cloud/key"
 // DataObjectSourceLabel defines the name of the label that specifies the source of the dataobject.
 const DataObjectSourceLabel = "data.landscaper.gardener.cloud/source"
 
+// DataObjectIndexLabel defines the name of the annotation that specifies the index of the dataobject (for list-type imports)
+const DataObjectIndexLabel = "data.landscaper.gardener.cloud/index"
+
 // DataObjectHashAnnotation defines the name of the annotation that specifies the hash of the data.
 const DataObjectHashAnnotation = "data.landscaper.gardener.cloud/hash"
 

--- a/apis/core/v1alpha1/types_target.go
+++ b/apis/core/v1alpha1/types_target.go
@@ -54,6 +54,11 @@ var TargetDefinition = lsschema.CustomResourceDefinition{
 			JSONPath: ".metadata.labels['data\\.landscaper\\.gardener\\.cloud\\/key']",
 		},
 		{
+			Name:     "Idx",
+			Type:     "string",
+			JSONPath: ".metadata.labels['data\\.landscaper\\.gardener\\.cloud\\/index']",
+		},
+		{
 			Name:     "Age",
 			Type:     "date",
 			JSONPath: ".metadata.creationTimestamp",

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_dataobject.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_dataobject.go
@@ -35,6 +35,9 @@ const DataObjectKeyLabel = "data.landscaper.gardener.cloud/key"
 // DataObjectSourceLabel defines the name of the label that specifies the source of the dataobject.
 const DataObjectSourceLabel = "data.landscaper.gardener.cloud/source"
 
+// DataObjectIndexLabel defines the name of the annotation that specifies the index of the dataobject (for list-type imports)
+const DataObjectIndexLabel = "data.landscaper.gardener.cloud/index"
+
 // DataObjectHashAnnotation defines the name of the annotation that specifies the hash of the data.
 const DataObjectHashAnnotation = "data.landscaper.gardener.cloud/hash"
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
@@ -54,6 +54,11 @@ var TargetDefinition = lsschema.CustomResourceDefinition{
 			JSONPath: ".metadata.labels['data\\.landscaper\\.gardener\\.cloud\\/key']",
 		},
 		{
+			Name:     "Idx",
+			Type:     "string",
+			JSONPath: ".metadata.labels['data\\.landscaper\\.gardener\\.cloud\\/index']",
+		},
+		{
 			Name:     "Age",
 			Type:     "date",
 			JSONPath: ".metadata.creationTimestamp",

--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -173,7 +173,7 @@ Blueprints describe formal imports. A formal import parameter has a name and a *
 
 - **`targetList`**
 
-  This type can be used if, instead of a single target object, an arbitrary number of targets should be imported. All targets imported as part of a targetlist import must have the same `targetType`.
+  This type can be used if, instead of a single target object, an arbitrary number of targets should be imported. All targets imported as part of a targetlist import must have the same `targetType`. For more information on how to work with TargetList imports, see the documentation [here](./TargetLists.md).
 
 
 - **`componentDescriptor`**
@@ -954,28 +954,4 @@ subinstallationExecutions:
       blueprint:
         ref: cd://componentReferences/ingress/resources/blueprint
       ...
-```
-
-### Hints for using Nested Installations
-
-#### TargetList Imports in nested installations
-
-To import a targetlist that has been imported by an installation, use `targetListRef` to reference the name of the parent import.
-
-```yaml
-imports:
-  targets:
-  - name: "my-foo-targets"
-    targets: # targetlist import
-    - foo
-    - foobar
-    - foobaz
-subinstallations:
-- apiVersion: landscaper.gardener.cloud/v1alpha1
-  kind: InstallationTemplate
-  name: mysubinst
-  imports:
-    targets:
-    - name: "also-my-foo-targets"
-      targetListRef: "my-foo-targets"
 ```

--- a/docs/usage/TargetLists.md
+++ b/docs/usage/TargetLists.md
@@ -143,6 +143,8 @@ subinstallations:
 
 ## Usage Examples
 
+See also the [landscaper examples](https://github.com/gardener/landscaper-examples/tree/master/targetlists) for full example Installations.
+
 ### One DeployItem per Target
 
 This is probably the most prominent use-case of the feature: The Installation is supposed to perform the same action for each Target of an imported TargetList. For example, the TargetList contains kubernetes-cluster targets - basically kubeconfigs - and the Installation should deploy a manifest into each of the referenced clusters.

--- a/docs/usage/TargetLists.md
+++ b/docs/usage/TargetLists.md
@@ -1,0 +1,282 @@
+# TargetList Imports
+
+While the Landscaper allows to import lists of Targets into Installations/Blueprints, it is not intuitively clear how they can be used. This documentation will provide a few examples for this. Please note that the provided example YAMLs often are redacted to show only the part of the spec which is of interest for demonstrating the usage of TargetList imports.
+
+**Index**:
+- [The Basics](#the-basics)
+  - [TargetList Import Declarations in Blueprints](#targetlist-import-declarations-in-blueprints)
+  - [TargetList Imports in Installations](#targetlist-imports-in-installations)
+  - [Referencing (Targets from) TargetList Imports](#referencing-targets-from-targetlist-imports)
+    - [In DeployItems](#in-deployitems)
+    - [In Nested Installations](#in-nested-installations)
+      - [Whole TargetList](#whole-targetlist)
+      - [Single Target from TargetList](#single-target-from-targetlist)
+- [Usage Examples](#usage-examples)
+  - [One DeployItem per Target](#one-deployitem-per-target)
+  - [One Nested Installation per Target](#one-nested-installation-per-target)
+
+
+## The Basics
+
+### TargetList Import Declarations in Blueprints
+
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/test
+```
+
+A TargetList import can be declared in a Blueprint simply by using `targetList` as type for the import.
+
+
+### TargetList Imports in Installations
+
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: targetlist
+spec:
+  imports:
+    targets:
+    - name: mytargets
+      targets:
+      - target1
+      - target2
+      - target3
+```
+
+To satisfy a Blueprint's `targetList` import in an Installation, simply provide a list of the Targets' names. All targets have to exist in the same namespace as the installation and must have the same `targetType` - the one specified in the Blueprint.
+
+> While probably rarely useful, it is possible to list the same Target multiple times.
+
+
+### Referencing (Targets from) TargetList Imports
+
+#### In DeployItems
+
+To reference a Target from a TargetList in a DeployItem's `target` field, use the name of the TargetList import and its index.
+```yaml
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+deployExecutions:
+- name: deploy-executions
+  type: Spiff
+  template:
+    deployItems:
+    - name: my-first-target-di
+      type: landscaper.gardener.cloud/kubernetes-manifest
+      target:
+        import: mytargets
+        index: 0
+```
+
+#### In Nested Installations
+
+##### Whole TargetList
+
+The special field `targetListRef` can be used to forward the complete TargetList import of a parent Installation to its subinstallation.
+```yaml
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+subinstallations:
+- apiVersion: landscaper.gardener.cloud/v1alpha1
+  kind: InstallationTemplate
+  name: mysubinst
+  imports:
+    targets:
+    - name: also-my-targets # assuming the nested installation's blueprint expects a TargetList import named 'also-my-targets'
+      targetListRef: mytargets
+```
+
+#### Single Target from TargetList
+
+To use a single Target from a parent Installation's TargetList import, reference it by using the name of the TargetList import, followed by the index in square brackets.
+```yaml
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+subinstallations:
+- apiVersion: landscaper.gardener.cloud/v1alpha1
+  kind: InstallationTemplate
+  name: mysubinst
+  imports:
+    targets:
+    - name: my-single-target # assuming the nested installation's blueprint expects a single target import named 'my-single-target'
+      target: "mytargets[0]"
+```
+
+This notation can also be used to compose new TargetLists:
+```yaml
+imports:
+- name: myfirsttargetlist
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+- name: mysecondtargetlist
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+subinstallations:
+- apiVersion: landscaper.gardener.cloud/v1alpha1
+  kind: InstallationTemplate
+  name: mysubinst
+  imports:
+    targets:
+    - name: also-my-targets # assuming the nested installation's blueprint expects a TargetList import named 'also-my-targets'
+      targets:
+      - "myfirsttargetlist[0]"
+      - "mysecondtargetlist[4]"
+```
+
+
+## Usage Examples
+
+### One DeployItem per Target
+
+This is probably the most prominent use-case of the feature: The Installation is supposed to perform the same action for each Target of an imported TargetList. For example, the TargetList contains kubernetes-cluster targets - basically kubeconfigs - and the Installation should deploy a manifest into each of the referenced clusters.
+
+To achieve this, use one of the offered templating options to render multiple DeployItems. Both of the examples specified below will result in one DeployItem per entry in the imported TargetList.
+
+#### GoTemplate
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+deployExecutions:
+- name: deploy-executions
+  type: GoTemplate
+  template: |
+    deployItems:
+    {{ range $idx, $target := .imports.mytargets }}
+    - name: my-di-{{ $idx }}-{{ $target.metadata.name }}
+      type: landscaper.gardener.cloud/kubernetes-manifest
+      target:
+        import: mytargets
+        index: {{ $idx }}
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+        manifests:
+        - policy: manage
+          manifest:
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: foo-{{ $idx }}
+              namespace: default
+            data:
+              foo: YmFy
+    {{ end }}
+```
+
+#### Spiff
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+deployExecutions:
+- name: deploy-executions
+  type: Spiff
+  template:
+    deployItems: (( sum[imports.mytargets|[]|s,idx,tar|-> s *diTemplate] ))
+    diTemplate:
+      <<<: (( &template &temporary ))
+      name: (( "my-di-" idx "-" tar.metadata.name ))
+      type: landscaper.gardener.cloud/kubernetes-manifest
+      target:
+        import: mytargets
+        index: (( idx ))
+      config:
+        apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+        kind: ProviderConfiguration
+        manifests:
+        - policy: manage
+          manifest:
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: (( "foo-" idx ))
+              namespace: default
+            data:
+              foo: YmFy
+```
+Note that it is not possible to name the variable which holds the current Target (`tar` in this case) `target`, as _Spiff_ will confuse this with the node named `target` in the DeployItem template (`diTemplate`).
+
+
+### One Nested Installation per Target
+
+It is also possible to create one nested installation per Target in a TargetList.
+
+#### GoTemplate
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+subinstallationExecutions:
+- name: subinst-executions
+  type: GoTemplate
+  template: |
+    subinstallations:
+    {{ range $idx, $target := .imports.mytargets }}
+    - apiVersion: landscaper.gardener.cloud/v1alpha1
+      kind: InstallationTemplate
+      name: my-subinst-{{ $idx }}-{{ $target.metadata.name }}
+      imports:
+        targets:
+        - target: "mytargets[{{ $idx }}]"
+          name: mytarget
+    {{ end }}
+```
+
+#### Spiff
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+imports:
+- name: mytargets
+  type: targetList
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+subinstallationExecutions:
+- name: subinst-executions
+  type: Spiff
+  template:
+    subinstallations: (( sum[imports.mytargets|[]|s,idx,tar|-> s *iTemplate] ))
+    iTemplate:
+      <<<: (( &template &temporary ))
+      apiVersion: landscaper.gardener.cloud/v1alpha1
+      kind: InstallationTemplate
+      name: (( "my-subinst-" idx "-" tar.metadata.name ))
+      imports:
+        targets:
+        - target: (( "mytargets[" idx "]" ))
+          name: mytarget
+```

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_targets.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_targets.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .metadata.labels['data\.landscaper\.gardener\.cloud\/key']
       name: Key
       type: string
+    - jsonPath: .metadata.labels['data\.landscaper\.gardener\.cloud\/index']
+      name: Idx
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/pkg/landscaper/dataobjects/target.go
+++ b/pkg/landscaper/dataobjects/target.go
@@ -82,6 +82,12 @@ func (t *TargetExtension) SetKey(key string) *TargetExtension {
 	return t
 }
 
+// SetIndex sets the index (for list-type objects)
+func (t *TargetExtension) SetIndex(idx *int) *TargetExtension {
+	t.metadata.Index = idx
+	return t
+}
+
 // Apply applies data and metadata to an existing target (except owner references).
 func (t *TargetExtension) Apply(target *lsv1alpha1.Target) error {
 	target.Name = lsv1alpha1helper.GenerateDataObjectName(t.metadata.Context, t.metadata.Key)

--- a/pkg/landscaper/installations/helper.go
+++ b/pkg/landscaper/installations/helper.go
@@ -179,7 +179,6 @@ func GetTargets(ctx context.Context,
 	contextName string,
 	inst *lsv1alpha1.Installation,
 	targetImport lsv1alpha1.TargetImport) ([]*dataobjects.TargetExtension, []string, error) {
-	// get deploy item from current context
 	var targets []*dataobjects.TargetExtension
 	var targetImportReferences []string
 	if len(targetImport.Target) != 0 {
@@ -215,7 +214,6 @@ func GetTargets(ctx context.Context,
 
 // GetTargetImport fetches the target import from the cluster.
 func GetTargetImport(ctx context.Context, kubeClient client.Client, contextName string, inst *lsv1alpha1.Installation, targetImport lsv1alpha1.TargetImport) (*dataobjects.TargetExtension, error) {
-	// get deploy item from current context
 	targetName := targetImport.Target
 	target := &lsv1alpha1.Target{}
 	targetName = lsv1alpha1helper.GenerateDataObjectName(contextName, targetName)

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -567,6 +568,7 @@ func (o *Operation) createOrUpdateTargetImport(ctx context.Context, src string, 
 	targetExtension.SetNamespace(o.Inst.GetInstallation().Namespace).
 		SetContext(src).
 		SetKey(importDef.Name).
+		SetIndex(nil).
 		SetSource(src).SetSourceType(lsv1alpha1.ImportDataObjectSourceType)
 
 	targetForUpdate := &lsv1alpha1.Target{}
@@ -609,6 +611,7 @@ func (o *Operation) createOrUpdateTargetListImport(ctx context.Context, src stri
 		tar.SetNamespace(o.Inst.GetInstallation().Namespace).
 			SetContext(src).
 			SetKey(importDef.Name).
+			SetIndex(pointer.Int(i)).
 			SetSource(src).SetSourceType(lsv1alpha1.ImportDataObjectSourceType)
 	}
 

--- a/test/integration/installations/import-export.go
+++ b/test/integration/installations/import-export.go
@@ -139,7 +139,7 @@ func ImportExportTests(f *framework.Framework) {
 				}),
 			))
 
-			// target export
+			// target exports
 			By("verify target exports")
 			labels[lsv1alpha1.DataObjectKeyLabel] = "targetExp"
 			rawTargetExports := &lsv1alpha1.TargetList{}
@@ -151,7 +151,23 @@ func ImportExportTests(f *framework.Framework) {
 					targetExports = append(targetExports, elem)
 				}
 			}
-			Expect(targetExports).To(HaveLen(1), "there should be exactly one root-level target export")
+			Expect(targetExports).To(HaveLen(1), "there should be exactly one root-level target export for targetExp")
+			Expect(targetExports).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Spec": BeEquivalentTo(expectedTargetExport),
+			})))
+
+			// target export from list import
+			labels[lsv1alpha1.DataObjectKeyLabel] = "targetExpFromList"
+			rawTargetExports = &lsv1alpha1.TargetList{}
+			utils.ExpectNoError(f.Client.List(ctx, rawTargetExports, client.InNamespace(state.Namespace), client.MatchingLabels(labels)))
+			targetExports = []lsv1alpha1.Target{}
+			for _, elem := range rawTargetExports.Items {
+				con, ok := elem.Labels[lsv1alpha1.DataObjectContextLabel]
+				if !ok || len(con) == 0 {
+					targetExports = append(targetExports, elem)
+				}
+			}
+			Expect(targetExports).To(HaveLen(1), "there should be exactly one root-level target export for targetExpFromList")
 			Expect(targetExports).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Spec": BeEquivalentTo(expectedTargetExport),
 			})))

--- a/test/integration/installations/testdata/test1/00-root-installation.yaml
+++ b/test/integration/installations/testdata/test1/00-root-installation.yaml
@@ -57,6 +57,8 @@ spec:
     targets:
     - name: targetExp
       target: targetExp
+    - name: targetExpFromList
+      target: targetExpFromList
 
   exportDataMappings:
     additionalDataExp: (( "mapping-" exports.dataExp ))
@@ -99,6 +101,9 @@ spec:
           - name: targetExp
             type: target
             targetType: landscaper.gardener.cloud/mock
+          - name: targetExpFromList
+            type: target
+            targetType: landscaper.gardener.cloud/mock
           
           exportExecutions:
           - type: GoTemplate
@@ -106,6 +111,7 @@ spec:
               exports:
                 dataExp: {{ .values.dataobjects.subDataExp }}
                 targetExp: {{ toJson .values.targets.subTargetExp.spec }}
+                targetExpFromList: {{ toJson .values.targets.subTargetExpFromList.spec }}
 
           subinstallations:
           - apiVersion: landscaper.gardener.cloud/v1alpha1
@@ -120,6 +126,8 @@ spec:
               targets:
               - name: subTargetImp
                 target: targetImp
+              - name: subTargetImpFromList
+                target: "targetListImp[0]"
               - name: subTargetListImp
                 targetListRef: targetListImp
               - name: subEmptyTargetListImp
@@ -131,6 +139,8 @@ spec:
               targets:
               - name: subTargetExp
                 target: subTargetExp
+              - name: subTargetExpFromList
+                target: subTargetExpFromList
             blueprint:
               filesystem:
                 blueprint.yaml: |
@@ -161,6 +171,9 @@ spec:
                   - name: subTargetImp
                     type: target
                     targetType: landscaper.gardener.cloud/mock
+                  - name: subTargetImpFromList
+                    type: target
+                    targetType: landscaper.gardener.cloud/mock
                   - name: subTargetListImp
                     type: targetList
                     targetType: landscaper.gardener.cloud/mock
@@ -175,9 +188,13 @@ spec:
                   - name: subTargetExp
                     type: target
                     targetType: landscaper.gardener.cloud/mock
+                  - name: subTargetExpFromList
+                    type: target
+                    targetType: landscaper.gardener.cloud/mock
                   exportExecutions:
                   - type: Spiff
                     template:
                       exports:
                         subDataExp: (( values.dataobjects.subDataImp ))
                         subTargetExp: (( values.targets.subTargetImp.spec ))
+                        subTargetExpFromList: (( values.targets.subTargetImpFromList.spec ))

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/dataobjects.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/dataobjects.go
@@ -29,6 +29,8 @@ const InstallationPrefix = "Inst."
 // ExecutionPrefix is the prefix combined with execution name is used as label value. Do not change length.
 const ExecutionPrefix = "Exec."
 
+var subdomainRegex = regexp.MustCompile("^([a-z0-9]|([a-z0-9][a-z0-9.-]*[a-z0-9]))$")
+
 // GenerateDataObjectName generates the unique name for a data object exported or imported by a installation.
 // It returns a non contextified data name if the name starts with a "#".
 func GenerateDataObjectName(context string, name string) string {
@@ -36,7 +38,6 @@ func GenerateDataObjectName(context string, name string) string {
 		return strings.TrimPrefix(name, NonContextifiedPrefix)
 	}
 	// for backward compatibility, we need to hash names which are incompatible with the k8s resource naming scheme
-	subdomainRegex := regexp.MustCompile("^([a-z0-9]|([a-z0-9][a-z0-9.-]*[a-z0-9]))$")
 	if len(context) == 0 && subdomainRegex.MatchString(name) {
 		return name
 	}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_dataobject.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_dataobject.go
@@ -35,6 +35,9 @@ const DataObjectKeyLabel = "data.landscaper.gardener.cloud/key"
 // DataObjectSourceLabel defines the name of the label that specifies the source of the dataobject.
 const DataObjectSourceLabel = "data.landscaper.gardener.cloud/source"
 
+// DataObjectIndexLabel defines the name of the annotation that specifies the index of the dataobject (for list-type imports)
+const DataObjectIndexLabel = "data.landscaper.gardener.cloud/index"
+
 // DataObjectHashAnnotation defines the name of the annotation that specifies the hash of the data.
 const DataObjectHashAnnotation = "data.landscaper.gardener.cloud/hash"
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
@@ -54,6 +54,11 @@ var TargetDefinition = lsschema.CustomResourceDefinition{
 			JSONPath: ".metadata.labels['data\\.landscaper\\.gardener\\.cloud\\/key']",
 		},
 		{
+			Name:     "Idx",
+			Type:     "string",
+			JSONPath: ".metadata.labels['data\\.landscaper\\.gardener\\.cloud\\/index']",
+		},
+		{
 			Name:     "Age",
 			Type:     "date",
 			JSONPath: ".metadata.creationTimestamp",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to use a single Target from a TargetList import of the parent Installation in a subinstallation. This allows, for example, to create one subinstallation per Target of a TargetList. See the [new TargetList documentation](docs/usage/TargetLists.md) for details and examples.
```
```doc user
A dedicated documentation for TargetList imports has been added, see [here](docs/usage/TargetLists.md).
```
