### PR TITLE
Manifest Expansion: Handle Empty Lists

### DIFF
--- a/pkg/deployer/lib/manifest_expansion.go
+++ b/pkg/deployer/lib/manifest_expansion.go
@@ -54,7 +54,7 @@ func expandManifest(manifest *runtime.RawExtension) ([]*runtime.RawExtension, er
 		return nil, fmt.Errorf("unable to expand manifest: %w", err)
 	}
 
-	if len(manifestList.Items) == 0 {
+	if manifestList.Items == nil {
 		return []*runtime.RawExtension{manifest}, nil
 	}
 

--- a/pkg/deployer/lib/manifest_expansion_test.go
+++ b/pkg/deployer/lib/manifest_expansion_test.go
@@ -60,6 +60,28 @@ var _ = Describe("Manifest expansion", func() {
 		}))
 	})
 
+	It("should handle an empty list as list", func() {
+		manifests := []*runtime.RawExtension{
+			raw(v1.ConfigMapList{Items: []v1.ConfigMap{}}),
+		}
+
+		expanded, err := ExpandManifests(manifests)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(expanded).To(HaveLen(0))
+	})
+
+	It("should handle a normal object not as list", func() {
+		manifests := []*runtime.RawExtension{
+			raw(buildConfigMap("cm1")),
+		}
+
+		expanded, err := ExpandManifests(manifests)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(expanded).To(Equal([]*runtime.RawExtension{
+			raw(buildConfigMap("cm1")),
+		}))
+	})
+
 	It("should expand managed resource manifests", func() {
 		manifests := []managedresource.Manifest{
 			{Policy: managedresource.ManagePolicy, Manifest: raw(buildConfigMap("cm1"))},

--- a/test/utils/envtest/state.go
+++ b/test/utils/envtest/state.go
@@ -538,7 +538,8 @@ func CleanupForObject(ctx context.Context, c client.Client, obj client.Object, t
 }
 
 // CleanupForInstallation cleans up an installation from a cluster
-func (s *State) CleanupForInstallation(ctx context.Context, c client.Client, obj *lsv1alpha1.Installation, timeout time.Duration) error {
+func (s *State) CleanupForInstallation(ctx context.Context, c client.Client, obj *lsv1alpha1.Installation,
+	timeout time.Duration) error {
 	if err := c.Get(ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request is a continuation of #701 (Expand Manifests). It fixes the case of [list objects][1] with 0 items, for example:

```yaml
apiVersion: v1
kind: ConfigMapList
items: []
``` 

[1]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- bugfix concerning empty object lists in helm charts
```
