### PR TITLE
set deployer verbosity to debug for integration tests

### DIFF
--- a/.ci/int-test-helper/install-landscaper
+++ b/.ci/int-test-helper/install-landscaper
@@ -31,6 +31,17 @@ landscaper:
     - helm
     - manifest
     - mock
+    deployersConfig:
+      Deployers:
+        container:
+          deployer:
+            verbosityLevel: debug
+        helm:
+          deployer:
+            verbosityLevel: debug
+        manifest:
+          deployer:
+            verbosityLevel: debug
     deployItemTimeouts:
       pickup: 30s
       abort: 30s

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -62,13 +62,14 @@ landscaper:
 #  - mock
 #  - manifest
   deployersConfig: {}
-#    container:
-#      container-helm chart values
-#      ...
-#    my-custom-deployer:
-#      apiVersion: landscaper.gardener.cloud/v1alpha1
-#      kind: DeployerRegistration
-#      ...
+#    Deployers:
+#      container:
+#        container-helm chart values
+#        ...
+#      my-custom-deployer:
+#        apiVersion: landscaper.gardener.cloud/v1alpha1
+#        kind: DeployerRegistration
+#        ...
 
 #  deployItemTimeouts:
 #    # how long deployers may take to react on changes to deploy items

--- a/hack/install-landscaper-for-integration-test.sh
+++ b/hack/install-landscaper-for-integration-test.sh
@@ -61,6 +61,17 @@ landscaper:
     - helm
     - manifest
     - mock
+    deployersConfig:
+      Deployers:
+        container:
+          deployer:
+            verbosityLevel: debug
+        helm:
+          deployer:
+            verbosityLevel: debug
+        manifest:
+          deployer:
+            verbosityLevel: debug
     deployItemTimeouts:
       pickup: 30s
       abort: 30s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:
During the integration tests, the deployers will now log on debug level by default.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
