### PR TITLE
add audit configuration to landscaper-service component

### DIFF
--- a/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
@@ -63,7 +63,7 @@ imports:
     required: false
     type: data
     schema:
-      type: string
+      type: object
 
   - name: subaccountId
     required: false

--- a/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/blueprint.yaml
@@ -59,6 +59,18 @@ imports:
         The "shootConfig" Specifies the gardener shoot configuration.
       $ref: "cd://resources/shoot-config-definition"
 
+  - name: auditPolicy
+    required: false
+    type: data
+    schema:
+      type: string
+
+  - name: subaccountId
+    required: false
+    type: data
+    schema:
+      type: string
+
   - name: registryConfig
     type: data
     schema:

--- a/.landscaper/landscaper-service/blueprint/installation/shoot-cluster-subinst.yaml
+++ b/.landscaper/landscaper-service/blueprint/installation/shoot-cluster-subinst.yaml
@@ -22,6 +22,10 @@ imports:
       dataRef: shootSecretBindingName
     - name: shootConfig
       dataRef: shootConfig
+    - name: auditPolicy
+      dataRef: auditPolicy
+    - name: subaccountId
+      dataRef: subaccountId
 
 exports:
   targets:

--- a/.landscaper/landscaper-service/blueprint/shoot/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/shoot/blueprint.yaml
@@ -36,6 +36,18 @@ imports:
     schema:
       $ref: "cd://resources/shoot-config-definition"
 
+  - name: auditPolicy
+    required: false
+    type: data
+    schema:
+      type: string
+
+  - name: subaccountId
+    required: false
+    type: data
+    schema:
+      type: string
+
 exports:
   - name: shootClusterKubeconfig
     type: data

--- a/.landscaper/landscaper-service/blueprint/shoot/blueprint.yaml
+++ b/.landscaper/landscaper-service/blueprint/shoot/blueprint.yaml
@@ -40,7 +40,7 @@ imports:
     required: false
     type: data
     schema:
-      type: string
+      type: object
 
   - name: subaccountId
     required: false

--- a/.landscaper/landscaper-service/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/shoot/deploy-execution.yaml
@@ -40,6 +40,23 @@ deployItems:
       deleteTimeout: 30m
 
       manifests:
+        {{ if .imports.auditPolicy }}
+        - policy: manage
+          manifest:
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: {{ .imports.name }}-audit-policy
+              namespace: {{ .imports.namespace }}
+            {{ if .imports.labels }}
+              labels:
+{{ toYaml .imports.labels | indent 16 }}
+            {{ end }}
+            data:
+              policy: |-
+{{ .imports.auditPolicy | indent 16 }}
+        {{ end }}
+
         - policy: manage
           annotateBeforeDelete:
             confirmation.gardener.cloud/deletion: "true"
@@ -51,6 +68,10 @@ deployItems:
               namespace: {{ .imports.namespace }}
               annotations:
                 shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds: '30'
+                gardener.cloud/operation: reconcile
+                {{ if .imports.subaccountId }}
+                custom.shoot.sapcloud.io/subaccountId: {{ .imports.subaccountId }}
+                {{ end }}
             {{ if .imports.labels }}
               labels:
 {{ toYaml .imports.labels | indent 16 }}
@@ -96,6 +117,13 @@ deployItems:
               kubernetes:
                 version: {{ .imports.shootConfig.kubernetes.version }}
                 enableStaticTokenKubeconfig: true
+                {{ if .imports.auditPolicy }}
+                kubeAPIServer:
+                  auditConfig:
+                    auditPolicy:
+                      configMapRef:
+                        name: {{ .imports.name }}-audit-policy
+                {{ end }}
               purpose: production
               maintenance:
                 timeWindow:

--- a/.landscaper/landscaper-service/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-service/blueprint/shoot/deploy-execution.yaml
@@ -54,7 +54,7 @@ deployItems:
             {{ end }}
             data:
               policy: |-
-{{ .imports.auditPolicy | indent 16 }}
+{{ toYaml .imports.auditPolicy | indent 16 }}
         {{ end }}
 
         - policy: manage

