### PR TITLE
add dns settings to landscaper webhook ingress

### DIFF
--- a/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/landscaper/deploy-execution.yaml
@@ -88,6 +88,9 @@ deployItems:
 
           ingress:
             host: {{ .imports.webhooksHostName }}
+            className: nginx
+            dns:
+              class: garden
 
         service:
           type: ClusterIP

--- a/charts/landscaper/charts/landscaper/templates/ingress.yaml
+++ b/charts/landscaper/charts/landscaper/templates/ingress.yaml
@@ -4,11 +4,15 @@ kind: Ingress
 metadata:
   name: {{ include "landscaper.webhooks.fullname" . }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+{{- if .Values.webhooksServer.ingress.dns }}
+    dns.gardener.cloud/class: {{ .Values.webhooksServer.ingress.dns.class }}
+    dns.gardener.cloud/dnsnames: {{ .Values.webhooksServer.ingress.host }}
+{{- end }}
   labels:
     {{- include "landscaper.labels" . | nindent 4 }}
 spec:
+  ingressClassName: {{ .Values.webhooksServer.ingress.className }}
   rules:
     - host: {{ .Values.webhooksServer.ingress.host }}
       http:

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -130,7 +130,11 @@ webhooksServer:
   # Specify to create a webhooks server ingress in combination with "landscaperKubeconfig".
   # This is needed when the webhooks server pod is placed on a different cluster than the landscaper resources.
   # ingress:
-  #  host: webhooks.ingress.mydomain.net
+  #   host: webhooks.ingress.mydomain.net
+  #   className: nginx
+  #   # enable the gardener dns extension to create a DNS entry for this ingress.
+  #   dns:
+  #     class: garden
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 3

**What this PR does / why we need it**:

For operating our own ingress controller, the webhooks server ingress needs to be annotated with garden dns settings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add dns settings to landscaper webhook ingress.
```
