### PR TITLE
Check Interruption of Readiness Check and Export Collection

### DIFF
--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -206,6 +206,7 @@ func (h *Helm) checkResourcesReady(ctx context.Context, client client.Client, fa
 			Timeout:             h.ProviderConfiguration.ReadinessChecks.Timeout,
 			ManagedResources:    h.ProviderStatus.ManagedResources.TypedObjectReferenceList(),
 			FailOnMissingObject: failOnMissingObject,
+			InterruptionChecker: deployerlib.NewInterruptionChecker(h.DeployItem, h.lsKubeClient),
 		}
 		err := defaultReadinessCheck.CheckResourcesReady()
 		if err != nil {
@@ -216,12 +217,13 @@ func (h *Helm) checkResourcesReady(ctx context.Context, client client.Client, fa
 	if h.ProviderConfiguration.ReadinessChecks.CustomReadinessChecks != nil {
 		for _, customReadinessCheckConfig := range h.ProviderConfiguration.ReadinessChecks.CustomReadinessChecks {
 			customReadinessCheck := health.CustomReadinessCheck{
-				Context:          ctx,
-				Client:           client,
-				CurrentOp:        "CustomCheckResourcesReadinessHelm",
-				Timeout:          h.ProviderConfiguration.ReadinessChecks.Timeout,
-				ManagedResources: h.ProviderStatus.ManagedResources.TypedObjectReferenceList(),
-				Configuration:    customReadinessCheckConfig,
+				Context:             ctx,
+				Client:              client,
+				CurrentOp:           "CustomCheckResourcesReadinessHelm",
+				Timeout:             h.ProviderConfiguration.ReadinessChecks.Timeout,
+				ManagedResources:    h.ProviderStatus.ManagedResources.TypedObjectReferenceList(),
+				Configuration:       customReadinessCheckConfig,
+				InterruptionChecker: deployerlib.NewInterruptionChecker(h.DeployItem, h.lsKubeClient),
 			}
 			err := customReadinessCheck.CheckResourcesReady()
 			if err != nil {
@@ -245,10 +247,9 @@ func (h *Helm) readExportValues(ctx context.Context, currOp string, targetClient
 	}
 	if len(exportDefinition.Exports) != 0 {
 		opts := resourcemanager.ExporterOptions{
-			KubeClient: targetClient,
-			Objects:    managedResourceStatusList,
-			DeployItem: h.DeployItem,
-			LsClient:   h.lsKubeClient,
+			KubeClient:          targetClient,
+			Objects:             managedResourceStatusList,
+			InterruptionChecker: deployerlib.NewInterruptionChecker(h.DeployItem, h.lsKubeClient),
 		}
 		if h.Configuration.Export.DefaultTimeout != nil {
 			opts.DefaultTimeout = &h.Configuration.Export.DefaultTimeout.Duration

--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -247,6 +247,8 @@ func (h *Helm) readExportValues(ctx context.Context, currOp string, targetClient
 		opts := resourcemanager.ExporterOptions{
 			KubeClient: targetClient,
 			Objects:    managedResourceStatusList,
+			DeployItem: h.DeployItem,
+			LsClient:   h.lsKubeClient,
 		}
 		if h.Configuration.Export.DefaultTimeout != nil {
 			opts.DefaultTimeout = &h.Configuration.Export.DefaultTimeout.Duration

--- a/pkg/deployer/lib/interruption_checker.go
+++ b/pkg/deployer/lib/interruption_checker.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
+)
+
+type InterruptionChecker struct {
+	deployItem *lsv1alpha1.DeployItem
+	lsClient   client.Client
+}
+
+func NewInterruptionChecker(deployItem *lsv1alpha1.DeployItem, lsClient client.Client) *InterruptionChecker {
+	return &InterruptionChecker{
+		deployItem: deployItem,
+		lsClient:   lsClient,
+	}
+}
+
+func (c *InterruptionChecker) Check(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+
+	di := &lsv1alpha1.DeployItem{}
+	err := read_write_layer.GetDeployItem(ctx, c.lsClient, client.ObjectKeyFromObject(c.deployItem), di)
+	if err != nil {
+		return err
+	}
+
+	if di.Status.DeployItemPhase == lsv1alpha1.DeployItemPhaseFailed {
+		return fmt.Errorf("interrupted during readiness check/export collection")
+	}
+
+	return nil
+}

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -24,17 +24,19 @@ import (
 	health "github.com/gardener/landscaper/apis/deployer/utils/readinesschecks"
 	lserror "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/pkg/deployer/lib"
 	"github.com/gardener/landscaper/pkg/utils"
 )
 
 // CustomReadinessCheck contains all the data and methods required to kick off a custom readiness check
 type CustomReadinessCheck struct {
-	Context          context.Context
-	Client           client.Client
-	CurrentOp        string
-	Timeout          *lsv1alpha1.Duration
-	ManagedResources []lsv1alpha1.TypedObjectReference
-	Configuration    health.CustomReadinessCheckConfiguration
+	Context             context.Context
+	Client              client.Client
+	CurrentOp           string
+	Timeout             *lsv1alpha1.Duration
+	ManagedResources    []lsv1alpha1.TypedObjectReference
+	Configuration       health.CustomReadinessCheckConfiguration
+	InterruptionChecker *lib.InterruptionChecker
 }
 
 // CheckResourcesReady starts a custom readiness check by checking the readiness of the submitted resources
@@ -59,7 +61,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady() error {
 	}
 
 	timeout := c.Timeout.Duration
-	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject); err != nil {
+	if err := WaitForObjectsReady(c.Context, timeout, c.Client, objects, c.CheckObject, c.InterruptionChecker); err != nil {
 		return lserror.NewWrappedError(err,
 			c.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}

--- a/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
@@ -19,6 +19,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lserror "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/pkg/deployer/lib"
 )
 
 // DefaultReadinessCheck contains all the data and methods required to kick off a default readiness check
@@ -29,6 +30,7 @@ type DefaultReadinessCheck struct {
 	Timeout             *lsv1alpha1.Duration
 	ManagedResources    []lsv1alpha1.TypedObjectReference
 	FailOnMissingObject bool
+	InterruptionChecker *lib.InterruptionChecker
 }
 
 // CheckResourcesReady implements the default readiness check for Kubernetes manifests
@@ -50,7 +52,7 @@ func (d *DefaultReadinessCheck) CheckResourcesReady() error {
 	objects = d.filterObjects(objects)
 
 	timeout := d.Timeout.Duration
-	if err := WaitForObjectsReady(d.Context, timeout, d.Client, objects, d.CheckObject); err != nil {
+	if err := WaitForObjectsReady(d.Context, timeout, d.Client, objects, d.CheckObject, d.InterruptionChecker); err != nil {
 		return lserror.NewWrappedError(err,
 			d.CurrentOp, "CheckResourceReadiness", err.Error(), lsv1alpha1.ErrorReadinessCheckTimeout)
 	}

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -95,6 +95,8 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 		opts := resourcemanager.ExporterOptions{
 			KubeClient: targetClient,
 			Objects:    applier.GetManagedResourcesStatus(),
+			DeployItem: m.DeployItem,
+			LsClient:   m.lsKubeClient,
 		}
 		if m.Configuration.Export.DefaultTimeout != nil {
 			opts.DefaultTimeout = &m.Configuration.Export.DefaultTimeout.Duration

--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 
 	"github.com/imdario/mergo"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -93,10 +92,9 @@ func (m *Manifest) Reconcile(ctx context.Context) error {
 
 	if m.ProviderConfiguration.Exports != nil {
 		opts := resourcemanager.ExporterOptions{
-			KubeClient: targetClient,
-			Objects:    applier.GetManagedResourcesStatus(),
-			DeployItem: m.DeployItem,
-			LsClient:   m.lsKubeClient,
+			KubeClient:          targetClient,
+			Objects:             applier.GetManagedResourcesStatus(),
+			InterruptionChecker: deployerlib.NewInterruptionChecker(m.DeployItem, m.lsKubeClient),
 		}
 		if m.Configuration.Export.DefaultTimeout != nil {
 			opts.DefaultTimeout = &m.Configuration.Export.DefaultTimeout.Duration
@@ -129,6 +127,7 @@ func (m *Manifest) CheckResourcesReady(ctx context.Context, client client.Client
 			Timeout:             m.ProviderConfiguration.ReadinessChecks.Timeout,
 			ManagedResources:    managedresources,
 			FailOnMissingObject: true,
+			InterruptionChecker: deployerlib.NewInterruptionChecker(m.DeployItem, m.lsKubeClient),
 		}
 		err := defaultReadinessCheck.CheckResourcesReady()
 		if err != nil {
@@ -143,12 +142,13 @@ func (m *Manifest) CheckResourcesReady(ctx context.Context, client client.Client
 				timeout = m.ProviderConfiguration.ReadinessChecks.Timeout
 			}
 			customReadinessCheck := health.CustomReadinessCheck{
-				Context:          ctx,
-				Client:           client,
-				CurrentOp:        "CustomCheckResourcesReadinessManifest",
-				Timeout:          timeout,
-				ManagedResources: managedresources,
-				Configuration:    customReadinessCheckConfig,
+				Context:             ctx,
+				Client:              client,
+				CurrentOp:           "CustomCheckResourcesReadinessManifest",
+				Timeout:             timeout,
+				ManagedResources:    managedresources,
+				Configuration:       customReadinessCheckConfig,
+				InterruptionChecker: deployerlib.NewInterruptionChecker(m.DeployItem, m.lsKubeClient),
 			}
 			err := customReadinessCheck.CheckResourcesReady()
 			if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

Currently, the helm and manifest deployers wait during a readiness check and during the collection of export values. (This behaviour is not changed by this pull request.) This pull request adds a check whether the deploy item was interrupted in the meantime. In this case the readiness check (resp. export collection) is stopped.

Without this fix, an interrupted deploy item might appear finished (phase = Failed), although the deployer is still processing it. If you then trigger a new reconcile, the new reconcile of the deploy item does not start until the current reconcile has really finished, for example due to a timeout.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
