### PR TITLE
Retry only if something changed

### DIFF
--- a/apis/core/types_deployitem.go
+++ b/apis/core/types_deployitem.go
@@ -66,6 +66,9 @@ type DeployItemSpec struct {
 	// Defaults to ten minutes if not specified.
 	// +optional
 	Timeout *Duration `json:"timeout,omitempty"`
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployItemStatus contains the status of a deploy item

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -132,4 +132,8 @@ type DeployItemTemplate struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }

--- a/apis/core/v1alpha1/types_deployitem.go
+++ b/apis/core/v1alpha1/types_deployitem.go
@@ -121,6 +121,9 @@ type DeployItemSpec struct {
 	// Defaults to ten minutes if not specified.
 	// +optional
 	Timeout *Duration `json:"timeout,omitempty"`
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployItemStatus contains the status of a deploy item.

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -205,4 +205,8 @@ type DeployItemTemplate struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1646,6 +1646,7 @@ func autoConvert_v1alpha1_DeployItemTemplate_To_core_DeployItemTemplate(in *Depl
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.DependsOn = *(*[]string)(unsafe.Pointer(&in.DependsOn))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 
@@ -1661,6 +1662,7 @@ func autoConvert_core_DeployItemTemplate_To_v1alpha1_DeployItemTemplate(in *core
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.DependsOn = *(*[]string)(unsafe.Pointer(&in.DependsOn))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1564,6 +1564,7 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 
@@ -1579,6 +1580,7 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4130,6 +4130,13 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemTemplate(ref common.Referenc
 							},
 						},
 					},
+					"updateOnChangeOnly": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name", "type", "config"},
 			},

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -3926,6 +3926,13 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.Duration"),
 						},
 					},
