### PR TITLE
Webhook server runs on several replicas 

### DIFF
--- a/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
@@ -8,23 +8,9 @@ kind: Deployment
 metadata:
   name: {{ include "landscaper.webhooks.fullname" . }}
   labels:
-    landscaper.gardener.cloud/component: webhook-server-topology
     {{- include "landscaper.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.webhooksServer.replicaCount }}
-  topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: ScheduleAnyway
-    labelSelector:
-      matchLabels:
-        landscaper.gardener.cloud/topology: webhook-server
-  - maxSkew: 1
-    topologyKey: kubernetes.io/hostname
-    whenUnsatisfiable: ScheduleAnyway
-    labelSelector:
-      matchLabels:
-        landscaper.gardener.cloud/topology: webhook-server
   selector:
     matchLabels:
       {{- include "landscaper.webhooks.selectorLabels" . | nindent 6 }}
@@ -35,6 +21,7 @@ spec:
         {{ $key }}: {{ $value}}
         {{- end }}
       labels:
+        landscaper.gardener.cloud/topology: webhook-server
         {{- include "landscaper.webhooks.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -101,4 +88,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            landscaper.gardener.cloud/topology: webhook-server
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            landscaper.gardener.cloud/topology: webhook-server
 {{- end }}

--- a/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
@@ -22,6 +22,7 @@ spec:
         {{- end }}
       labels:
         landscaper.gardener.cloud/topology: webhook-server
+        landscaper.gardener.cloud/topology-ns: {{ .Release.Namespace }}
         {{- include "landscaper.webhooks.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -95,10 +96,12 @@ spec:
         labelSelector:
           matchLabels:
             landscaper.gardener.cloud/topology: webhook-server
+            landscaper.gardener.cloud/topology-ns: {{ .Release.Namespace }}
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
             landscaper.gardener.cloud/topology: webhook-server
+            landscaper.gardener.cloud/topology-ns: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
+++ b/charts/landscaper/charts/landscaper/templates/deployment-webhooks.yaml
@@ -8,9 +8,23 @@ kind: Deployment
 metadata:
   name: {{ include "landscaper.webhooks.fullname" . }}
   labels:
+    landscaper.gardener.cloud/component: webhook-server-topology
     {{- include "landscaper.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.webhooksServer.replicaCount }}
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        landscaper.gardener.cloud/topology: webhook-server
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        landscaper.gardener.cloud/topology: webhook-server
   selector:
     matchLabels:
       {{- include "landscaper.webhooks.selectorLabels" . | nindent 6 }}

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -113,7 +113,7 @@ webhooksServer:
   #   kubeconfig: |
   #     <cluster-kubeconfig>
 
-  replicaCount: 1
+  replicaCount: 2
   image:
     repository: eu.gcr.io/gardener-project/landscaper/landscaper-webhooks-server
     pullPolicy: IfNotPresent

--- a/cmd/landscaper-webhooks-server/app/app.go
+++ b/cmd/landscaper-webhooks-server/app/app.go
@@ -144,7 +144,14 @@ func registerWebhooks(ctx context.Context,
 	} else {
 		dnsNames = webhookcert.GeDNSNamesFromNamespacedName(wo.ServiceNamespace, wo.ServiceName)
 	}
-	wo.CABundle, err = webhookcert.GenerateCertificates(ctx, kubeClient, webhookServer.CertDir, o.webhook.certificatesNamespace, "landscaper-webhook", certSecretName, dnsNames)
+
+	secretNamespace := o.webhook.certificatesNamespace
+	if len(secretNamespace) == 0 {
+		secretNamespace = o.webhook.webhookServiceNamespace
+	}
+
+	wo.CABundle, err = webhookcert.GenerateCertificates(ctx, kubeClient, webhookServer.CertDir,
+		secretNamespace, "landscaper-webhook", certSecretName, dnsNames)
 	if err != nil {
 		return fmt.Errorf("unable to generate webhook certificates: %w", err)
 	}

--- a/controller-utils/pkg/webhook/certificates.go
+++ b/controller-utils/pkg/webhook/certificates.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"path/filepath"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates"
 )
@@ -53,12 +54,8 @@ func GetDNSNamesFromURL(rawurl string) ([]string, error) {
 
 // GenerateCertificates generates the certificates that are required for a webhook. It returns the ca bundle, and it
 // stores the server certificate and key locally on the file system.
-func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string, dnsNames []string) ([]byte, error) {
-	var (
-		caCert     *certificates.Certificate
-		serverCert *certificates.Certificate
-		err        error
-	)
+func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string,
+	dnsNames []string) ([]byte, error) {
 
 	caConfig := &certificates.CertificateSecretConfig{
 		CommonName: "webhook-ca",
@@ -66,72 +63,98 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 		PKCS:       certificates.PKCS8,
 	}
 
-	// If the namespace is not set then the webhook controller is running locally. We simply generate a new certificate in this case.
-	if len(namespace) == 0 {
-		caCert, serverCert, err = GenerateNewCAAndServerCert(name, dnsNames, *caConfig)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
-		}
-		return writeCertificates(certDir, caCert, serverCert)
-	}
-
 	// The controller stores the generated webhook certificate in a secret in the cluster. It tries to read it. If it does not exist a
 	// new certificate is generated.
 
-	generateAndUpdateCertificate := func() ([]byte, error) {
-		// The secret was not found, let's generate new certificates and store them in the secret afterwards.
-		caCert, serverCert, err = GenerateNewCAAndServerCert(name, dnsNames, *caConfig)
+	secret := &corev1.Secret{}
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+
+		if !apierrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "error fetching secret for webhook server")
+		}
+
+		caCert, serverCert, err := generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
-		secret := &corev1.Secret{}
-		secret.ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: certSecretName}
-		secret.Type = corev1.SecretTypeOpaque
-		secret.Data = map[string][]byte{
-			certificates.DataKeyCertificateCA: caCert.CertificatePEM,
-			certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
-			certificates.DataKeyCertificate:   serverCert.CertificatePEM,
-			certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
-		}
-
-		if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, secret, func() error {
-			secret.Type = corev1.SecretTypeOpaque
-			secret.Data = map[string][]byte{
-				certificates.DataKeyCertificateCA: caCert.CertificatePEM,
-				certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
-				certificates.DataKeyCertificate:   serverCert.CertificatePEM,
-				certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
+		err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, namespace, certSecretName, true)
+		if err == nil {
+			return writeCertificates(certDir, caCert, serverCert)
+		} else {
+			// try to refetch secret if it was created by another replica
+			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				return nil, errors.Wrapf(err, "could not fetch secret for webhook")
 			}
-			return nil
-		}); err != nil {
+		}
+	}
+
+	// The secret has been found and we are now trying to read the stored certificate inside it and updates it if
+	// required
+	caCert, serverCert, retry, err := loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+	if err != nil {
+		if retry {
+			secret = &corev1.Secret{}
+			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
 			return nil, err
 		}
 
-		return writeCertificates(certDir, caCert, serverCert)
-	}
-
-	secret := &corev1.Secret{}
-	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
-		return generateAndUpdateCertificate()
-	}
-
-	// The secret has been found and we are now trying to read the stored certificate inside it.
-	caCert, serverCert, err = loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading data of secret %s/%s", namespace, certSecretName)
-	}
-
-	// update certificates if the dns names have changed
-	if !sets.NewString(caCert.Certificate.DNSNames...).HasAll(dnsNames...) {
-		return generateAndUpdateCertificate()
 	}
 
 	return writeCertificates(certDir, caCert, serverCert)
 }
 
