### PR TITLE
Sync target to garden project 

### DIFF
--- a/apis/core/types_target_sync.go
+++ b/apis/core/types_target_sync.go
@@ -41,6 +41,15 @@ type TargetSyncSpec struct {
 	// SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.
 	SecretRef LocalSecretReference `json:"secretRef"`
 
+	// CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef
+	// +optional
+	CreateTargetToSource bool `json:"createTargetToSource,omitempty"`
+
+	// TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+	// is set on true. If TargetToSourceName is empty SourceNamespace is used instead.
+	// +optional
+	TargetToSourceName string `json:"targetToSourceName,omitempty"`
+
 	// SecretNameExpression defines the names of the secrets which should be synced via a regular expression according
 	// to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches
 	// all names.

--- a/apis/core/v1alpha1/types_target_sync.go
+++ b/apis/core/v1alpha1/types_target_sync.go
@@ -43,6 +43,15 @@ type TargetSyncSpec struct {
 	// SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.
 	SecretRef LocalSecretReference `json:"secretRef"`
 
+	// CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef
+	// +optional
+	CreateTargetToSource bool `json:"createTargetToSource,omitempty"`
+
+	// TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+	// is set on true. If TargetToSourceName is empty SourceNamespace is used instead.
+	// +optional
+	TargetToSourceName string `json:"targetToSourceName,omitempty"`
+
 	// SecretNameExpression defines the names of the secrets which should be synced via a regular expression according
 	// to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches
 	// all names.

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -3192,6 +3192,8 @@ func autoConvert_v1alpha1_TargetSyncSpec_To_core_TargetSyncSpec(in *TargetSyncSp
 	if err := Convert_v1alpha1_LocalSecretReference_To_core_LocalSecretReference(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	out.CreateTargetToSource = in.CreateTargetToSource
+	out.TargetToSourceName = in.TargetToSourceName
 	out.SecretNameExpression = in.SecretNameExpression
 	out.ShootNameExpression = in.ShootNameExpression
 	out.TokenRotation = (*core.TokenRotation)(unsafe.Pointer(in.TokenRotation))
@@ -3208,6 +3210,8 @@ func autoConvert_core_TargetSyncSpec_To_v1alpha1_TargetSyncSpec(in *core.TargetS
 	if err := Convert_core_LocalSecretReference_To_v1alpha1_LocalSecretReference(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	out.CreateTargetToSource = in.CreateTargetToSource
+	out.TargetToSourceName = in.TargetToSourceName
 	out.SecretNameExpression = in.SecretNameExpression
 	out.ShootNameExpression = in.ShootNameExpression
 	out.TokenRotation = (*TokenRotation)(unsafe.Pointer(in.TokenRotation))

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -6808,6 +6808,20 @@ func schema_landscaper_apis_core_v1alpha1_TargetSyncSpec(ref common.ReferenceCal
 							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.LocalSecretReference"),
 						},
 					},
+					"createTargetToSource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"targetToSourceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource is set on true. If TargetToSourceName is empty SourceNamespace is used instead.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"secretNameExpression": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SecretNameExpression defines the names of the secrets which should be synced via a regular expression according to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches all names. if not set no secrets are synced",

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_target_sync.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_target_sync.go
@@ -41,6 +41,15 @@ type TargetSyncSpec struct {
 	// SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.
 	SecretRef LocalSecretReference `json:"secretRef"`
 
+	// CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef
+	// +optional
+	CreateTargetToSource bool `json:"createTargetToSource,omitempty"`
+
+	// TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+	// is set on true. If TargetToSourceName is empty SourceNamespace is used instead.
+	// +optional
+	TargetToSourceName string `json:"targetToSourceName,omitempty"`
+
 	// SecretNameExpression defines the names of the secrets which should be synced via a regular expression according
 	// to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches
 	// all names.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target_sync.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target_sync.go
@@ -43,6 +43,15 @@ type TargetSyncSpec struct {
 	// SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.
 	SecretRef LocalSecretReference `json:"secretRef"`
 
+	// CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef
+	// +optional
+	CreateTargetToSource bool `json:"createTargetToSource,omitempty"`
+
+	// TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+	// is set on true. If TargetToSourceName is empty SourceNamespace is used instead.
+	// +optional
+	TargetToSourceName string `json:"targetToSourceName,omitempty"`
+
 	// SecretNameExpression defines the names of the secrets which should be synced via a regular expression according
 	// to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches
 	// all names.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -3192,6 +3192,8 @@ func autoConvert_v1alpha1_TargetSyncSpec_To_core_TargetSyncSpec(in *TargetSyncSp
 	if err := Convert_v1alpha1_LocalSecretReference_To_core_LocalSecretReference(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	out.CreateTargetToSource = in.CreateTargetToSource
+	out.TargetToSourceName = in.TargetToSourceName
 	out.SecretNameExpression = in.SecretNameExpression
 	out.ShootNameExpression = in.ShootNameExpression
 	out.TokenRotation = (*core.TokenRotation)(unsafe.Pointer(in.TokenRotation))
@@ -3208,6 +3210,8 @@ func autoConvert_core_TargetSyncSpec_To_v1alpha1_TargetSyncSpec(in *core.TargetS
 	if err := Convert_core_LocalSecretReference_To_v1alpha1_LocalSecretReference(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	out.CreateTargetToSource = in.CreateTargetToSource
+	out.TargetToSourceName = in.TargetToSourceName
 	out.SecretNameExpression = in.SecretNameExpression
 	out.ShootNameExpression = in.ShootNameExpression
 	out.TokenRotation = (*TokenRotation)(unsafe.Pointer(in.TokenRotation))

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@
 - [Landscaper Cli Usage](usage/LandscaperCli.md)
 - [Configuring the Landscaper Logs](usage/Logging.md)
 - [Repository Context](usage/RepositoryContext.md)
+- [TargetList Imports](usage/TargetLists.md)
 - [TargetSync Objects ](usage/TargetSyncs.md)
 - [Targets](usage/Targets.md)
 - [Templating](usage/Templating.md)

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1548,6 +1548,31 @@ LocalSecretReference
 </tr>
 <tr>
 <td>
+<code>createTargetToSource</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetToSourceName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+is set on true. If TargetToSourceName is empty SourceNamespace is used instead.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secretNameExpression</code></br>
 <em>
 string
@@ -5516,6 +5541,31 @@ LocalSecretReference
 </td>
 <td>
 <p>SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>createTargetToSource</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetToSourceName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+is set on true. If TargetToSourceName is empty SourceNamespace is used instead.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/TargetSyncs.md
+++ b/docs/usage/TargetSyncs.md
@@ -135,6 +135,28 @@ The entries of a *TargetSync* object have the following meaning:
 An example how to create a *TargetSync* object could be found 
 [here](https://github.com/gardener/landscaper-examples/tree/master/sync-targets/example1).
 
+## Target to Source Cluster
+
+It is also possible to automatically create a target to the source cluster from where the targets to the shoots
+or the secrets are synchronized. This target just references the same secret as the *TargetSync* object. This allows
+e.g. the creation of shoot cluster manifests in the source namespace if this is the namespace of a Gardener project.
+
+The required configuration in the *TargetSync* object is as follows:
+
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: TargetSync
+metadata:
+  name: <some name>
+  namespace: <Namespace 1>
+spec:
+  createTargetToSource: true
+  targetToSourceName: <some name> # optional
+  ...
+```
+
+*targetToSourceName* is the name of the target. If this is not set, the target gets the name of the *sourceNamespace*.
+
 ## Token Rotation
 
 If the field `tokenRotation.enabled` is set on true, the token in the kubeconfig of the secret referenced by

--- a/pkg/landscaper/controllers/targetsync/testdata/state/test1/target-sync.yaml
+++ b/pkg/landscaper/controllers/targetsync/testdata/state/test1/target-sync.yaml
@@ -9,3 +9,5 @@ spec:
     key: kubeconfig
     name: test-target-sync
   sourceNamespace: {{ .Namespace2 }}
+  createTargetToSource: true
+  targetToSourceName: test-source-target-name

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_targetsyncs.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_targetsyncs.yaml
@@ -21,6 +21,10 @@ spec:
           spec:
             description: Spec contains the specification
             properties:
+              createTargetToSource:
+                description: CreateTargetToSource specifies if set on true, that also
+                  a target is created, which references the secret in SecretRef
+                type: boolean
               secretNameExpression:
                 description: SecretNameExpression defines the names of the secrets
                   which should be synced via a regular expression according to https://github.com/google/re2/wiki/Syntax
@@ -51,6 +55,11 @@ spec:
               sourceNamespace:
                 description: SourceNamespace describes the namespace from where the
                   secrets should be synced
+                type: string
+              targetToSourceName:
+                description: TargetToSourceName is the name of the target referencing
+                  the secret defined in SecretRef if CreateTargetToSource is set on
+                  true. If TargetToSourceName is empty SourceNamespace is used instead.
                 type: string
               tokenRotation:
                 description: TokenRotation defines the data to perform an automatic

--- a/vendor/github.com/gardener/landscaper/apis/core/types_target_sync.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_target_sync.go
@@ -41,6 +41,15 @@ type TargetSyncSpec struct {
 	// SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.
 	SecretRef LocalSecretReference `json:"secretRef"`
 
+	// CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef
+	// +optional
+	CreateTargetToSource bool `json:"createTargetToSource,omitempty"`
+
+	// TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+	// is set on true. If TargetToSourceName is empty SourceNamespace is used instead.
+	// +optional
+	TargetToSourceName string `json:"targetToSourceName,omitempty"`
+
 	// SecretNameExpression defines the names of the secrets which should be synced via a regular expression according
 	// to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches
 	// all names.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target_sync.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target_sync.go
@@ -43,6 +43,15 @@ type TargetSyncSpec struct {
 	// SecretRef references the secret that contains the kubeconfig to the namespace of the secrets to be synced.
 	SecretRef LocalSecretReference `json:"secretRef"`
 
+	// CreateTargetToSource specifies if set on true, that also a target is created, which references the secret in SecretRef
+	// +optional
+	CreateTargetToSource bool `json:"createTargetToSource,omitempty"`
+
+	// TargetToSourceName is the name of the target referencing the secret defined in SecretRef if CreateTargetToSource
+	// is set on true. If TargetToSourceName is empty SourceNamespace is used instead.
+	// +optional
+	TargetToSourceName string `json:"targetToSourceName,omitempty"`
+
 	// SecretNameExpression defines the names of the secrets which should be synced via a regular expression according
 	// to https://github.com/google/re2/wiki/Syntax with the extension that * is also a valid expression and matches
 	// all names.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -3192,6 +3192,8 @@ func autoConvert_v1alpha1_TargetSyncSpec_To_core_TargetSyncSpec(in *TargetSyncSp
 	if err := Convert_v1alpha1_LocalSecretReference_To_core_LocalSecretReference(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	out.CreateTargetToSource = in.CreateTargetToSource
+	out.TargetToSourceName = in.TargetToSourceName
 	out.SecretNameExpression = in.SecretNameExpression
 	out.ShootNameExpression = in.ShootNameExpression
 	out.TokenRotation = (*core.TokenRotation)(unsafe.Pointer(in.TokenRotation))
@@ -3208,6 +3210,8 @@ func autoConvert_core_TargetSyncSpec_To_v1alpha1_TargetSyncSpec(in *core.TargetS
 	if err := Convert_core_LocalSecretReference_To_v1alpha1_LocalSecretReference(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	out.CreateTargetToSource = in.CreateTargetToSource
+	out.TargetToSourceName = in.TargetToSourceName
 	out.SecretNameExpression = in.SecretNameExpression
 	out.ShootNameExpression = in.ShootNameExpression
 	out.TokenRotation = (*TokenRotation)(unsafe.Pointer(in.TokenRotation))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR implements the creation of a target referencing the same secret as the target sync object. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
