### PR TITLE
Docu for Kubeconfig Templating Functions

### DIFF
--- a/docs/usage/Templating.md
+++ b/docs/usage/Templating.md
@@ -156,6 +156,61 @@ The following additional functions are available:
    type: ociRegistry
    imageReference: host:5000/myrepo/myimage:1.0.0
    ```
+  
+- **`getShootAdminKubeconfig(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+  returns a temporary admin kubeconfig for a Gardener Shoot cluster as described 
+  [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md#shootsadminkubeconfig-subresource). 
+  The kubeconfig is returned as base64 encoded string.  
+
+  Arguments:
+  - `shootName` the name of the shoot cluster  
+  - `shootNamespace` the namespace of the Gardener project to which the Shoot belongs: `garden-<PROJECT NAME>`  
+  - `expirationSeconds` the number of seconds after which the kubeconfig expires.  
+  - `target` a Target that contains a kubeconfig for the Gardener project to which the Shoot belongs.  
+
+  Here is an example of an export execution that uses the `getShootAdminKubeconfig` function. 
+  ```yaml
+  export-execution.yaml: |
+    exports:
+      {{- $kubeconfig := getShootAdminKubeconfig .imports.shootName .imports.shootNamespace 86400 .imports.gardenerServiceAccount | b64dec }}
+      shootAdminKubeconfig: |
+        {{- nindent 4 $kubeconfig }}
+      shootAdminTarget:
+        type: landscaper.gardener.cloud/kubernetes-cluster
+        config:
+          kubeconfig: |
+            {{- nindent 8 $kubeconfig }}
+  ```
+  It constructs two export values: `shootAdminKubeconfig` returns the kubeconfig as string, and `shootAdminTarget` 
+  returns the kubeconfig wrapped in a Target. You can find the full example 
+  [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/shoot-admin-kubeconfig).  
+
+- **`getServiceAccountKubeconfig(serviceAccountName, serviceAccountNamespace string, expirationSeconds int, target Target): string`**
+  returns a kubeconfig for a cluster. The kubeconfig will contain a token obtained by a 
+  [token request](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) 
+  for the specified ServiceAccount. The kubeconfig is returned as base64 encoded string.
+
+  Arguments:
+  - `serviceAccountName` the name of the ServiceAccount  
+  - `serviceAccountNamespace` the namespace of the ServiceAccount  
+  - `expirationSeconds` the number of seconds after which the kubeconfig expires.  
+  - `target` a Target that contains a kubeconfig for the cluster.  
+
+  Example:
+  ```yaml
+  export-execution.yaml: |
+    exports:
+      {{- $kubeconfig := getServiceAccountKubeconfig .imports.serviceAccountName .imports.serviceAccountNamespace 7776000 .imports.cluster | b64dec }}
+      serviceAccountKubeconfig: |
+        {{- nindent 4 $kubeconfig }}
+      serviceAccountTarget:
+        type: landscaper.gardener.cloud/kubernetes-cluster
+        config:
+          kubeconfig: |
+            {{- nindent 8 $kubeconfig }}
+  ```
+  You can find the full example
+  [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/service-account-kubeconfig).
 
 
 ##### State


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This pull request adds documentation for the templating functions `getShootAdminKubeconfig` and `getServiceAccountKubeconfig`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- New templating functions for kubeconfigs
```
