### PR TITLE
fix nil pointer in pickup timeout detection

### DIFF
--- a/pkg/landscaper/controllers/deployitem/reconcile.go
+++ b/pkg/landscaper/controllers/deployitem/reconcile.go
@@ -109,7 +109,10 @@ func (con *controller) Reconcile(ctx context.Context, req reconcile.Request) (re
 }
 
 func (con *controller) isPickupTimeoutExceeded(di *lsv1alpha1.DeployItem) (bool, *time.Duration) {
-	waitingForPickupDuration := time.Since(di.Status.JobIDGenerationTime.Time)
+	waitingForPickupDuration := time.Duration(0)
+	if di.Status.JobIDGenerationTime != nil {
+		waitingForPickupDuration = time.Since(di.Status.JobIDGenerationTime.Time)
+	}
 	if waitingForPickupDuration >= con.pickupTimeout {
 		return true, nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression
/priority 3

**Special notes for your reviewer**:
Split from #669 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug in the pickup timeout detection which would cause the Landscaper to crash once upon creation of a new DeployItem with an empty status.
```
