### PR TITLE
Improve int tests

### DIFF
--- a/test/integration/executions/generations.go
+++ b/test/integration/executions/generations.go
@@ -101,7 +101,7 @@ func GenerationHandlingTestsForNewReconcile(f *framework.Framework) {
 			exec.Spec.DeployItems[0].Configuration = &runtime.RawExtension{
 				Raw: rawMockConfig,
 			}
-			utils.ExpectNoError(f.Client.Update(ctx, exec))
+			utils.ExpectNoError(state.Update(ctx, exec))
 
 			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(utils.UpdateJobIdForExecutionC(ctx, state.Client, exec)).To(Succeed())

--- a/test/integration/targets/targets.go
+++ b/test/integration/targets/targets.go
@@ -207,7 +207,7 @@ func TargetTests(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target, path.Join(testdataDir, "installation-target-root-1", "target-1-updated.yaml")))
 			target.SetNamespace(state.Namespace)
 			target.ObjectMeta.ResourceVersion = targetOld.ObjectMeta.ResourceVersion
-			utils.ExpectNoError(f.Client.Update(ctx, target))
+			utils.ExpectNoError(state.Update(ctx, target))
 
 			By("Reconcile Installation")
 			instOld := &lsv1alpha1.Installation{}
@@ -259,7 +259,7 @@ func TargetTests(f *framework.Framework) {
 			utils.ExpectNoError(utils.ReadResourceFromFile(target2, path.Join(testdataDir, "installation-target-root-1", "target-2-updated.yaml")))
 			target2.SetNamespace(state.Namespace)
 			target2.ObjectMeta.ResourceVersion = target2Old.ObjectMeta.ResourceVersion
-			utils.ExpectNoError(f.Client.Update(ctx, target2))
+			utils.ExpectNoError(state.Update(ctx, target2))
 
 			By("Reconcile Installation")
 			utils.ExpectNoError(utils.UpdateInstallationFromFile(ctx, state.State, inst, path.Join(testdataDir, "installation-target-root-1", "installation-2.yaml")))

--- a/test/integration/tutorial/ingress-nginx.go
+++ b/test/integration/tutorial/ingress-nginx.go
@@ -82,7 +82,7 @@ func NginxIngressTestForNewReconcile(f *framework.Framework) {
 			utils.ExpectNoError(f.Client.Get(ctx, instKey, inst))
 			inst.Spec.ComponentDescriptor.Reference.Version = "v0.3.3"
 			lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
-			err = f.Client.Update(ctx, inst)
+			err = state.Update(ctx, inst)
 			utils.ExpectNoError(err)
 
 			// wait for installation to finish

--- a/test/integration/webhook/webhook.go
+++ b/test/integration/webhook/webhook.go
@@ -142,7 +142,7 @@ func WebhookTest(f *framework.Framework) {
 
 			updated := di.DeepCopy()
 			updated.Spec.Type = "other-type"
-			err = f.Client.Update(ctx, updated)
+			err = state.Update(ctx, updated)
 			Expect(err).To(HaveOccurred()) // validation webhook should have denied this
 			Expect(err.Error()).To(HavePrefix("admission webhook \"deployitems.validation.landscaper.gardener.cloud\" denied the request"))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind test
/priority 3

**What this PR does / why we need it**:

Make int tests more robust.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
