### PR TITLE
Add missing refs to component descriptor

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -55,6 +55,10 @@ component-cli ca resources add ${LS_CA_PATH} \
     VERSION=${VERSION} \
     ${SOURCE_PATH}/.landscaper/resources.yaml
 
+component-cli ca component-references add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    ${SOURCE_PATH}/.landscaper/component-references.yaml
+
 printf "> Add Landscaper CA to ctf\n"
 component-cli ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
 

--- a/.landscaper/component-references.yaml
+++ b/.landscaper/component-references.yaml
@@ -1,0 +1,21 @@
+---
+componentName: github.com/gardener/landscaper/container-deployer
+name: landscaper
+version: ${VERSION}
+...
+---
+componentName: github.com/gardener/landscaper/helm-deployer
+name: landscaper
+version: ${VERSION}
+...
+---
+componentName: github.com/gardener/landscaper/manifest-deployer
+name: landscaper
+version: ${VERSION}
+...
+---
+componentName: github.com/gardener/landscaper/mock-deployer
+name: landscaper
+version: ${VERSION}
+...
+

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -7,6 +7,20 @@ access:
   imageReference: eu.gcr.io/gardener-project/landscaper/charts/landscaper:${VERSION}
 ---
 type: helm.io/chart
+name: landscaper-controller-rbac-chart
+relation: local
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/landscaper-rbac:${VERSION}
+---
+type: helm.io/chart
+name: landscaper-controller-deployment-chart
+relation: local
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper/charts/landscaper-controller:${VERSION}
+---
+type: helm.io/chart
 name: landscaper-agent-chart
 relation: local
 access:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Add missing refs to component descriptor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
