### PR TITLE
Render ImportExecutions in blueprint renderer

### DIFF
--- a/pkg/utils/landscaper/installation_simulator.go
+++ b/pkg/utils/landscaper/installation_simulator.go
@@ -205,7 +205,7 @@ func (s *InstallationSimulator) SetCallbacks(callbacks InstallationSimulatorCall
 }
 
 // Run starts the simulation for the given component descriptor, blueprint and imports and returns the calculated exports.
-func (s *InstallationSimulator) Run(cd *cdv2.ComponentDescriptor, blueprint *blueprints.Blueprint, dataImports, targetImports map[string]interface{}) (*BlueprintExports, error) {
+func (s *InstallationSimulator) Run(cd *cdv2.ComponentDescriptor, blueprint *blueprints.Blueprint, imports map[string]interface{}) (*BlueprintExports, error) {
 	ctx := &ResolvedInstallation{
 		ComponentDescriptor: cd,
 		Installation: &lsv1alpha1.Installation{
@@ -219,7 +219,7 @@ func (s *InstallationSimulator) Run(cd *cdv2.ComponentDescriptor, blueprint *blu
 		Blueprint: blueprint,
 	}
 
-	_, exports, err := s.executeInstallation(ctx, nil, dataImports, targetImports)
+	_, exports, err := s.executeInstallation(ctx, nil, imports, imports)
 	return exports, err
 }
 
@@ -236,6 +236,11 @@ func (s *InstallationSimulator) executeInstallation(ctx *ResolvedInstallation, i
 	imports := make(map[string]interface{})
 	mergeMaps(imports, dataImports)
 	mergeMaps(imports, targetImports)
+
+	imports, err := s.blueprintRenderer.RenderImportExecutions(ctx, imports)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error while executing import executions: %w", err)
+	}
 
 	s.callbacks.OnInstallation(pathString, ctx.Installation)
 	s.callbacks.OnImports(pathString, imports)

--- a/pkg/utils/landscaper/installation_simulator_test.go
+++ b/pkg/utils/landscaper/installation_simulator_test.go
@@ -243,6 +243,8 @@ targetExports: []
 		Expect(callbacks.imports).To(HaveKey("root/subinst-b"))
 		Expect(callbacks.imports).To(HaveKey("root/subinst-c"))
 
+		Expect(callbacks.imports["root"]).To(HaveKeyWithValue("foo", "bar"))
+
 		Expect(callbacks.imports["root/subinst-a"]).To(HaveKey("subinst-a-param-a"))
 		Expect(callbacks.imports["root/subinst-a"]).To(HaveKey("subinst-a-param-b"))
 		Expect(callbacks.imports["root/subinst-a"]).To(HaveKey("cluster"))

--- a/pkg/utils/landscaper/installation_simulator_test.go
+++ b/pkg/utils/landscaper/installation_simulator_test.go
@@ -193,17 +193,14 @@ targetExports: []
 		err = yaml.Unmarshal(marshaled, &clusterListMap)
 		Expect(err).ToNot(HaveOccurred())
 
-		dataImports := map[string]interface{}{
+		imports := map[string]interface{}{
 			"root-param-a": "valua-a",
 			"root-param-b": "value-b",
+			"cluster":      clusterMap,
+			"clusters":     clusterListMap,
 		}
 
-		targetImports := map[string]interface{}{
-			"cluster":  clusterMap,
-			"clusters": clusterListMap,
-		}
-
-		exports, err := simulator.Run(cd, blueprint, dataImports, targetImports)
+		exports, err := simulator.Run(cd, blueprint, imports)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exports).ToNot(BeNil())
 

--- a/pkg/utils/landscaper/testdata/01-subinstallations/root/blobs/blueprint/blueprint.yaml
+++ b/pkg/utils/landscaper/testdata/01-subinstallations/root/blobs/blueprint/blueprint.yaml
@@ -22,6 +22,15 @@ imports:
     schema:
       type: string
 
+importExecutions:
+- name: test
+  type: Spiff
+  template:
+    errors: []
+    bindings:
+      <<<: (( imports ))
+      foo: bar
+
 exports:
   - name: export-root-a
     type: data


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:
This PR causes the `landscapercli blueprint render` command to process `ImportExecutions`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `landscapercli blueprint render` command will now process the defined `ImportExecutions` (instead of ignoring them).
```
```bugfix user
DeployItem templates without a target reference will not cause a nil pointer exception anymore during the `landscapercli blueprint render` command.
```
