### PR TITLE
Remove Secrets with Static Tokens From RBAC Helm Chart

### DIFF
--- a/charts/landscaper/charts/rbac/templates/serviceaccount.yaml
+++ b/charts/landscaper/charts/rbac/templates/serviceaccount.yaml
@@ -17,21 +17,6 @@ metadata:
   {{- end }}
 ---
 apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
-  name: {{ include "landscaper.controller.serviceAccountName" . }}-token
-  labels:
-    {{- include "landscaper.labels" . | nindent 4 }}
-  annotations:
-    kubernetes.io/service-account.name: {{ include "landscaper.controller.serviceAccountName" . }}
-    {{- with .Values.global.serviceAccount.controller.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-{{- end }}
-{{- if .Values.global.serviceAccount.webhooksServer.create }}
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "landscaper.webhooksServer.serviceAccountName" . }}
@@ -43,21 +28,6 @@ metadata:
   {{- end }}
 ---
 apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
-  name: {{ include "landscaper.webhooksServer.serviceAccountName" . }}-token
-  labels:
-    {{- include "landscaper.labels" . | nindent 4 }}
-  annotations:
-    kubernetes.io/service-account.name: {{ include "landscaper.webhooksServer.serviceAccountName" . }}
-    {{- with .Values.global.serviceAccount.webhooksServer.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-{{- end }}
-{{- if .Values.global.serviceAccount.user.create }}
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "landscaper.user.serviceAccountName" . }}
@@ -67,17 +37,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
----
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
-  name: {{ include "landscaper.user.serviceAccountName" . }}-token
-  labels:
-    {{- include "landscaper.labels" . | nindent 4 }}
-  annotations:
-    kubernetes.io/service-account.name: {{ include "landscaper.user.serviceAccountName" . }}
-    {{- with .Values.global.serviceAccount.user.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/priority 3

**What this PR does / why we need it**:

This pull request removes the following Secrets from the `landscaper-rbac` Helm chart: 

- `landscaper-controller-token`,   
- `landscaper-webhooks-token`,  
- `landscaper-user-token`.  

(These are the names as used in the landscaper service.) 

Since pull request https://github.com/gardener/landscaper-service/pull/111, the controllers of landscaper instances of the landscaper service do no longer use static kubeconfigs to access their resource cluster. Therefore we can remove the Secrets into which the static tokens were generated.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- cleanup of static token secrets
```