+func loadAndUpdateSecret(ctx context.Context, kubeClient client.Client, secret *corev1.Secret, name string, dnsNames []string,
+	caConfig *certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, bool, error) {
+
+	caCert, serverCert, err := loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
+	if err != nil {
+		return nil, nil, false, errors.Wrapf(err, "error reading data of secret %s/%s", secret.Namespace, secret.Name)
+	}
+
+	// update certificates if the dns names have changed
+	if !sets.NewString(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
+		caCert, serverCert, err = generateNewCAAndServerCert(name, dnsNames, *caConfig)
+		if err != nil {
+			return nil, nil, false, errors.Wrapf(err, "error generating new certificates for webhook server")
+		}
+
+		if err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, secret.Namespace, secret.Name, false); err != nil {
+			return nil, nil, true, errors.Wrapf(err, "error updating secret for webhook")
+		}
+	}
+
+	return caCert, serverCert, false, nil
+}
+
+func createOrUpdateSecret(ctx context.Context, kubeClient client.Client, caCert, serverCert *certificates.Certificate,
+	namespace, certSecretName string, create bool) error {
+	// The secret was not found, let's generate new certificates and store them in the secret afterwards.
+	secret := &corev1.Secret{}
+	secret.ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: certSecretName}
+	secret.Type = corev1.SecretTypeOpaque
+	secret.Data = map[string][]byte{
+		certificates.DataKeyCertificateCA: caCert.CertificatePEM,
+		certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
+		certificates.DataKeyCertificate:   serverCert.CertificatePEM,
+		certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
+	}
+
+	if create {
+		return kubeClient.Create(ctx, secret)
+	} else {
+		return kubeClient.Update(ctx, secret)
+	}
+}
+
 // GenerateNewCAAndServerCert generates a new ca and server certificate for a service in a name and namespace.
