### PR TITLE
Improve error reporting

### DIFF
--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -178,6 +178,16 @@ func HandleReconcileResult(ctx context.Context, err lserrors.LsError, oldDeployI
 
 			if apierrors.IsConflict(err2) { // reduce logging
 				logger.Debug("Unable to update status", lc.KeyError, err2.Error())
+				if updatedLastError != nil {
+					// try to store at least the last error
+					diRecheck := &lsv1alpha1.DeployItem{}
+					errRecheck := read_write_layer.GetDeployItem(ctx, lsClient, kutil.ObjectKey(deployItem.Name, deployItem.Namespace), diRecheck)
+					if errRecheck != nil {
+						lsutil.SetLastError(&diRecheck.Status, updatedLastError)
+						_ = read_write_layer.NewWriter(lsClient).UpdateDeployItemStatus(ctx, read_write_layer.W000033, diRecheck)
+					}
+				}
+
 			} else {
 				logger.Error(err2, "Unable to update status")
 			}

--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -147,7 +147,9 @@ func HandleReconcileResult(ctx context.Context, err lserrors.LsError, oldDeployI
 	lsClient client.Client, lsEventRecorder record.EventRecorder) error {
 
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
-	lsutil.SetLastError(&deployItem.Status, lserrors.TryUpdateLsError(deployItem.Status.GetLastError(), err))
+
+	updatedLastError := lserrors.TryUpdateLsError(deployItem.Status.GetLastError(), err)
+	lsutil.SetLastError(&deployItem.Status, updatedLastError)
 
 	if deployItem.Status.GetLastError() != nil {
 		if lserrors.ContainsAnyErrorCode(deployItem.Status.GetLastError().Codes, lsv1alpha1.UnrecoverableErrorCodes) {

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -171,7 +171,17 @@ func SetLastError(deployItemStatus *lsv1alpha1.DeployItemStatus, err *lsv1alpha1
 		if lastErrors == nil {
 			deployItemStatus.SetLastErrors([]*lsv1alpha1.Error{})
 		}
-		lastErrors = append(lastErrors, err)
+
+		errAlreadyContained := false
+		for _, j := range lastErrors {
+			if err.Operation == j.Operation && err.Reason == j.Reason {
+				errAlreadyContained = true
+			}
+		}
+
+		if !errAlreadyContained {
+			lastErrors = append(lastErrors, err)
+		}
 
 		if len(lastErrors) > 5 {
 			lastErrors = lastErrors[1:]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Improve error reporting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- Improve error reporting
```
