### PR TITLE
Wait Intervals during Export Collection

### DIFF
--- a/pkg/deployer/lib/resourcemanager/exporter.go
+++ b/pkg/deployer/lib/resourcemanager/exporter.go
@@ -96,11 +96,12 @@ func (e *Exporter) Export(ctx context.Context, exports *managedresource.Exports)
 			log2 := log.WithValues(lc.KeyExportKey, export.Key)
 
 			backoff := wait.Backoff{
-				Jitter: 1.15,
-				Steps:  math.MaxInt32,
-				Cap:    export.Timeout.Duration,
+				Duration: 2 * time.Second,
+				Jitter:   1.15,
+				Steps:    math.MaxInt32,
 			}
 			var lastErr error
+			// The waiting intervals do not increase exponentially, because no backoff factor is set
 			if err := wait.ExponentialBackoffWithContext(ctx, backoff, func() (done bool, err error) {
 
 				if err := e.interruptionChecker.Check(ctx); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

During the collection of export parameters, the helm and manifest deployers read values from the target cluster. This is repeated until the values are found or a timeout is reached. Currently, there is no wait interval between the retries. The present pull request fixes this. We use a constant wait interval (plus some jitter).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- There was no wait interval between the retries, because `backoff.Duration` was missing in the backoff object for the `wait.ExponentialBackoffWithContext` function.

- The timeout is managed by the context: `ctx, cancel := context.WithTimeout(ctx, export.Timeout.Duration)`, not by `backoff.Cap`. 

- Function `wait.ExponentialBackoffWithContext` was probably only used, because it allows to specify a jitter. The intervals do not exponentially grow, because `backoff.Factor` is not set. 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