-func GenerateNewCAAndServerCert(name string, dnsNames []string, caConfig certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, error) {
+func generateNewCAAndServerCert(name string, dnsNames []string, caConfig certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, error) {
 	caCert, err := caConfig.GenerateCertificate()
 	if err != nil {
 		return nil, nil, err

--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -42,7 +42,7 @@ spec:
   region: europe-west1
   secretBindingName: shoot-cluster-canary-sap-gcp-k8s-wm-canary
   kubernetes:
-    version: 1.25.6
+    version: "1.25"
   purpose: evaluation
   addons:
     kubernetesDashboard:

--- a/pkg/utils/landscaper/landscaper.go
+++ b/pkg/utils/landscaper/landscaper.go
@@ -43,7 +43,8 @@ func WaitForInstallationToFinish(
 }
 
 func IsInstallationFinished(inst *lsv1alpha1.Installation, phase lsv1alpha1.InstallationPhase) (bool, error) {
-	if inst.Status.JobIDFinished != inst.Status.JobID || helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) {
+	if inst.Status.JobIDFinished != inst.Status.JobID || helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) ||
+		inst.Status.InstallationPhase.IsEmpty() {
 		return false, nil
 	} else if inst.Status.InstallationPhase != phase {
 		return false, fmt.Errorf("installation has finish with unexpected phase: %s, expected: %s", inst.Status.InstallationPhase, phase)

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
@@ -12,12 +12,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates"
 )
@@ -53,12 +57,9 @@ func GetDNSNamesFromURL(rawurl string) ([]string, error) {
 
 // GenerateCertificates generates the certificates that are required for a webhook. It returns the ca bundle, and it
 // stores the server certificate and key locally on the file system.
-func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string, dnsNames []string) ([]byte, error) {
-	var (
-		caCert     *certificates.Certificate
-		serverCert *certificates.Certificate
-		err        error
-	)
+func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string,
+	dnsNames []string) ([]byte, error) {
+	log, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "GenerateCertificates")
 
 	caConfig := &certificates.CertificateSecretConfig{
 		CommonName: "webhook-ca",
@@ -66,72 +67,126 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 		PKCS:       certificates.PKCS8,
 	}
 
-	// If the namespace is not set then the webhook controller is running locally. We simply generate a new certificate in this case.
-	if len(namespace) == 0 {
-		caCert, serverCert, err = GenerateNewCAAndServerCert(name, dnsNames, *caConfig)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
-		}
-		return writeCertificates(certDir, caCert, serverCert)
-	}
-
 	// The controller stores the generated webhook certificate in a secret in the cluster. It tries to read it. If it does not exist a
 	// new certificate is generated.
 
-	generateAndUpdateCertificate := func() ([]byte, error) {
-		// The secret was not found, let's generate new certificates and store them in the secret afterwards.
-		caCert, serverCert, err = GenerateNewCAAndServerCert(name, dnsNames, *caConfig)
+	secret := &corev1.Secret{}
+	log.Info("ttt0")
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+		log.Info("ttt1")
+
+		if !apierrors.IsNotFound(err) {
+			log.Info("ttt2")
+			return nil, errors.Wrapf(err, "error fetching secret for webhook server")
+		}
+
+		log.Info("ttt3")
+		caCert, serverCert, err := generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
+			log.Info("ttt4")
 			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
-		secret := &corev1.Secret{}
-		secret.ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: certSecretName}
-		secret.Type = corev1.SecretTypeOpaque
-		secret.Data = map[string][]byte{
-			certificates.DataKeyCertificateCA: caCert.CertificatePEM,
-			certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
-			certificates.DataKeyCertificate:   serverCert.CertificatePEM,
-			certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
-		}
+		log.Info("ttt5")
 
-		if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, secret, func() error {
-			secret.Type = corev1.SecretTypeOpaque
-			secret.Data = map[string][]byte{
-				certificates.DataKeyCertificateCA: caCert.CertificatePEM,
-				certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
-				certificates.DataKeyCertificate:   serverCert.CertificatePEM,
-				certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
+		err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, namespace, certSecretName, true)
+		if err == nil {
+			log.Info("ttt6")
+			return writeCertificates(certDir, caCert, serverCert)
+		} else {
+			log.Info("ttt7")
+			// try to refetch secret if it was created by another replica
+			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				return nil, errors.Wrapf(err, "could not fetch secret for webhook")
 			}
-			return nil
-		}); err != nil {
+		}
+	}
+
+	// The secret has been found and we are now trying to read the stored certificate inside it and updates it if
+	// required
+	log.Info("ttt8")
+	caCert, serverCert, retry, err := loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+	log.Info("ttt9")
+	if err != nil {
+		log.Info("ttt10")
+		if retry {
+			log.Info("ttt11")
+			secret = &corev1.Secret{}
+			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				log.Info("ttt12")
+				caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+				if err != nil {
+					log.Info("ttt13")
+					return nil, err
+				}
+			}
+		} else {
+			log.Info("ttt14")
 			return nil, err
 		}
 
