### PR TITLE
Improved reconcile for container deployer.

### DIFF
--- a/pkg/deployer/container/reconciler_pod.go
+++ b/pkg/deployer/container/reconciler_pod.go
@@ -7,7 +7,9 @@ package container
 import (
 	"context"
 
-	lserror "github.com/gardener/landscaper/apis/errors"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
+
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,17 +57,19 @@ func NewPodReconciler(
 
 func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	_, ctx = r.log.StartReconcileAndAddToContext(ctx, req)
-	deployItem, lsCtx, err := GetAndCheckReconcile(r.lsClient, r.config)(ctx, req)
+	deployItem, _, err := GetAndCheckReconcile(r.lsClient, r.config)(ctx, req)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	if deployItem == nil {
 		return reconcile.Result{}, nil
 	}
-	old := deployItem.DeepCopy()
-	err = r.diRec.Reconcile(ctx, lsCtx, deployItem, nil)
-	lsErr := lserror.BuildLsErrorOrNil(err, "Reconcile", "Reconcile")
-	return reconcile.Result{}, deployerlib.HandleReconcileResult(ctx, lsErr, old, deployItem, r.lsClient, r.lsEventRecorder)
+
+	lsv1alpha1helper.Touch(&deployItem.ObjectMeta)
+	if err = read_write_layer.NewWriter(r.lsClient).UpdateDeployItem(ctx, read_write_layer.W000030, deployItem); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
 }
 
 // PodEventHandler implements the controller runtime handler interface


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area container-deployer
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Improved reconcile for container deployer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improved reconcile for container deployer
```
