### PR TITLE
use minimalistic helm chart instead of nginx chart for helm deployer test

### DIFF
--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -94,10 +94,7 @@ func DeployerBlueprintTests(f *framework.Framework) {
 			ComponentDescriptorName: "github.com/gardener/landscaper/helm-deployer",
 			BlueprintResourceName:   "helm-deployer-blueprint",
 			DeployItem: func(state *envtest.State, target *lsv1alpha1.Target) (*lsv1alpha1.DeployItem, error) {
-				ref := "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18"
-				if !f.RunOnShoot {
-					ref = "eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0"
-				}
+				ref := "eu.gcr.io/gardener-project/landscaper/integration-tests/charts/hello-world:1.0.0"
 				return helm.NewDeployItemBuilder().
 					Key(state.Namespace, "my-di").
 					Target(target.Namespace, target.Name).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Instead of deploying the nginx helm chart from the tutorial, the helm deployer integration test will now use the minimalistic helm chart from [here](https://github.com/gardener/landscaper-examples/tree/master/hello-world).
Some failures of the integration test seem to not come from any problems within the Landscaper, but from helm itself. Reducing the complexity of the used helm chart will hopefully increase the stability and reduce false positives of the integration tests.

Disadvantage: This creates kind of a dependency between the Landscaper and the Landscaper examples repo. On the other hand: The uploaded helm chart, which is now referenced in the integration test, won't change in the OCI registry, so incompatibilities are only expected if there are breaking changes in the Landscaper itself, and then we want to update the examples anyway, so I don't see too much of a problem here.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The deployer blueprint integration tests now use a minimalistic helm chart for verifying the helm deployer instead of the nginx helm chart from the tutorial. This is supposed to improve stability of the integration tests.
```
