### PR TITLE
LsHealthCheck: Init status on create

### DIFF
--- a/apis/core/v1alpha1/types_ls_health_check.go
+++ b/apis/core/v1alpha1/types_ls_health_check.go
@@ -69,4 +69,5 @@ type LsHealthCheckStatus string
 const (
 	LsHealthCheckStatusOk     LsHealthCheckStatus = "Ok"
 	LsHealthCheckStatusFailed LsHealthCheckStatus = "Failed"
+	LsHealthCheckStatusInit   LsHealthCheckStatus = "Init"
 )

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_ls_health_check.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_ls_health_check.go
@@ -69,4 +69,5 @@ type LsHealthCheckStatus string
 const (
 	LsHealthCheckStatusOk     LsHealthCheckStatus = "Ok"
 	LsHealthCheckStatusFailed LsHealthCheckStatus = "Failed"
+	LsHealthCheckStatusInit   LsHealthCheckStatus = "Init"
 )

--- a/pkg/landscaper/controllers/healthcheck/add.go
+++ b/pkg/landscaper/controllers/healthcheck/add.go
@@ -30,7 +30,7 @@ func AddControllersToManager(ctx context.Context, logger logging.Logger, hostMgr
 		if apierrors.IsNotFound(err) {
 			lsHealthCheck = &lsv1alpha1.LsHealthCheck{
 				ObjectMeta:     metav1.ObjectMeta{Name: agentConfig.Name, Namespace: agentConfig.Namespace},
-				Status:         lsv1alpha1.LsHealthCheckStatusOk,
+				Status:         lsv1alpha1.LsHealthCheckStatusInit,
 				Description:    "ok",
 				LastUpdateTime: metav1.Unix(0, 0),
 			}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_ls_health_check.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_ls_health_check.go
@@ -69,4 +69,5 @@ type LsHealthCheckStatus string
 const (
 	LsHealthCheckStatusOk     LsHealthCheckStatus = "Ok"
 	LsHealthCheckStatusFailed LsHealthCheckStatus = "Failed"
+	LsHealthCheckStatusInit   LsHealthCheckStatus = "Init"
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
LsHealthCheck: status is Init when created
```