-		return writeCertificates(certDir, caCert, serverCert)
 	}
 
-	secret := &corev1.Secret{}
-	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
-		return generateAndUpdateCertificate()
-	}
-
-	// The secret has been found and we are now trying to read the stored certificate inside it.
-	caCert, serverCert, err = loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading data of secret %s/%s", namespace, certSecretName)
-	}
-
-	// update certificates if the dns names have changed
-	if !sets.NewString(caCert.Certificate.DNSNames...).HasAll(dnsNames...) {
-		return generateAndUpdateCertificate()
-	}
-
+	log.Info("ttt15: write webhook certificates", "caCert", caCert, "serverCert", serverCert)
 	return writeCertificates(certDir, caCert, serverCert)
 }
 
+func loadAndUpdateSecret(ctx context.Context, kubeClient client.Client, secret *corev1.Secret, name string, dnsNames []string,
+	caConfig *certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, bool, error) {
+	log, ctx := logging.FromContextOrNew(ctx, nil)
+	log.Info("ttt8-1")
+
+	caCert, serverCert, err := loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
+	if err != nil {
+		log.Info("ttt8-2")
+		return nil, nil, false, errors.Wrapf(err, "error reading data of secret %s/%s", secret.Namespace, secret.Name)
+	}
+
+	log.Info("ttt8-3-1", "caCert.Certificate.DNSNames", len(caCert.Certificate.DNSNames), "dnsNames", len(dnsNames))
+	log.Info("ttt8-3-2", "caCert.Certificate.DNSNames", caCert.Certificate.DNSNames, "dnsNames", dnsNames)
+	log.Info("ttt8-3-3", "serverCert.Certificate.DNSNames", serverCert.Certificate.DNSNames, "dnsNames", dnsNames)
+	// update certificates if the dns names have changed
+	if !sets.NewString(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
+		log.Info("ttt8-4")
+		caCert, serverCert, err = generateNewCAAndServerCert(name, dnsNames, *caConfig)
+		if err != nil {
+			log.Info("ttt8-5")
+			return nil, nil, false, errors.Wrapf(err, "error generating new certificates for webhook server")
+		}
+
+		log.Info("ttt8-6")
+		if err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, secret.Namespace, secret.Name, false); err != nil {
+			log.Info("ttt8-7")
+			return nil, nil, true, errors.Wrapf(err, "error updating secret for webhook")
+		}
+	}
+
+	log.Info("ttt8-8")
+	return caCert, serverCert, false, nil
+}
+
+func createOrUpdateSecret(ctx context.Context, kubeClient client.Client, caCert, serverCert *certificates.Certificate,
+	namespace, certSecretName string, create bool) error {
+	// The secret was not found, let's generate new certificates and store them in the secret afterwards.
+	secret := &corev1.Secret{}
+	secret.ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: certSecretName}
+	secret.Type = corev1.SecretTypeOpaque
+	secret.Data = map[string][]byte{
+		certificates.DataKeyCertificateCA: caCert.CertificatePEM,
+		certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
+		certificates.DataKeyCertificate:   serverCert.CertificatePEM,
+		certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
+	}
+
+	if create {
+		return kubeClient.Create(ctx, secret)
+	} else {
+		return kubeClient.Update(ctx, secret)
+	}
+}
+
 // GenerateNewCAAndServerCert generates a new ca and server certificate for a service in a name and namespace.
-func GenerateNewCAAndServerCert(name string, dnsNames []string, caConfig certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, error) {
+func generateNewCAAndServerCert(name string, dnsNames []string, caConfig certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, error) {
 	caCert, err := caConfig.GenerateCertificate()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Webhook server can runs with several replicas which are distributed on different nodes and zones. By default, 2 replicas are started. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Webhook server can run on several replicas
```
