### PR TITLE
Templating Function to Build OIDC Kubeconfigs

### DIFF
--- a/pkg/utils/token/oidc_kubeconfig_builder.go
+++ b/pkg/utils/token/oidc_kubeconfig_builder.go
@@ -1,0 +1,87 @@
+package token
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
+	"github.com/gardener/landscaper/pkg/utils/targetresolver"
+)
+
+func BuildOIDCKubeconfig(ctx context.Context, issuerURL, clientID string, target *v1alpha1.Target,
+	targetResolver targetresolver.TargetResolver) (string, error) {
+
+	resolvedTarget, err := targetResolver.Resolve(ctx, target)
+	if err != nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: could not resolve target: %w", err)
+	}
+
+	targetConfig := &targettypes.KubernetesClusterTargetConfig{}
+	err = json.Unmarshal([]byte(resolvedTarget.Content), targetConfig)
+	if err != nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: failed to unmarshal target config: %w", err)
+	}
+	if targetConfig.Kubeconfig.StrVal == nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: target config contains no kubeconfig: %w", err)
+	}
+
+	kubeconfigBytes := []byte(*targetConfig.Kubeconfig.StrVal)
+
+	config, err := clientcmd.Load(kubeconfigBytes)
+	if err != nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: failed to load config: %w", err)
+	}
+
+	context, ok := config.Contexts[config.CurrentContext]
+	if !ok || context == nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: current context not found: %w", err)
+	}
+
+	config.Contexts = map[string]*api.Context{
+		config.CurrentContext: context,
+	}
+
+	cluster, ok := config.Clusters[context.Cluster]
+	if !ok || context == nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: current cluster not found: %w", err)
+	}
+
+	config.Clusters = map[string]*api.Cluster{
+		context.Cluster: cluster,
+	}
+
+	config.AuthInfos = map[string]*api.AuthInfo{
+		context.AuthInfo: {
+			Exec: &api.ExecConfig{
+				APIVersion: "client.authentication.k8s.io/v1beta1",
+				Command:    "kubectl",
+				Args: []string{
+					"oidc-login",
+					"get-token",
+					fmt.Sprintf("--oidc-issuer-url=%s", issuerURL),
+					fmt.Sprintf("--oidc-client-id=%s", clientID),
+					"--oidc-extra-scope=email",
+					"--oidc-extra-scope=profile",
+					"--oidc-extra-scope=offline_access",
+					"--oidc-use-pkce",
+					"--grant-type=auto",
+				},
+			},
+		},
+	}
+
+	oidcKubeconfig, err := clientcmd.Write(*config)
+	if err != nil {
+		return "", fmt.Errorf("oidc kubeconfig builder: failed to write config: %w", err)
+	}
+
+	oidcKubeconfig64 := base64.StdEncoding.EncodeToString(oidcKubeconfig)
+
+	return oidcKubeconfig64, nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This pull request adds a templating function `getOidcKubeconfig` to construct an OIDC kubeconfig for a given `issuerURL` and `clientID`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- New templating function to construct an OIDC kubeconfig.
```
