### PR TITLE
Support More Number Types in Templating Functions

### DIFF
--- a/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
@@ -308,9 +308,9 @@ func getShootAdminKubeconfigGoFunc(targetResolver targetresolver.TargetResolver)
 			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a string as 2nd argument, namely the shoot namespace")
 		}
 
-		expirationSeconds, ok := args[2].(int)
-		if !ok {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects an integer as 3rd argument, namely the expiration seconds")
+		expirationSeconds, err := toInt64(args[2])
+		if err != nil {
+			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects an integer as 3rd argument, namely the expiration seconds: %w", err)
 		}
 
 		targetObj := args[3]
@@ -351,9 +351,9 @@ func getServiceAccountKubeconfigGoFunc(targetResolver targetresolver.TargetResol
 			return "", fmt.Errorf("templating function getServiceAccountToken expects a string as 2nd argument, namely the service account namespace")
 		}
 
-		expirationSeconds, ok := args[2].(int)
-		if !ok {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects an integer as 3rd argument, namely the expiration seconds")
+		expirationSeconds, err := toInt64(args[2])
+		if err != nil {
+			return "", fmt.Errorf("templating function getServiceAccountToken expects an integer as 3rd argument, namely the expiration seconds: %w", err)
 		}
 
 		targetObj := args[3]
@@ -374,8 +374,7 @@ func getServiceAccountKubeconfigGoFunc(targetResolver targetresolver.TargetResol
 			return "", err
 		}
 
-		expirationSeconds64 := int64(expirationSeconds)
-		return tokenClient.GetServiceAccountKubeconfig(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds64)
+		return tokenClient.GetServiceAccountKubeconfig(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds)
 	}
 }
 
@@ -409,5 +408,26 @@ func getOidcKubeconfigGoFunc(targetResolver targetresolver.TargetResolver) func(
 
 		ctx := context.Background()
 		return token.BuildOIDCKubeconfig(ctx, issuerURL, clientID, target, targetResolver)
+	}
+}
+
+func toInt64(value interface{}) (int64, error) {
+	switch n := value.(type) {
+	case int64:
+		return n, nil
+	case int32:
+		return int64(n), nil
+	case int16:
+		return int64(n), nil
+	case int8:
+		return int64(n), nil
+	case int:
+		return int64(n), nil
+	case float64:
+		return int64(n), nil
+	case float32:
+		return int64(n), nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T", value)
 	}
 }

--- a/pkg/utils/token/shoot_client.go
+++ b/pkg/utils/token/shoot_client.go
@@ -69,7 +69,7 @@ func (c *ShootClient) ListShoots(ctx context.Context, shootNamespace string) (*u
 }
 
 // GetShootAdminKubeconfig returns a short-lived admin kubeconfig for the specified shoot as base64 encoded string.
-func (c *ShootClient) GetShootAdminKubeconfig(ctx context.Context, shootName, shootNamespace string, kubeconfigExpirationSeconds int) (string, error) {
+func (c *ShootClient) GetShootAdminKubeconfig(ctx context.Context, shootName, shootNamespace string, kubeconfigExpirationSeconds int64) (string, error) {
 
 	adminKubeconfigRequest := unstructured.Unstructured{
 		Object: map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

The templating functions `getShootAdminKubeconfig` and `getServiceAccountKubeconfig` expect a parameter `expirationSeconds`. Depending on how the function is called, the actual type of the provided value varies. With this pull request different number types are supported. 

For example, if the value comes from a DataObject import, the type is `float64`:
```yaml
  {{- $shootAdminKubeconfig := getShootAdminKubeconfig ... .imports.rotationConfig.adminKubeconfigExpirationSeconds ...}}
```  
On the other hand, if the value is directly set, the type is `int`:
```yaml
  {{- $shootAdminKubeconfig := getShootAdminKubeconfig ... 600 ...}}
```  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
