### PR TITLE
minor fixes

### DIFF
--- a/pkg/deployer/container/reconciler_deployitem.go
+++ b/pkg/deployer/container/reconciler_deployitem.go
@@ -73,6 +73,7 @@ func (d *deployer) Reconcile(ctx context.Context, lsCtx *lsv1alpha1.Context, di 
 	if err != nil {
 		return err
 	}
+	ctx = logging.NewContext(ctx, d.log)
 	return containerOp.Reconcile(ctx, container.OperationReconcile)
 }
 
@@ -81,6 +82,7 @@ func (d deployer) Delete(ctx context.Context, lsCtx *lsv1alpha1.Context, di *lsv
 	if err != nil {
 		return err
 	}
+	ctx = logging.NewContext(ctx, d.log)
 	return containerOp.Delete(ctx)
 }
 

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -218,6 +218,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			}
 
 			// initialize deployitem for reconcile
+			logger.Debug("Setting deployitem to phase 'Init'", "updateOnChangeOnly", di.Spec.UpdateOnChangeOnly, lc.KeyGeneration, di.GetGeneration(), lc.KeyObservedGeneration, di.Status.ObservedGeneration, lc.KeyDeployItemPhase, di.Status.Phase)
 			di.Status.Phase = lsv1alpha1.DeployItemPhases.Init
 			di.Status.DeployerPhase = lsv1alpha1.DeployerPhases.Progressing
 			if err := c.updateDiForNewReconcile(ctx, di); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority 3

**What this PR does / why we need it**:
This PR adds some minor improvements:
- Fixes a bug in the container deployer where annotations were checked instead of labels.
- Adds a debug log if the container deployer decides that a new pod should be run.
- The `landscaper.gardener.cloud/operation=test-reconcile` annotation now also works if `updateOnChangeOnly` is set to `true` for container deployitems
  - To achieve this, the current reconcile is not aborted anymore after removing the annotation and generating a new job id. This means that there will always be a second reconciliation queued after the current one, but since the test-reconcile annotation is supposed to start a new full reconciliation, which would have changed the deployitem and caused a second reconciliation anyway, this shouldn't have any relevant impact.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