--- a/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
+++ b/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
@@ -178,10 +178,13 @@ var _ = Describe("Landscaper Service Component", func() {
 
 	It("should install the shoot cluster blueprint", func() {
 		imports := GetImports(filepath.Join(testData, "imports-shoot.yaml"))
-		auditPolicy, err := os.ReadFile(filepath.Join(testData, "auditpolicy.yaml"))
+		auditPolicyRaw, err := os.ReadFile(filepath.Join(testData, "auditpolicy.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 
-		imports["auditPolicy"] = string(auditPolicy)
+		var auditPolicy map[string]interface{}
+		err = yaml.Unmarshal(auditPolicyRaw, &auditPolicy)
+		Expect(err).ToNot(HaveOccurred())
+		imports["auditPolicy"] = auditPolicy
 
 		renderer := lsutils.NewBlueprintRenderer(&cdList, registry, &repositoryContext)
 		out, err := renderer.RenderDeployItemsAndSubInstallations(&lsutils.ResolvedInstallation{

--- a/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
+++ b/test/landscaper/landscaper_service_blueprints/landscaper_service_blueprint_test.go
@@ -7,11 +7,12 @@ package landscaper_service_blueprints_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/gardener/landscaper/pkg/deployer/manifest"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gardener/landscaper/pkg/deployer/manifest"
 
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
@@ -176,12 +177,18 @@ var _ = Describe("Landscaper Service Component", func() {
 	})
 
 	It("should install the shoot cluster blueprint", func() {
+		imports := GetImports(filepath.Join(testData, "imports-shoot.yaml"))
+		auditPolicy, err := os.ReadFile(filepath.Join(testData, "auditpolicy.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+
+		imports["auditPolicy"] = string(auditPolicy)
+
 		renderer := lsutils.NewBlueprintRenderer(&cdList, registry, &repositoryContext)
 		out, err := renderer.RenderDeployItemsAndSubInstallations(&lsutils.ResolvedInstallation{
 			ComponentDescriptor: landscaperServiceCD,
 			Installation:        &lsv1alpha1.Installation{},
 			Blueprint:           GetBlueprint(filepath.Join(projectRoot, ".landscaper/landscaper-service/blueprint/shoot")),
-		}, GetImports(filepath.Join(testData, "imports-shoot.yaml")))
+		}, imports)
 
 		testutils.ExpectNoError(err)
 		Expect(out.DeployItems).To(HaveLen(1))

--- a/test/landscaper/landscaper_service_blueprints/testdata/auditpolicy.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/auditpolicy.yaml
@@ -1,0 +1,62 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+  - level: None
+    users:
+      - "gardener"
+      - "kubelet"
+      - "etcd-client"
+      - "vpn-seed"
+      - "aws-lb-readvertiser"
+      - "cloud-config-downloader"
+      - "system:kube-apiserver:kubelet"
+      - "system:kube-controller-manager"
+      - "system:kube-aggregator"
+      - "system:kube-scheduler"
+      - "system:kube-addon-manager"
+      - "system:kube-aggregator"
+      - "system:kube-proxy"
+      - "system:cluster-autoscaler"
+      - "system:machine-controller-manager"
+      - "system:cloud-controller-manager"
+      - "system:apiserver"
+      - "garden.sapcloud.io:system:cert-broker"
+      - "gardener.cloud:system:cert-management"
+      - "gardener.cloud:system:gardener-resource-manager"
+  - level: None
+    userGroups:
+      - "system:nodes"
+      - "system:serviceaccounts:kube-system"
+      - "garden.sapcloud.io:monitoring"
+  - level: None
+    resources:
+      - group: ""
+        resources: ["secrets", "events", "configmaps", "tokenreviews"]
+  - level: None
+    verbs: ["watch", "get", "list"]
+  - level: None
+    nonResourceURLs:
+      - /*
+  - level: Metadata
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "coordination.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "settings.k8s.io"
+      - group: "storage.k8s.io"

--- a/test/landscaper/landscaper_service_blueprints/testdata/imports-installation.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/imports-installation.yaml
@@ -78,7 +78,8 @@ imports:
       version: 1.24.6
 
   subaccountId: abcdef
-  auditPolicy: foobar
+  auditPolicy:
+    foo: bar
 
   registryConfig:
     cache:

--- a/test/landscaper/landscaper_service_blueprints/testdata/imports-installation.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/imports-installation.yaml
@@ -77,6 +77,9 @@ imports:
     kubernetes:
       version: 1.24.6
 
+  subaccountId: abcdef
+  auditPolicy: foobar
+
   registryConfig:
     cache:
       useInMemoryOverlay: false

--- a/test/landscaper/landscaper_service_blueprints/testdata/imports-shoot.yaml
+++ b/test/landscaper/landscaper_service_blueprints/testdata/imports-shoot.yaml
@@ -45,3 +45,5 @@ imports:
     region: europe-west1
     kubernetes:
       version: 1.24.6
+
+  subaccountId: abcdef


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area laas
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Add audit log configuration to landscaper-service component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add audit log configuration to landscaper-service component.
```
