### PR TITLE
Bugfix: duplicate CDs in list of components

### DIFF
--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -346,6 +346,11 @@ All template [executions](./Templating.md) get a common standardized binding:
   the component descriptor of the owning component
 
 
+- **`components`**
+
+  the component descriptors of all referenced components, either directly or transitively (includes the component descriptor of the owning component too)
+
+
 - **`blueprintDef`**
 
   the blueprint definition, as given in the installation (not the blueprint.yaml itself)

--- a/pkg/landscaper/registry/components/cdutils/utils.go
+++ b/pkg/landscaper/registry/components/cdutils/utils.go
@@ -92,10 +92,16 @@ func componentIdentifierFromCD(cd cdv2.ComponentDescriptor) componentIdentifier 
 // resolveToComponentDescriptorListHelper is a helper function which fetches all referenced component descriptor, including the referencing one
 // the fetched CDs are stored in the given 'cds' map to avoid duplicates
 func resolveToComponentDescriptorListHelper(ctx context.Context, client ctf.ComponentResolver, cd cdv2.ComponentDescriptor, repositoryContext *cdv2.UnstructuredTypedObject, overwriter componentoverwrites.Overwriter, cds map[componentIdentifier]cdv2.ComponentDescriptor) error {
+	cid := componentIdentifierFromCD(cd)
+	if _, ok := cds[cid]; ok {
+		// we have already handled this component before, no need to do it again
+		return nil
+	}
+	cds[cid] = cd
+
 	if len(cd.RepositoryContexts) == 0 {
 		return errors.New("component descriptor must at least contain one repository context with a base url")
 	}
-	cds[componentIdentifierFromCD(cd)] = cd
 
 	for _, compRef := range cd.ComponentReferences {
 		resolvedComponent, err := ResolveWithOverwriter(ctx, client, repositoryContext, compRef.ComponentName, compRef.Version, overwriter)

--- a/pkg/landscaper/registry/components/cdutils/utils.go
+++ b/pkg/landscaper/registry/components/cdutils/utils.go
@@ -64,26 +64,51 @@ var _ ctf.TypedBlobResolver = &BlobResolverFunc{}
 // ResolveToComponentDescriptorList transitively resolves all referenced components of a component descriptor and
 // return a list containing all resolved component descriptors.
 func ResolveToComponentDescriptorList(ctx context.Context, client ctf.ComponentResolver, cd cdv2.ComponentDescriptor, repositoryContext *cdv2.UnstructuredTypedObject, overwriter componentoverwrites.Overwriter) (cdv2.ComponentDescriptorList, error) {
+	cds := map[componentIdentifier]cdv2.ComponentDescriptor{} // the resolved component descriptor list will be stored in this
 	cdList := cdv2.ComponentDescriptorList{}
 	cdList.Metadata = cd.Metadata
-	if len(cd.RepositoryContexts) == 0 {
-		return cdList, errors.New("component descriptor must at least contain one repository context with a base url")
+	if err := resolveToComponentDescriptorListHelper(ctx, client, cd, repositoryContext, overwriter, cds); err != nil {
+		return cdList, err
 	}
-	cdList.Components = []cdv2.ComponentDescriptor{cd}
+	cdList.Components = make([]cdv2.ComponentDescriptor, len(cds))
+	i := 0
+	for _, cd := range cds {
+		cdList.Components[i] = cd
+		i++
+	}
+
+	return cdList, nil
+}
+
+type componentIdentifier struct {
+	Name    string
+	Version string
+}
+
+func componentIdentifierFromCD(cd cdv2.ComponentDescriptor) componentIdentifier {
+	return componentIdentifier{Name: cd.Name, Version: cd.Version}
+}
+
+// resolveToComponentDescriptorListHelper is a helper function which fetches all referenced component descriptor, including the referencing one
+// the fetched CDs are stored in the given 'cds' map to avoid duplicates
+func resolveToComponentDescriptorListHelper(ctx context.Context, client ctf.ComponentResolver, cd cdv2.ComponentDescriptor, repositoryContext *cdv2.UnstructuredTypedObject, overwriter componentoverwrites.Overwriter, cds map[componentIdentifier]cdv2.ComponentDescriptor) error {
+	if len(cd.RepositoryContexts) == 0 {
+		return errors.New("component descriptor must at least contain one repository context with a base url")
+	}
+	cds[componentIdentifierFromCD(cd)] = cd
 
 	for _, compRef := range cd.ComponentReferences {
 		resolvedComponent, err := ResolveWithOverwriter(ctx, client, repositoryContext, compRef.ComponentName, compRef.Version, overwriter)
 		if err != nil {
-			return cdList, fmt.Errorf("unable to resolve component descriptor for %s with version %s: %w", compRef.Name, compRef.Version, err)
+			return fmt.Errorf("unable to resolve component descriptor for %s with version %s: %w", compRef.Name, compRef.Version, err)
 		}
-		cdList.Components = append(cdList.Components, *resolvedComponent)
-		resolvedComponentReferences, err := ResolveToComponentDescriptorList(ctx, client, *resolvedComponent, repositoryContext, overwriter)
+		err = resolveToComponentDescriptorListHelper(ctx, client, *resolvedComponent, repositoryContext, overwriter, cds)
 		if err != nil {
-			return cdList, fmt.Errorf("unable to resolve component references for component descriptor %s with version %s: %w", compRef.Name, compRef.Version, err)
+			return fmt.Errorf("unable to resolve component references for component descriptor %s with version %s: %w", compRef.Name, compRef.Version, err)
 		}
-		cdList.Components = append(cdList.Components, resolvedComponentReferences.Components...)
 	}
-	return cdList, nil
+
+	return nil
 }
 
 // ResolveWithOverwriter is like resolver.Resolve, but applies the given overwrites first.

--- a/pkg/landscaper/registry/components/cdutils/utils_test.go
+++ b/pkg/landscaper/registry/components/cdutils/utils_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdutils_test
+
+import (
+	"context"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/ctf"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	testutils "github.com/gardener/landscaper/test/utils"
+
+	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
+	"github.com/gardener/landscaper/pkg/landscaper/registry/components/cdutils"
+)
+
+var (
+	fakeCompRepo ctf.ComponentResolver
+	repoCtx      *cdv2.UnstructuredTypedObject
+	ctx          context.Context
+	err          error
+)
+
+var _ = BeforeSuite(func() {
+	fakeCompRepo, err = componentsregistry.NewLocalClient("../../testdata/registry")
+	repoCtx = testutils.LocalRepositoryContext("../../testdata/registry")
+	Expect(err).ToNot(HaveOccurred())
+})
+
+type componentIdentifier struct {
+	Name    string
+	Version string
+}
+
+func componentIdentifierFromCD(cd cdv2.ComponentDescriptor) componentIdentifier {
+	return componentIdentifier{Name: cd.Name, Version: cd.Version}
+}
+
+var _ = Describe("cdutils Tests", func() {
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("should return each referenced component only once when resolving component references", func() {
+		cd, err := cdutils.ResolveWithOverwriter(ctx, fakeCompRepo, repoCtx, "example.com/root", "v1.0.0", nil)
+		testutils.ExpectNoError(err)
+		Expect(cd).ToNot(BeNil())
+		cdList, err := cdutils.ResolveToComponentDescriptorList(ctx, fakeCompRepo, *cd, repoCtx, nil)
+		testutils.ExpectNoError(err)
+		fetchedComponents := []componentIdentifier{}
+		for _, fcd := range cdList.Components {
+			fetchedComponents = append(fetchedComponents, componentIdentifierFromCD(fcd))
+		}
+		Expect(fetchedComponents).To(ConsistOf(
+			componentIdentifier{
+				Name:    "example.com/root",
+				Version: "v1.0.0",
+			},
+			componentIdentifier{
+				Name:    "example.com/a",
+				Version: "v1.0.0",
+			},
+			componentIdentifier{
+				Name:    "example.com/b",
+				Version: "v1.0.0",
+			},
+			componentIdentifier{
+				Name:    "example.com/ab",
+				Version: "v1.0.0",
+			},
+		))
+	})
+
+})

--- a/pkg/landscaper/registry/testdata/registry/a/component-descriptor.yaml
+++ b/pkg/landscaper/registry/testdata/registry/a/component-descriptor.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/a
+  version: v1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "../../../testdata/registry"
+
+  sources: []
+  resources: []
+  componentReferences:
+  - name: a-ref-ab
+    componentName: example.com/ab
+    version: v1.0.0

--- a/pkg/landscaper/registry/testdata/registry/ab/component-descriptor.yaml
+++ b/pkg/landscaper/registry/testdata/registry/ab/component-descriptor.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/ab
+  version: v1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "../../../testdata/registry"
+
+  sources: []
+  resources: []
+  componentReferences: []

--- a/pkg/landscaper/registry/testdata/registry/b/component-descriptor.yaml
+++ b/pkg/landscaper/registry/testdata/registry/b/component-descriptor.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/b
+  version: v1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "../../../testdata/registry"
+
+  sources: []
+  resources: []
+  componentReferences:
+  - name: b-ref-ab
+    componentName: example.com/ab
+    version: v1.0.0

--- a/pkg/landscaper/registry/testdata/registry/root/component-descriptor.yaml
+++ b/pkg/landscaper/registry/testdata/registry/root/component-descriptor.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/root
+  version: v1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "../../../testdata/registry"
+
+  sources: []
+  resources: []
+  componentReferences:
+  - name: root-ref-a
+    componentName: example.com/a
+    version: v1.0.0
+  - name: root-ref-b
+    componentName: example.com/b
+    version: v1.0.0

--- a/test/utils/cnudie.go
+++ b/test/utils/cnudie.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	componentsregistry "github.com/gardener/landscaper/pkg/landscaper/registry/components"
 )
 
 // MakeRepositoryContext creates a new oci registry repository context.
@@ -28,6 +29,12 @@ func DefaultRepositoryContext(baseUrl string) *cdv2.UnstructuredTypedObject {
 // ExampleRepositoryContext creates a new example repository context.
 func ExampleRepositoryContext() *cdv2.UnstructuredTypedObject {
 	return DefaultRepositoryContext("example.com")
+}
+
+// LocalRepositoryContext returns a new 'local' repository context.
+func LocalRepositoryContext(baseurl string) *cdv2.UnstructuredTypedObject {
+	rctx, _ := cdv2.NewUnstructured(&componentsregistry.NewLocalRepository(baseurl).ObjectType)
+	return &rctx
 }
 
 // CreateExampleDefaultContext creates default context with the example repository.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:
When templating in blueprints, it was possible to access the list of all referenced components, including transitively referenced ones. There were a few problems, though:
1. This binding was not mentioned in the documentation.
2. The code which resolves the component references had some bugs which lead to a lot of duplicates in the generated list.

This PR adresses both of these issues.

**Special notes for your reviewer**:
The solution would be way nicer if Golang had some kind of Set structure which allowed for a custom comparator - we could use a Set of component descriptors which are considered equal if their name and version are equal, respectively. Unfortunately, Golang doesn't have a Set structure at all and the implementation from the k8s apimachinery library does not allow for custom comparators. In theory, it should still work with the default field-wise comparison, but since CDs can become quite big, I implemented this via a map instead, using a struct with name and version as the key.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
The `components` binding which is available in the blueprint templating and contains a list of all referenced components is now mentioned in the documentation.
```
```bugfix user
The `components` binding which is available in the blueprint templating will not contain duplicates anymore.
```
