### PR TITLE
Phase Transition Time

### DIFF
--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -95,6 +95,10 @@ type ExecutionStatus struct {
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecutionPhase `json:"phase,omitempty"`
+
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
 }
 
 // ExecutionGeneration links a deployitem to the generation of the execution when it was applied.

--- a/apis/core/types_installation.go
+++ b/apis/core/types_installation.go
@@ -156,6 +156,10 @@ type InstallationStatus struct {
 	// InstallationPhase is the current phase of the installation.
 	InstallationPhase InstallationPhase `json:"phase,omitempty"`
 
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
+
 	// ImportsHash is the hash of the import data.
 	ImportsHash string `json:"importsHash,omitempty"`
 

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -203,6 +203,10 @@ type ExecutionStatus struct {
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecutionPhase `json:"phase,omitempty"`
+
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
 }
 
 // ExecutionGeneration links a deployitem to the generation of the execution when it was applied.

--- a/apis/core/v1alpha1/types_installation.go
+++ b/apis/core/v1alpha1/types_installation.go
@@ -285,6 +285,10 @@ type InstallationStatus struct {
 	// InstallationPhase is the current phase of the installation.
 	InstallationPhase InstallationPhase `json:"phase,omitempty"`
 
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
+
 	// ImportsHash is the hash of the import data.
 	ImportsHash string `json:"importsHash,omitempty"`
 

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2141,6 +2141,7 @@ func autoConvert_v1alpha1_ExecutionStatus_To_core_ExecutionStatus(in *ExecutionS
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.ExecutionPhase = core.ExecutionPhase(in.ExecutionPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	return nil
 }
 
@@ -2159,6 +2160,7 @@ func autoConvert_core_ExecutionStatus_To_v1alpha1_ExecutionStatus(in *core.Execu
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.ExecutionPhase = ExecutionPhase(in.ExecutionPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	return nil
 }
 
@@ -2492,6 +2494,7 @@ func autoConvert_v1alpha1_InstallationStatus_To_core_InstallationStatus(in *Inst
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.InstallationPhase = core.InstallationPhase(in.InstallationPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	out.ImportsHash = in.ImportsHash
 	out.AutomaticReconcileStatus = (*core.AutomaticReconcileStatus)(unsafe.Pointer(in.AutomaticReconcileStatus))
 	return nil
@@ -2513,6 +2516,7 @@ func autoConvert_core_InstallationStatus_To_v1alpha1_InstallationStatus(in *core
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.InstallationPhase = InstallationPhase(in.InstallationPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	out.ImportsHash = in.ImportsHash
 	out.AutomaticReconcileStatus = (*AutomaticReconcileStatus)(unsafe.Pointer(in.AutomaticReconcileStatus))
 	return nil

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1296,6 +1296,10 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 		*out = make([]ExecutionGeneration, len(*in))
 		copy(*out, *in)
 	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 
@@ -1688,6 +1692,10 @@ func (in *InstallationStatus) DeepCopyInto(out *InstallationStatus) {
 		in, out := &in.ExecutionReference, &out.ExecutionReference
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
 	}
 	if in.AutomaticReconcileStatus != nil {
 		in, out := &in.AutomaticReconcileStatus, &out.AutomaticReconcileStatus

--- a/apis/core/zz_generated.deepcopy.go
+++ b/apis/core/zz_generated.deepcopy.go
@@ -1296,6 +1296,10 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 		*out = make([]ExecutionGeneration, len(*in))
 		copy(*out, *in)
 	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 
@@ -1688,6 +1692,10 @@ func (in *InstallationStatus) DeepCopyInto(out *InstallationStatus) {
 		in, out := &in.ExecutionReference, &out.ExecutionReference
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
 	}
 	if in.AutomaticReconcileStatus != nil {
 		in, out := &in.AutomaticReconcileStatus, &out.AutomaticReconcileStatus

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4967,11 +4967,17 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionStatus(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"phaseTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PhaseTransitionTime is the time when the phase last changed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ExecutionGeneration", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.VersionedNamedObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ExecutionGeneration", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.VersionedNamedObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -5646,6 +5652,12 @@ func schema_landscaper_apis_core_v1alpha1_InstallationStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"phaseTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PhaseTransitionTime is the time when the phase last changed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 					"importsHash": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ImportsHash is the hash of the import data.",
@@ -5664,7 +5676,7 @@ func schema_landscaper_apis_core_v1alpha1_InstallationStatus(ref common.Referenc
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcileStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ImportStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.NamedObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcileStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ImportStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.NamedObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -95,6 +95,10 @@ type ExecutionStatus struct {
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecutionPhase `json:"phase,omitempty"`
+
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
 }
 
 // ExecutionGeneration links a deployitem to the generation of the execution when it was applied.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -156,6 +156,10 @@ type InstallationStatus struct {
 	// InstallationPhase is the current phase of the installation.
 	InstallationPhase InstallationPhase `json:"phase,omitempty"`
 
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
+
 	// ImportsHash is the hash of the import data.
 	ImportsHash string `json:"importsHash,omitempty"`
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -203,6 +203,10 @@ type ExecutionStatus struct {
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecutionPhase `json:"phase,omitempty"`
+
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
 }
 
 // ExecutionGeneration links a deployitem to the generation of the execution when it was applied.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -285,6 +285,10 @@ type InstallationStatus struct {
 	// InstallationPhase is the current phase of the installation.
 	InstallationPhase InstallationPhase `json:"phase,omitempty"`
 
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
+
 	// ImportsHash is the hash of the import data.
 	ImportsHash string `json:"importsHash,omitempty"`
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2141,6 +2141,7 @@ func autoConvert_v1alpha1_ExecutionStatus_To_core_ExecutionStatus(in *ExecutionS
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.ExecutionPhase = core.ExecutionPhase(in.ExecutionPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	return nil
 }
 
@@ -2159,6 +2160,7 @@ func autoConvert_core_ExecutionStatus_To_v1alpha1_ExecutionStatus(in *core.Execu
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.ExecutionPhase = ExecutionPhase(in.ExecutionPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	return nil
 }
 
@@ -2492,6 +2494,7 @@ func autoConvert_v1alpha1_InstallationStatus_To_core_InstallationStatus(in *Inst
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.InstallationPhase = core.InstallationPhase(in.InstallationPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	out.ImportsHash = in.ImportsHash
 	out.AutomaticReconcileStatus = (*core.AutomaticReconcileStatus)(unsafe.Pointer(in.AutomaticReconcileStatus))
 	return nil
@@ -2513,6 +2516,7 @@ func autoConvert_core_InstallationStatus_To_v1alpha1_InstallationStatus(in *core
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.InstallationPhase = InstallationPhase(in.InstallationPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	out.ImportsHash = in.ImportsHash
 	out.AutomaticReconcileStatus = (*AutomaticReconcileStatus)(unsafe.Pointer(in.AutomaticReconcileStatus))
 	return nil

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1296,6 +1296,10 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 		*out = make([]ExecutionGeneration, len(*in))
 		copy(*out, *in)
 	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 
@@ -1688,6 +1692,10 @@ func (in *InstallationStatus) DeepCopyInto(out *InstallationStatus) {
 		in, out := &in.ExecutionReference, &out.ExecutionReference
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
 	}
 	if in.AutomaticReconcileStatus != nil {
 		in, out := &in.AutomaticReconcileStatus, &out.AutomaticReconcileStatus

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1296,6 +1296,10 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 		*out = make([]ExecutionGeneration, len(*in))
 		copy(*out, *in)
 	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 
@@ -1688,6 +1692,10 @@ func (in *InstallationStatus) DeepCopyInto(out *InstallationStatus) {
 		in, out := &in.ExecutionReference, &out.ExecutionReference
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
 	}
 	if in.AutomaticReconcileStatus != nil {
 		in, out := &in.AutomaticReconcileStatus, &out.AutomaticReconcileStatus

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3652,6 +3652,20 @@ ExecutionPhase
 <p>ExecutionPhase is the current phase of the execution.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>phaseTransitionTime</code></br>
+<em>
+<a href="https://v1-22.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PhaseTransitionTime is the time when the phase last changed.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="landscaper.gardener.cloud/v1alpha1.ExportDefinition">ExportDefinition
@@ -4479,6 +4493,20 @@ InstallationPhase
 </td>
 <td>
 <p>InstallationPhase is the current phase of the installation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>phaseTransitionTime</code></br>
+<em>
+<a href="https://v1-22.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PhaseTransitionTime is the time when the phase last changed.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -95,6 +95,9 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 			exec.Status.ExecutionPhase = lsv1alpha1.ExecutionPhases.InitDelete
 		}
 
+		now := metav1.Now()
+		exec.Status.PhaseTransitionTime = &now
+
 		// do not use setExecutionPhaseAndUpdate because jobIDFinished should not be set here
 		if err := c.Writer().UpdateExecutionStatus(ctx, read_write_layer.W000105, exec); err != nil {
 			return lserrors.NewWrappedError(err, op, "UpdateExecutionStatus", err.Error())
@@ -306,6 +309,10 @@ func (c *controller) setExecutionPhaseAndUpdate(ctx context.Context, exec *lsv1a
 		logger.Error(lsErr, "setExecutionPhaseAndUpdate")
 	}
 
+	if phase != exec.Status.ExecutionPhase {
+		now := metav1.Now()
+		exec.Status.PhaseTransitionTime = &now
+	}
 	exec.Status.ExecutionPhase = phase
 
 	if exec.Status.ExecutionPhase.IsFinal() {

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
@@ -304,6 +305,10 @@ func (c *Controller) setInstallationPhaseAndUpdate(ctx context.Context, inst *ls
 		c.EventRecorder().Event(inst, corev1.EventTypeWarning, lastErr.Reason, lastErr.Message)
 	}
 
+	if phase != inst.Status.InstallationPhase {
+		now := metav1.Now()
+		inst.Status.PhaseTransitionTime = &now
+	}
 	inst.Status.InstallationPhase = phase
 	if phase.IsFinal() {
 		inst.Status.JobIDFinished = inst.Status.JobID

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -283,6 +283,10 @@ spec:
               phase:
                 description: ExecutionPhase is the current phase of the execution.
                 type: string
+              phaseTransitionTime:
+                description: PhaseTransitionTime is the time when the phase last changed.
+                format: date-time
+                type: string
             type: object
         required:
         - spec

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
@@ -808,6 +808,10 @@ spec:
               phase:
                 description: InstallationPhase is the current phase of the installation.
                 type: string
+              phaseTransitionTime:
+                description: PhaseTransitionTime is the time when the phase last changed.
+                format: date-time
+                type: string
             required:
             - observedGeneration
             - configGeneration

--- a/pkg/landscaper/installations/operation.go
+++ b/pkg/landscaper/installations/operation.go
@@ -9,9 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
-
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	corev1 "k8s.io/api/core/v1"
@@ -22,18 +19,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	lserrors "github.com/gardener/landscaper/apis/errors"
-
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/jsonschema"
+	lsoperation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/landscaper/registry/components/cdutils"
 	lsutil "github.com/gardener/landscaper/pkg/utils"
-
-	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	lsoperation "github.com/gardener/landscaper/pkg/landscaper/operation"
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
@@ -377,7 +374,7 @@ func GetRootInstallations(ctx context.Context, kubeClient client.Client, filter 
 }
 
 // NewTriggerDependents triggers all installations that depend on the current installation.
-func (o *Operation) NewTriggerDependents(ctx context.Context) error {
+func (o *Operation) TriggerDependents(ctx context.Context) error {
 	for _, sibling := range o.Context().Siblings {
 		if !importsAnyExport(o.Inst, sibling) {
 			continue

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -95,6 +95,10 @@ type ExecutionStatus struct {
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecutionPhase `json:"phase,omitempty"`
+
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
 }
 
 // ExecutionGeneration links a deployitem to the generation of the execution when it was applied.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -156,6 +156,10 @@ type InstallationStatus struct {
 	// InstallationPhase is the current phase of the installation.
 	InstallationPhase InstallationPhase `json:"phase,omitempty"`
 
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
+
 	// ImportsHash is the hash of the import data.
 	ImportsHash string `json:"importsHash,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -203,6 +203,10 @@ type ExecutionStatus struct {
 
 	// ExecutionPhase is the current phase of the execution.
 	ExecutionPhase ExecutionPhase `json:"phase,omitempty"`
+
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
 }
 
 // ExecutionGeneration links a deployitem to the generation of the execution when it was applied.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -285,6 +285,10 @@ type InstallationStatus struct {
 	// InstallationPhase is the current phase of the installation.
 	InstallationPhase InstallationPhase `json:"phase,omitempty"`
 
+	// PhaseTransitionTime is the time when the phase last changed.
+	// +optional
+	PhaseTransitionTime *metav1.Time `json:"phaseTransitionTime,omitempty"`
+
 	// ImportsHash is the hash of the import data.
 	ImportsHash string `json:"importsHash,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2141,6 +2141,7 @@ func autoConvert_v1alpha1_ExecutionStatus_To_core_ExecutionStatus(in *ExecutionS
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.ExecutionPhase = core.ExecutionPhase(in.ExecutionPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	return nil
 }
 
@@ -2159,6 +2160,7 @@ func autoConvert_core_ExecutionStatus_To_v1alpha1_ExecutionStatus(in *core.Execu
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.ExecutionPhase = ExecutionPhase(in.ExecutionPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	return nil
 }
 
@@ -2492,6 +2494,7 @@ func autoConvert_v1alpha1_InstallationStatus_To_core_InstallationStatus(in *Inst
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.InstallationPhase = core.InstallationPhase(in.InstallationPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	out.ImportsHash = in.ImportsHash
 	out.AutomaticReconcileStatus = (*core.AutomaticReconcileStatus)(unsafe.Pointer(in.AutomaticReconcileStatus))
 	return nil
@@ -2513,6 +2516,7 @@ func autoConvert_core_InstallationStatus_To_v1alpha1_InstallationStatus(in *core
 	out.JobID = in.JobID
 	out.JobIDFinished = in.JobIDFinished
 	out.InstallationPhase = InstallationPhase(in.InstallationPhase)
+	out.PhaseTransitionTime = (*metav1.Time)(unsafe.Pointer(in.PhaseTransitionTime))
 	out.ImportsHash = in.ImportsHash
 	out.AutomaticReconcileStatus = (*AutomaticReconcileStatus)(unsafe.Pointer(in.AutomaticReconcileStatus))
 	return nil

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1296,6 +1296,10 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 		*out = make([]ExecutionGeneration, len(*in))
 		copy(*out, *in)
 	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 
@@ -1688,6 +1692,10 @@ func (in *InstallationStatus) DeepCopyInto(out *InstallationStatus) {
 		in, out := &in.ExecutionReference, &out.ExecutionReference
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
 	}
 	if in.AutomaticReconcileStatus != nil {
 		in, out := &in.AutomaticReconcileStatus, &out.AutomaticReconcileStatus

--- a/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1296,6 +1296,10 @@ func (in *ExecutionStatus) DeepCopyInto(out *ExecutionStatus) {
 		*out = make([]ExecutionGeneration, len(*in))
 		copy(*out, *in)
 	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 
@@ -1688,6 +1692,10 @@ func (in *InstallationStatus) DeepCopyInto(out *InstallationStatus) {
 		in, out := &in.ExecutionReference, &out.ExecutionReference
 		*out = new(ObjectReference)
 		**out = **in
+	}
+	if in.PhaseTransitionTime != nil {
+		in, out := &in.PhaseTransitionTime, &out.PhaseTransitionTime
+		*out = (*in).DeepCopy()
 	}
 	if in.AutomaticReconcileStatus != nil {
 		in, out := &in.AutomaticReconcileStatus, &out.AutomaticReconcileStatus


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This pull request adds a `phaseTransitionTime` field to the status of Installations, Executions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- the status of installations and executions contains now the timestamp of the last phase transition 
```
