### PR TITLE
Expand Manifests

### DIFF
--- a/pkg/deployer/helm/ensure.go
+++ b/pkg/deployer/helm/ensure.go
@@ -154,6 +154,12 @@ func (h *Helm) createManifests(ctx context.Context, currOp string, files, crds m
 		return nil, lserrors.NewWrappedError(err,
 			currOp, "DecodeHelmTemplatedObjects", err.Error())
 	}
+
+	objects, err = deployerlib.ExpandManifests(objects)
+	if err != nil {
+		return nil, lserrors.NewWrappedError(err, currOp, "ExpandManifests", err.Error())
+	}
+
 	crdObjects, err := kutil.ParseFilesToRawExtension(logger, crds)
 	if err != nil {
 		return nil, lserrors.NewWrappedError(err,

--- a/pkg/deployer/lib/lib_suite_test.go
+++ b/pkg/deployer/lib/lib_suite_test.go
@@ -1,0 +1,13 @@
+package lib
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deployer Library Test Suite")
+}

--- a/pkg/deployer/lib/manifest_expansion.go
+++ b/pkg/deployer/lib/manifest_expansion.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ExpandManifests(manifests []*runtime.RawExtension) ([]*runtime.RawExtension, error) {
+	result := []*runtime.RawExtension{}
+
+	for i := range manifests {
+		manifestList, err := expandManifest(manifests[i])
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, manifestList...)
+	}
+
+	return result, nil
+}
+
+func expandManifest(manifest *runtime.RawExtension) ([]*runtime.RawExtension, error) {
+	manifestList := &metav1.List{}
+	if err := json.Unmarshal(manifest.Raw, &manifestList); err != nil {
+		return nil, fmt.Errorf("unable to expand manifest: %w", err)
+	}
+
+	if len(manifestList.Items) == 0 {
+		return []*runtime.RawExtension{manifest}, nil
+	}
+
+	result := make([]*runtime.RawExtension, len(manifestList.Items))
+	for i := range manifestList.Items {
+		result[i] = &manifestList.Items[i]
+	}
+	return result, nil
+}

--- a/pkg/deployer/lib/manifest_expansion_test.go
+++ b/pkg/deployer/lib/manifest_expansion_test.go
@@ -1,0 +1,60 @@
+package lib
+
+import (
+	"encoding/json"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Manifest expansion", func() {
+
+	buildConfigMap := func(name string) v1.ConfigMap {
+		return v1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "testNamespace"},
+			Data:       map[string]string{"testKey": "testValue"},
+		}
+	}
+
+	buildConfigMapList := func(names ...string) v1.ConfigMapList {
+		items := make([]v1.ConfigMap, len(names))
+		for i := range names {
+			items[i] = buildConfigMap(names[i])
+		}
+		return v1.ConfigMapList{Items: items}
+	}
+
+	raw := func(a any) *runtime.RawExtension {
+		bytes, err := json.Marshal(a)
+		Expect(err).NotTo(HaveOccurred())
+		return &runtime.RawExtension{Raw: bytes}
+	}
+
+	It("should expand manifests", func() {
+		names := []string{"cm1", "cm2", "cm3", "cm4", "cm5", "cm6", "cm7", "cm8"}
+
+		manifests := []*runtime.RawExtension{
+			raw(buildConfigMap("cm1")),
+			raw(buildConfigMapList("cm2", "cm3")),
+			raw(buildConfigMapList("cm4", "cm5", "cm6")),
+			raw(buildConfigMap("cm7")),
+			raw(buildConfigMapList("cm8")),
+		}
+
+		expanded, err := ExpandManifests(manifests)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(expanded).To(HaveLen(8))
+
+		for i, name := range names {
+			cm := &v1.ConfigMap{}
+			Expect(expanded[i]).NotTo(BeNil())
+			Expect(json.Unmarshal(expanded[i].Raw, cm)).To(Succeed())
+			Expect(cm.Name).To(Equal(name))
+		}
+	})
+})

--- a/pkg/deployer/lib/resourcemanager/objectapplier.go
+++ b/pkg/deployer/lib/resourcemanager/objectapplier.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/imdario/mergo"
-
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,13 +25,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
-
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
+	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
 	lserrors "github.com/gardener/landscaper/apis/errors"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+	"github.com/gardener/landscaper/pkg/deployer/lib"
 )
 
 // ApplyManifests creates or updates all configured manifests.
@@ -389,7 +388,13 @@ func (a *ManifestApplier) prepareManifests() error {
 	a.manifestExecutions = [3][]*Manifest{}
 	crdNamespacedInfo := map[string]bool{}
 	todo := []*Manifest{}
-	for _, obj := range a.manifests {
+
+	managedResourceManifests, err := lib.ExpandManagedResourceManifests(a.manifests)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range managedResourceManifests {
 		typeMeta := metav1.TypeMeta{}
 		if err := json.Unmarshal(obj.Manifest.Raw, &typeMeta); err != nil {
 			return fmt.Errorf("unable to parse type metadata: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request fixes a bug in the helm deployer. If a helm chart contains a [list object][1], the status update after the helm deployment fails.

Example of a list object:

```yaml
apiVersion: v1
kind: ConfigMapList
items:
- apiVersion: v1
  kind: ConfigMap
  ...
- apiVersion: v1
  kind: ConfigMap
  ...
```

[1]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- bugfix concerning object lists in helm charts
```