+					"updateOnChangeOnly": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"type"},
 			},

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -66,6 +66,9 @@ type DeployItemSpec struct {
 	// Defaults to ten minutes if not specified.
 	// +optional
 	Timeout *Duration `json:"timeout,omitempty"`
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployItemStatus contains the status of a deploy item

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -132,4 +132,8 @@ type DeployItemTemplate struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -121,6 +121,9 @@ type DeployItemSpec struct {
 	// Defaults to ten minutes if not specified.
 	// +optional
 	Timeout *Duration `json:"timeout,omitempty"`
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployItemStatus contains the status of a deploy item.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -205,4 +205,8 @@ type DeployItemTemplate struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1646,6 +1646,7 @@ func autoConvert_v1alpha1_DeployItemTemplate_To_core_DeployItemTemplate(in *Depl
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.DependsOn = *(*[]string)(unsafe.Pointer(&in.DependsOn))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 
@@ -1661,6 +1662,7 @@ func autoConvert_core_DeployItemTemplate_To_v1alpha1_DeployItemTemplate(in *core
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.DependsOn = *(*[]string)(unsafe.Pointer(&in.DependsOn))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1564,6 +1564,7 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 
@@ -1579,6 +1580,7 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -582,6 +582,18 @@ Value has to be parsable by time.ParseDuration (or &lsquo;none&rsquo; to deactiv
 Defaults to ten minutes if not specified.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>updateOnChangeOnly</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2494,6 +2506,18 @@ When the time is exceeded, the landscaper will add the abort annotation to the d
 and later put it in &lsquo;Failed&rsquo; if the deployer doesn&rsquo;t handle the abort properly.
 Value has to be parsable by time.ParseDuration (or &lsquo;none&rsquo; to deactivate the timeout).
 Defaults to ten minutes if not specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>updateOnChangeOnly</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2811,6 +2811,18 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <p>DependsOn lists deploy items that need to be executed before this one</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>updateOnChangeOnly</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="landscaper.gardener.cloud/v1alpha1.DeployItemType">DeployItemType

--- a/docs/guided-tour/README.md
+++ b/docs/guided-tour/README.md
@@ -49,6 +49,7 @@ In this tour, you will learn about the different Landscaper features by simple e
 <!--
 Delete without uninstall
 automatic reconcile
+reconcile updateOnChangeOnly
 Deploying a blueprint to multiple targets/target list
 Pull secrets for helm chart repo (with and without secret ref)
 Pull secret in context to access a protected oci registry

--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -527,6 +527,10 @@ A deployitem specification has the following fields:
 
   If the import refers to a targetlist import, `index` specifies the list index of the referenced target.
 
+  - **`updateOnChangeOnly`** *bool*
+
+  If set on true, a successfully processed deployitem is only deployed again, if something has changed in its spec. 
+
 
   - **`name`** *string (deprecated)*
 

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
@@ -91,6 +91,10 @@ spec:
                 description: Type is the type of the deployer that should handle the
                   item.
                 type: string
+              updateOnChangeOnly:
+                description: UpdateOnChangeOnly specifies if redeployment is executed
+                  only if the specification of the deploy item has changed.
+                type: boolean
             required:
             - type
             type: object

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -79,6 +79,11 @@ spec:
                     type:
                       description: DataType is the DeployItem type of the execution.
                       type: string
+                    updateOnChangeOnly:
+                      description: UpdateOnChangeOnly specifies if redeployment is
+                        executed only if the specification of the deploy item has
+                        changed.
+                      type: boolean
                   required:
                   - name
                   - type

--- a/pkg/landscaper/execution/helper.go
+++ b/pkg/landscaper/execution/helper.go
@@ -25,6 +25,7 @@ func ApplyDeployItemTemplate(di *lsv1alpha1.DeployItem, tmpl lsv1alpha1.DeployIt
 	di.Spec.Type = tmpl.Type
 	di.Spec.Target = tmpl.Target
 	di.Spec.Configuration = tmpl.Configuration
+	di.Spec.UpdateOnChangeOnly = tmpl.UpdateOnChangeOnly
 	for k, v := range tmpl.Labels {
 		kutil.SetMetaDataLabel(&di.ObjectMeta, k, v)
 	}

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -8,16 +8,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/gotemplate"
-	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/spiff"
 
 	"github.com/gardener/landscaper/apis/core"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -27,6 +22,9 @@ import (
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/gotemplate"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/spiff"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
 const (
@@ -118,12 +116,13 @@ func (o *ExecutionOperation) RenderDeployItemTemplates(ctx context.Context, inst
 		}
 
 		execTemplates[i] = core.DeployItemTemplate{
-			Name:          elem.Name,
-			Type:          elem.Type,
-			Target:        target,
-			Labels:        elem.Labels,
-			Configuration: elem.Configuration,
-			DependsOn:     elem.DependsOn,
+			Name:               elem.Name,
+			Type:               elem.Type,
+			Target:             target,
+			Labels:             elem.Labels,
+			Configuration:      elem.Configuration,
+			DependsOn:          elem.DependsOn,
+			UpdateOnChangeOnly: elem.UpdateOnChangeOnly,
 		}
 	}
 

--- a/pkg/landscaper/installations/executions/template/template.go
+++ b/pkg/landscaper/installations/executions/template/template.go
@@ -138,6 +138,10 @@ type DeployItemSpecification struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployExecutorOutput describes the output of deploy executor.

--- a/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
+++ b/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gardener/landscaper/pkg/deployer/manifest"
-
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"sigs.k8s.io/yaml"

--- a/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -66,6 +66,9 @@ type DeployItemSpec struct {
 	// Defaults to ten minutes if not specified.
 	// +optional
 	Timeout *Duration `json:"timeout,omitempty"`
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployItemStatus contains the status of a deploy item

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -132,4 +132,8 @@ type DeployItemTemplate struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -121,6 +121,9 @@ type DeployItemSpec struct {
 	// Defaults to ten minutes if not specified.
 	// +optional
 	Timeout *Duration `json:"timeout,omitempty"`
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }
 
 // DeployItemStatus contains the status of a deploy item.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -205,4 +205,8 @@ type DeployItemTemplate struct {
 
 	// DependsOn lists deploy items that need to be executed before this one
 	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.
+	// +optional
+	UpdateOnChangeOnly bool `json:"updateOnChangeOnly,omitempty"`
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1646,6 +1646,7 @@ func autoConvert_v1alpha1_DeployItemTemplate_To_core_DeployItemTemplate(in *Depl
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.DependsOn = *(*[]string)(unsafe.Pointer(&in.DependsOn))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 
@@ -1661,6 +1662,7 @@ func autoConvert_core_DeployItemTemplate_To_v1alpha1_DeployItemTemplate(in *core
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.DependsOn = *(*[]string)(unsafe.Pointer(&in.DependsOn))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1564,6 +1564,7 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 
@@ -1579,6 +1580,7 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
+	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR adds the possibility to configure that a reconcile is only triggered if something has changed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- possibility to configure that a reconcile is only triggered if something has changed
```
