### PR TITLE
Guided Tour: Accessing Component Descriptors During Templating

### DIFF
--- a/docs/guided-tour/README.md
+++ b/docs/guided-tour/README.md
@@ -54,3 +54,7 @@ In this tour, you will learn about the different Landscaper features by simple e
 [12. Import Data Mappings](./import-export/import-data-mappings)
 
 [13. Export Parameters](./import-export/export-parameters)
+
+## Templating
+
+[14. Templating: Accessing Component Descriptors ](./templating/components)

--- a/docs/guided-tour/templating/components/README.md
+++ b/docs/guided-tour/templating/components/README.md
@@ -43,7 +43,7 @@ The template can be filled with values from a certain data structure. The follow
 provide access to the involved component descriptors:
 
 - **cd** : the component descriptor of the Installation. In our case, this is the root component descriptor.  
-  Let's consider an example, how to this field can be used. The expression below evaluates to the component name. 
+  Let's consider an example, how this field can be used. The expression below evaluates to the component name. 
   That is because field `cd` contains the complete 
   component descriptor, and inside it, the component name is located at the path `component.name`.
   ```yaml

--- a/docs/guided-tour/templating/components/README.md
+++ b/docs/guided-tour/templating/components/README.md
@@ -1,4 +1,4 @@
-# Templating Example
+# Templating: Accessing Component Descriptors 
 
 For prerequisites, see [here](../../README.md#prerequisites-and-basic-definitions).
 
@@ -6,44 +6,73 @@ This example demonstrates the templating of DeployItems. In particular, we show 
 during the templating.
 
 
-## Blueprint and Component Descriptors
+## References Between Component Descriptors
 
-You can find the blueprint for the current example [here](./blueprint). 
+Component descriptors can reference other component descriptors. In this example we consider three component descriptors, 
+which we name as follows:
+- the [root component descriptor](./component-root/component-descriptor.yaml),
+- the [core component descriptor](./component-core/component-descriptor.yaml),
+- the [extension component descriptor](./component-extension/component-descriptor.yaml).  
 
-We have uploaded the blueprint and the component descriptors into an OCI registry, so that the Landscaper can read them from there:
-- [blueprint](https://eu.gcr.io/gardener-project/landscaper/examples/blueprints/guided-tour/external-blueprint)
-- [component github.com/gardener/landscaper-examples/guided-tour/templating-components-root](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-root)
-- [component github.com/gardener/landscaper-examples/guided-tour/templating-components-core](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-core)
-- [component github.com/gardener/landscaper-examples/guided-tour/templating-components-extension](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-extension)
+The root component descriptor references the other two in its section `component.componentReferences`:
+
+```yaml
+component:
+  ...
+  componentReferences:
+    - componentName: github.com/gardener/landscaper-examples/guided-tour/templating-components-core
+      name: core
+      version: 1.0.0
+    - componentName: github.com/gardener/landscaper-examples/guided-tour/templating-components-extension
+      name: extension
+      version: 1.0.0
+```
+
+We have uploaded these three component descriptors into an OCI registry, so that the Landscaper can read them from there
+([root](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-root), 
+[core](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-core), 
+[extension](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-extension)).
 
 
-## Template
+## The Blueprint
 
-The file [blueprint/deploy-execution.yaml](./blueprint/deploy-execution.yaml) contains a [Go Template][2] which is 
-used to generate a DeployItem. 
-
+The [blueprint](./blueprint) of the present example belongs to the root component. Part of the blueprint is a 
+[deploy execution](./blueprint/deploy-execution.yaml). The deploy execution is a [Go Template][2], 
+which is used to generate a DeployItem. 
 The template can be filled with values from a certain data structure. The following fields in this data structure 
 provide access to the involved component descriptors:
 
-- **cd** : the component descriptor of the Installation.  
-  For example, the expression below evaluates to the component name. That is because field `cd` contains the complete 
+- **cd** : the component descriptor of the Installation. In our case, this is the root component descriptor.  
+  Let's consider an example, how to this field can be used. The expression below evaluates to the component name. 
+  That is because field `cd` contains the complete 
   component descriptor, and inside it, the component name is located at the path `component.name`.
   ```yaml
   {{ .cd.component.name }}
   ```
 
-- **components** : the list of all referenced component descriptors. A component descriptor can reference others. For
-  example the [root component descriptor](./component-root/component-descriptor.yaml) of this example 
-  references two other component descriptors in its section `component.componentReferences`. 
-  The field `components` contains the component descriptor of the Installation, and all further component descriptors
-  which can be reached from this one by (transitively) following component references.  
-  For example, a list with the names of the involved components can be obtained as follows:
+- **components** : a list of component descriptors. It contains the component descriptor of the 
+  Installation, and all further component descriptors which can be reached from this one by (transitively) following
+  component references. In our case, the list contains the three component descriptors from above.
+  To give an example, a list with the names of the involved components can be obtained as follows:
   ```yaml
   componentNames:
   {{ range $index, $comp := .components }}
     - {{ $comp.component.name }}  
   {{ end }}
   ```
+
+Let's discuss the  [deploy execution](./blueprint/deploy-execution.yaml) of our blueprint.
+
+- First, it loops over all components and collects all their resources in a list: `$resources`.  
+- In a second step, it selects the resources with certain labels. Resources with label `landscaper.gardener.cloud/guided-tour/type`
+are added to a dictionary `$typedResources`, and resources with label `landscaper.gardener.cloud/guided-tour/auxiliary` are added to
+a dictionary `$auxiliaryResources`.  
+- Finally, these "typed" and "auxiliary" resources are inserted at different places in a ConfigMap manifest, which will
+be deployed by the manifest deployer.  
+
+Note that you can use certain [sprig template functions][3] like `list`, `append`, `dict`, etc.
+
+For more details, see [Templating][1].
 
 
 ## Procedure
@@ -75,6 +104,8 @@ kubectl delete inst -n example templating-components
 
 [Templating][1]  
 [Go Template][2]  
+[Sprig template functions][3]
 
 [1]: ../../../usage/Templating.md  
 [2]: https://pkg.go.dev/text/template  
+[3]: http://masterminds.github.io/sprig/

--- a/docs/guided-tour/templating/components/README.md
+++ b/docs/guided-tour/templating/components/README.md
@@ -68,9 +68,38 @@ Let's discuss the  [deploy execution](./blueprint/deploy-execution.yaml) of our 
 are added to a dictionary `$typedResources`, and resources with label `landscaper.gardener.cloud/guided-tour/auxiliary` are added to
 a dictionary `$auxiliaryResources`.  
 - Finally, these "typed" and "auxiliary" resources are inserted at different places in a ConfigMap manifest, which will
-be deployed by the manifest deployer.  
+be deployed by the manifest deployer. 
 
-Note that you can use certain [sprig template functions][3] like `list`, `append`, `dict`, etc.
+The resources that we have collected from the component descriptors look for example like this:
+```yaml
+- access:
+    imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/image-a:1.0.0
+    type: ociRegistry
+  labels:
+    - name: landscaper.gardener.cloud/guided-tour/type
+      value: type-a
+  name: image-a
+  relation: external
+  type: ociImage
+  version: 1.0.0
+```
+This is not yet the desired result format. Therefore, we use a template `formateResource` to transform the resources. 
+The template extracts the field `.access.imageReference` from a resource, splits the string value in 
+three parts, and produces the following result: 
+```yaml
+registry: eu.gcr.io
+repository: gardener-project/landscaper/examples/images/image-a
+tag: 1.0.0
+```
+
+We can pass only one argument to a template. However, our template `formateResource` needs two inputs, a `resource` and
+an `indent`. To solve this, we put both values in a dictionary `$args` and pass this dictionary to template:
+```yaml
+{{- $args := dict "resource" $resource.access.imageReference "indent" 20 }}
+{{- template "formatResource" $args }}
+```
+
+Note that you can use certain [sprig template functions][3] like `list`, `append`, `dict` etc.
 
 For more details, see [Templating][1].
 

--- a/docs/guided-tour/templating/components/README.md
+++ b/docs/guided-tour/templating/components/README.md
@@ -1,0 +1,80 @@
+# Templating Example
+
+For prerequisites, see [here](../../README.md#prerequisites-and-basic-definitions).
+
+This example demonstrates the templating of DeployItems. In particular, we show how you can access component descriptors
+during the templating.
+
+
+## Blueprint and Component Descriptors
+
+You can find the blueprint for the current example [here](./blueprint). 
+
+We have uploaded the blueprint and the component descriptors into an OCI registry, so that the Landscaper can read them from there:
+- [blueprint](https://eu.gcr.io/gardener-project/landscaper/examples/blueprints/guided-tour/external-blueprint)
+- [component github.com/gardener/landscaper-examples/guided-tour/templating-components-root](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-root)
+- [component github.com/gardener/landscaper-examples/guided-tour/templating-components-core](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-core)
+- [component github.com/gardener/landscaper-examples/guided-tour/templating-components-extension](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/templating-components-extension)
+
+
+## Template
+
+The file [blueprint/deploy-execution.yaml](./blueprint/deploy-execution.yaml) contains a [Go Template][2] which is 
+used to generate a DeployItem. 
+
+The template can be filled with values from a certain data structure. The following fields in this data structure 
+provide access to the involved component descriptors:
+
+- **cd** : the component descriptor of the Installation.  
+  For example, the expression below evaluates to the component name. That is because field `cd` contains the complete 
+  component descriptor, and inside it, the component name is located at the path `component.name`.
+  ```yaml
+  {{ .cd.component.name }}
+  ```
+
+- **components** : the list of all referenced component descriptors. A component descriptor can reference others. For
+  example the [root component descriptor](./component-root/component-descriptor.yaml) of this example 
+  references two other component descriptors in its section `component.componentReferences`. 
+  The field `components` contains the component descriptor of the Installation, and all further component descriptors
+  which can be reached from this one by (transitively) following component references.  
+  For example, a list with the names of the involved components can be obtained as follows:
+  ```yaml
+  componentNames:
+  {{ range $index, $comp := .components }}
+    - {{ $comp.component.name }}  
+  {{ end }}
+  ```
+
+
+## Procedure
+
+The procedure to deploy the helm chart with the Landscaper is:
+
+1. Insert the kubeconfig of your target cluster into file [target.yaml](installation/target.yaml).
+
+2. On the Landscaper resource cluster, create namespace `example` and apply the [context.yaml](./installation/context.yaml), 
+   the [target.yaml](installation/target.yaml), and the [installation.yaml](installation/installation.yaml):
+
+   ```shell
+   kubectl create ns example
+   kubectl apply -f <path to context.yaml>
+   kubectl apply -f <path to target.yaml>
+   kubectl apply -f <path to installation.yaml>
+   ```
+
+## Cleanup
+
+To clean up, delete the Installation from the Landscaper resource cluster:
+
+```shell
+kubectl delete inst -n example templating-components
+```
+
+
+## References 
+
+[Templating][1]  
+[Go Template][2]  
+
+[1]: ../../../usage/Templating.md  
+[2]: https://pkg.go.dev/text/template  

--- a/docs/guided-tour/templating/components/blueprint/blueprint.yaml
+++ b/docs/guided-tour/templating/components/blueprint/blueprint.yaml
@@ -1,0 +1,13 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+jsonSchema: "https://json-schema.org/draft/2019-09/schema"
+
+imports:
+  - name: cluster
+    type: target
+    targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+deployExecutions:
+  - name: default-deploy-execution
+    file: /deploy-execution.yaml
+    type: GoTemplate

--- a/docs/guided-tour/templating/components/blueprint/deploy-execution.yaml
+++ b/docs/guided-tour/templating/components/blueprint/deploy-execution.yaml
@@ -57,13 +57,13 @@ deployItems:
                 images:
                   types:
                     {{- range $type, $resource := $typedResources }}
-                    {{- $args := dict "resource" $resource.access.imageReference "indent" 22 }}
+                    {{- $args := dict "resource" $resource.access.imageReference "indent" 20 }}
                     {{ $type }}:
                       {{- template "formatResource" $args }}
                     {{- end }}
                 auxiliaryImages:
                   {{- range $type, $resource := $auxiliaryResources }}
-                  {{- $args := dict "resource" $resource.access.imageReference "indent" 20 }}
+                  {{- $args := dict "resource" $resource.access.imageReference "indent" 18 }}
                   {{ $type }}:
                     {{- template "formatResource" $args }}
                   {{- end }}

--- a/docs/guided-tour/templating/components/blueprint/deploy-execution.yaml
+++ b/docs/guided-tour/templating/components/blueprint/deploy-execution.yaml
@@ -1,0 +1,69 @@
+{{- $resources := list }}
+{{- $typedResources := dict }}
+{{- $auxiliaryResources := dict }}
+
+
+{{/* collect all resources of the component and its referenced components in the list $resources */}}
+{{- range $_, $component := .components.components }}
+  {{- range $_, $resource := $component.component.resources }}
+    {{- $resources = append $resources $resource }}
+  {{- end }}
+{{- end }}
+
+
+{{/* classify the resources according to their labels */}}
+{{- range $index, $resource := $resources }}
+  {{- range .labels }}
+    {{- if eq .name "landscaper.gardener.cloud/guided-tour/type" }}
+      {{- $_ := set $typedResources .value $resource }}
+    {{- else if eq .name "landscaper.gardener.cloud/guided-tour/auxiliary" }}
+      {{- $_ := set $auxiliaryResources .value $resource }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+
+{{- define "formatResource"}}
+  {{- $indent := get . "indent" }}
+  {{- $resource := get . "resource" }}
+  {{- $a := splitn "/" 2 $resource }}
+  {{- $b := splitn ":" 2 $a._1 }}
+  {{ printf "registry: %s" $a._0 | indent $indent }}
+  {{ printf "repository: %s" $b._0 | indent $indent }}
+  {{ printf "tag: %s" $b._1 | indent $indent }}
+{{- end }}
+
+
+deployItems:
+  - name: default-deploy-item
+    type: landscaper.gardener.cloud/kubernetes-manifest
+    target:
+      import: cluster
+
+    config:
+      apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
+      kind: ProviderConfiguration
+      updateStrategy: update
+      manifests:
+        - policy: manage
+          manifest:
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: templating-components
+              namespace: example
+            data:
+              content: |
+                images:
+                  types:
+                    {{- range $type, $resource := $typedResources }}
+                    {{- $args := dict "resource" $resource.access.imageReference "indent" 22 }}
+                    {{ $type }}:
+                      {{- template "formatResource" $args }}
+                    {{- end }}
+                auxiliaryImages:
+                  {{- range $type, $resource := $auxiliaryResources }}
+                  {{- $args := dict "resource" $resource.access.imageReference "indent" 20 }}
+                  {{ $type }}:
+                    {{- template "formatResource" $args }}
+                  {{- end }}

--- a/docs/guided-tour/templating/components/commands/push-blueprint.sh
+++ b/docs/guided-tour/templating/components/commands/push-blueprint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPONENT_DIR="$(dirname $0)/.."
+BLUEPRINT_DIR="${COMPONENT_DIR}/blueprint"
+OCI_ARTIFACT_REF="eu.gcr.io/gardener-project/landscaper/examples/blueprints/guided-tour/templating-components:1.0.0"
+
+landscaper-cli blueprints push "${OCI_ARTIFACT_REF}" "${BLUEPRINT_DIR}"

--- a/docs/guided-tour/templating/components/commands/push-component-descriptor-core.sh
+++ b/docs/guided-tour/templating/components/commands/push-component-descriptor-core.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# COMPONENT_DIR is the is the path to the directory that contains the component-descriptor.yaml and resources.yaml
+EXAMPLE_DIR="$(dirname $0)/.."
+COMPONENT_DIR="${EXAMPLE_DIR}/component-core"
+
+# TRANSPORT_FILE is the path to the transport tar file that will be created and pushed to the oci registry
+TRANSPORT_FILE=${EXAMPLE_DIR}/commands/transport-core.tar
+
+echo "Component directory: ${COMPONENT_DIR}"
+echo "Transport file:      ${TRANSPORT_FILE}"
+
+if [ -f "${TRANSPORT_FILE}" ]; then
+  echo "Removing old transport file"
+  rm "${TRANSPORT_FILE}"
+fi
+
+echo "Creating transport file"
+landscaper-cli component-cli component-archive "${COMPONENT_DIR}" "${TRANSPORT_FILE}"
+
+echo "Pushing transport file to oci registry"
+component-cli ctf push "${TRANSPORT_FILE}"

--- a/docs/guided-tour/templating/components/commands/push-component-descriptor-extension.sh
+++ b/docs/guided-tour/templating/components/commands/push-component-descriptor-extension.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# COMPONENT_DIR is the is the path to the directory that contains the component-descriptor.yaml and resources.yaml
+EXAMPLE_DIR="$(dirname $0)/.."
+COMPONENT_DIR="${EXAMPLE_DIR}/component-extension"
+
+# TRANSPORT_FILE is the path to the transport tar file that will be created and pushed to the oci registry
+TRANSPORT_FILE=${EXAMPLE_DIR}/commands/transport-extension.tar
+
+echo "Component directory: ${COMPONENT_DIR}"
+echo "Transport file:      ${TRANSPORT_FILE}"
+
+if [ -f "${TRANSPORT_FILE}" ]; then
+  echo "Removing old transport file"
+  rm "${TRANSPORT_FILE}"
+fi
+
+echo "Creating transport file"
+landscaper-cli component-cli component-archive "${COMPONENT_DIR}" "${TRANSPORT_FILE}"
+
+echo "Pushing transport file to oci registry"
+component-cli ctf push "${TRANSPORT_FILE}"

--- a/docs/guided-tour/templating/components/commands/push-component-descriptor-root.sh
+++ b/docs/guided-tour/templating/components/commands/push-component-descriptor-root.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# COMPONENT_DIR is the is the path to the directory that contains the component-descriptor.yaml and resources.yaml
+EXAMPLE_DIR="$(dirname $0)/.."
+COMPONENT_DIR="${EXAMPLE_DIR}/component-root"
+
+# TRANSPORT_FILE is the path to the transport tar file that will be created and pushed to the oci registry
+TRANSPORT_FILE=${EXAMPLE_DIR}/commands/transport-root.tar
+
+echo "Component directory: ${COMPONENT_DIR}"
+echo "Transport file:      ${TRANSPORT_FILE}"
+
+if [ -f "${TRANSPORT_FILE}" ]; then
+  echo "Removing old transport file"
+  rm "${TRANSPORT_FILE}"
+fi
+
+echo "Creating transport file"
+landscaper-cli component-cli component-archive "${COMPONENT_DIR}" "${TRANSPORT_FILE}"
+
+echo "Pushing transport file to oci registry"
+component-cli ctf push "${TRANSPORT_FILE}"

--- a/docs/guided-tour/templating/components/component-core/component-descriptor.yaml
+++ b/docs/guided-tour/templating/components/component-core/component-descriptor.yaml
@@ -1,0 +1,37 @@
+meta:
+  schemaVersion: 'v2'
+component:
+  name: 'github.com/gardener/landscaper-examples/guided-tour/templating-components-core'
+  version: '1.0.0'
+
+  repositoryContexts:
+    - type: 'ociRegistry'
+      baseUrl: 'eu.gcr.io/gardener-project/landscaper/examples'
+
+  provider: 'internal'
+
+  componentReferences: []
+
+  sources: []
+
+  resources:
+    - access:
+        imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/image-a:1.0.0
+        type: ociRegistry
+      labels:
+        - name: landscaper.gardener.cloud/guided-tour/type
+          value: type-a
+      name: image-a
+      relation: external
+      type: ociImage
+      version: 1.0.0
+    - access:
+        imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/image-b:1.0.0
+        type: ociRegistry
+      labels:
+        - name: landscaper.gardener.cloud/guided-tour/auxiliary
+          value: aux-b
+      name: image-b
+      relation: external
+      type: ociImage
+      version: 1.0.0

--- a/docs/guided-tour/templating/components/component-extension/component-descriptor.yaml
+++ b/docs/guided-tour/templating/components/component-extension/component-descriptor.yaml
@@ -1,0 +1,37 @@
+meta:
+  schemaVersion: 'v2'
+component:
+  name: 'github.com/gardener/landscaper-examples/guided-tour/templating-components-extension'
+  version: '1.0.0'
+
+  repositoryContexts:
+    - type: 'ociRegistry'
+      baseUrl: 'eu.gcr.io/gardener-project/landscaper/examples'
+
+  provider: 'internal'
+
+  componentReferences: []
+
+  sources: []
+
+  resources:
+    - access:
+        imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/image-c:1.0.0
+        type: ociRegistry
+      labels:
+        - name: landscaper.gardener.cloud/guided-tour/auxiliary
+          value: aux-c
+      name: image-c
+      relation: external
+      type: ociImage
+      version: 1.0.0
+    - access:
+        imageReference: eu.gcr.io/gardener-project/landscaper/examples/images/image-d:1.0.0
+        type: ociRegistry
+      labels:
+        - name: landscaper.gardener.cloud/guided-tour/type
+          value: type-d
+      name: image-d
+      relation: external
+      type: ociImage
+      version: 1.0.0

--- a/docs/guided-tour/templating/components/component-root/component-descriptor.yaml
+++ b/docs/guided-tour/templating/components/component-root/component-descriptor.yaml
@@ -1,0 +1,30 @@
+meta:
+  schemaVersion: 'v2'
+component:
+  name: 'github.com/gardener/landscaper-examples/guided-tour/templating-components-root'
+  version: '1.0.0'
+
+  repositoryContexts:
+    - type: 'ociRegistry'
+      baseUrl: 'eu.gcr.io/gardener-project/landscaper/examples'
+
+  provider: 'internal'
+
+  componentReferences:
+    - componentName: github.com/gardener/landscaper-examples/guided-tour/templating-components-core
+      name: core
+      version: 1.0.0
+    - componentName: github.com/gardener/landscaper-examples/guided-tour/templating-components-extension
+      name: extension
+      version: 1.0.0
+
+  sources: []
+
+  resources:
+    - name: blueprint
+      type: blueprint
+      version: 1.0.0
+      relation: external
+      access:
+        type: ociRegistry
+        imageReference: eu.gcr.io/gardener-project/landscaper/examples/blueprints/guided-tour/templating-components:1.0.0

--- a/docs/guided-tour/templating/components/installation/context.yaml
+++ b/docs/guided-tour/templating/components/installation/context.yaml
@@ -1,0 +1,9 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Context
+metadata:
+  name: landscaper-examples
+  namespace: example
+
+repositoryContext:
+  baseUrl: eu.gcr.io/gardener-project/landscaper/examples
+  type: ociRegistry

--- a/docs/guided-tour/templating/components/installation/installation.yaml
+++ b/docs/guided-tour/templating/components/installation/installation.yaml
@@ -1,0 +1,24 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: templating-components
+  namespace: example
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
+
+spec:
+  context: landscaper-examples
+
+  componentDescriptor:
+    ref:
+      componentName: github.com/gardener/landscaper-examples/guided-tour/templating-components-root
+      version: 1.0.0
+
+  blueprint:
+    ref:
+      resourceName: blueprint
+
+  imports:
+    targets:
+      - name: cluster        # name of an import parameter of the blueprint
+        target: my-cluster   # name of the Target custom resource containing the kubeconfig of the target cluster

--- a/docs/guided-tour/templating/components/installation/target.yaml
+++ b/docs/guided-tour/templating/components/installation/target.yaml
@@ -1,0 +1,12 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Target
+metadata:
+  name: my-cluster
+  namespace: example
+spec:
+  type: landscaper.gardener.cloud/kubernetes-cluster
+  config:
+    kubeconfig: |
+      apiVersion: v1  # <-------------------------- replace with your kubeconfig
+      kind: Config    #
+      ...             #


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind task
/priority 3

**What this PR does / why we need it**:

This pull request adds an example to the Guided Tour. The example demonstrates how component descriptors can be accessed during the templating of a deploy execution.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
- the guided tour has been extended with a templating example
```
