### PR TITLE
use the correct expected replicas value for lshealthcheck

### DIFF
--- a/pkg/landscaper/controllers/healthcheck/add.go
+++ b/pkg/landscaper/controllers/healthcheck/add.go
@@ -3,6 +3,7 @@ package healthcheck
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +46,7 @@ func AddControllersToManager(ctx context.Context, logger logging.Logger, hostMgr
 
 	log := logger.Reconciles("lsHealthCheck", "LsHealthCheck")
 	healthCheckController := NewLsHealthCheckController(log, agentConfig, lsDeployments,
-		cl, hostMgr.GetScheme(), enabledDeployers)
+		cl, hostMgr.GetScheme(), enabledDeployers, 1*time.Minute)
 
 	err := builder.ControllerManagedBy(hostMgr).
 		For(&lsv1alpha1.LsHealthCheck{}).

--- a/pkg/landscaper/controllers/healthcheck/healtcheck_suite_test.go
+++ b/pkg/landscaper/controllers/healthcheck/healtcheck_suite_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper/test/utils/envtest"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Execution Controller Test Suite")
+}
+
+var (
+	testenv *envtest.Environment
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	projectRoot := filepath.Join("../../../../")
+	testenv, err = envtest.New(projectRoot)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = testenv.Start()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).ToNot(HaveOccurred())
+})

--- a/pkg/landscaper/controllers/healthcheck/reconcile_test.go
+++ b/pkg/landscaper/controllers/healthcheck/reconcile_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/landscaper/apis/config"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	"github.com/gardener/landscaper/pkg/api"
+	"github.com/gardener/landscaper/pkg/landscaper/controllers/healthcheck"
+	testutils "github.com/gardener/landscaper/test/utils"
+
+	"github.com/gardener/landscaper/test/utils/envtest"
+)
+
+var _ = Describe("Reconcile", func() {
+	var (
+		ctrl  reconcile.Reconciler
+		state *envtest.State
+	)
+	BeforeEach(func() {
+		var err error
+		state, err = testenv.InitState(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should set status to ok when all replicas are available", func() {
+		var err error
+		ctx := context.Background()
+
+		state, err = testenv.InitResources(ctx, "./testdata/test1")
+		Expect(err).ToNot(HaveOccurred())
+
+		agentConfig := config.AgentConfiguration{
+			Name:                "landscaper",
+			Namespace:           state.Namespace,
+			LandscaperNamespace: "ls-system",
+		}
+
+		lsDeployments := config.LsDeployments{
+			LsController: "landscaper-controller",
+			WebHook:      "landscaper-webhooks",
+		}
+
+		ctrl = healthcheck.NewLsHealthCheckController(logging.Discard(), &agentConfig, &lsDeployments, state.Client, api.Scheme, []string{"helm"}, 1*time.Second)
+
+		lsHealthCheck := &lsv1alpha1.LsHealthCheck{}
+		Expect(state.Client.Get(ctx, types.NamespacedName{Name: agentConfig.Name, Namespace: state.Namespace}, lsHealthCheck)).ToNot(HaveOccurred())
+
+		beforeReconcile := time.Now()
+		time.Sleep(time.Second * 1)
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(lsHealthCheck))
+
+		Expect(state.Client.Get(ctx, types.NamespacedName{Name: agentConfig.Name, Namespace: state.Namespace}, lsHealthCheck)).ToNot(HaveOccurred())
+		Expect(lsHealthCheck.Status).To(Equal(lsv1alpha1.LsHealthCheckStatusOk))
+		Expect(lsHealthCheck.LastUpdateTime.Time.After(beforeReconcile)).To(BeTrue())
+	})
+
+	It("should set status to failed when not all replicas are available", func() {
+		var err error
+		ctx := context.Background()
+
+		state, err = testenv.InitResources(ctx, "./testdata/test2")
+		Expect(err).ToNot(HaveOccurred())
+
+		agentConfig := config.AgentConfiguration{
+			Name:                "landscaper",
+			Namespace:           state.Namespace,
+			LandscaperNamespace: "ls-system",
+		}
+
+		lsDeployments := config.LsDeployments{
+			LsController: "landscaper-controller",
+			WebHook:      "landscaper-webhooks",
+		}
+
+		ctrl = healthcheck.NewLsHealthCheckController(logging.Discard(), &agentConfig, &lsDeployments, state.Client, api.Scheme, []string{"helm"}, 1*time.Second)
+
+		lsHealthCheck := &lsv1alpha1.LsHealthCheck{}
+		Expect(state.Client.Get(ctx, types.NamespacedName{Name: agentConfig.Name, Namespace: state.Namespace}, lsHealthCheck)).ToNot(HaveOccurred())
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(lsHealthCheck))
+
+		// The health check only transitions to failed after two consecutive failed checks.
+		Expect(state.Client.Get(ctx, types.NamespacedName{Name: agentConfig.Name, Namespace: state.Namespace}, lsHealthCheck)).ToNot(HaveOccurred())
+
+		time.Sleep(2 * time.Second)
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(lsHealthCheck))
+		Expect(state.Client.Get(ctx, types.NamespacedName{Name: agentConfig.Name, Namespace: state.Namespace}, lsHealthCheck)).ToNot(HaveOccurred())
+		Expect(lsHealthCheck.Status).To(Equal(lsv1alpha1.LsHealthCheckStatusFailed))
+	})
+})

--- a/pkg/landscaper/controllers/healthcheck/testdata/test1/deployments.yaml
+++ b/pkg/landscaper/controllers/healthcheck/testdata/test1/deployments.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: landscaper-controller
+  namespace: {{ .Namespace }}
+  generation: 1
+  labels:
+    app: landscaper-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: landscaper-controller
+  template:
+    metadata:
+      labels:
+        app: landscaper-controller
+    spec:
+      containers:
+        - name: dummy
+          image: dummy:0.1.0
+
+status:
+  observedGeneration: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+...
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: landscaper-webhooks
+  namespace: {{ .Namespace }}
+  generation: 1
+  labels:
+    app: landscaper-webhooks
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: landscaper-webhooks
+  template:
+    metadata:
+      labels:
+        app: landscaper-webhooks
+    spec:
+      containers:
+        - name: dummy
+          image: dummy:0.1.0
+
+status:
+  observedGeneration: 1
+  replicas: 2
+  updatedReplicas: 2
+  availableReplicas: 2
+  readyReplicas: 2
+...
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: helm-landscaper-helm-deployer
+  namespace: {{ .Namespace }}
+  generation: 1
+  labels:
+    app: landscaper-webhooks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: landscaper-webhooks
+  template:
+    metadata:
+      labels:
+        app: landscaper-webhooks
+    spec:
+      containers:
+        - name: dummy
+          image: dummy:0.1.0
+
+status:
+  observedGeneration: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+...

--- a/pkg/landscaper/controllers/healthcheck/testdata/test1/lshealthcheck.yaml
+++ b/pkg/landscaper/controllers/healthcheck/testdata/test1/lshealthcheck.yaml
@@ -1,0 +1,8 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: LsHealthCheck
+metadata:
+  name: landscaper
+  namespace: {{ .Namespace }}
+status: Init
+description: ""
+lastUpdateTime: "1970-01-01T00:00:00Z"

--- a/pkg/landscaper/controllers/healthcheck/testdata/test2/deployments.yaml
+++ b/pkg/landscaper/controllers/healthcheck/testdata/test2/deployments.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: landscaper-controller
+  namespace: {{ .Namespace }}
+  generation: 1
+  labels:
+    app: landscaper-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: landscaper-controller
+  template:
+    metadata:
+      labels:
+        app: landscaper-controller
+    spec:
+      containers:
+        - name: dummy
+          image: dummy:0.1.0
+
+status:
+  observedGeneration: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+...
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: landscaper-webhooks
+  namespace: {{ .Namespace }}
+  generation: 1
+  labels:
+    app: landscaper-webhooks
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: landscaper-webhooks
+  template:
+    metadata:
+      labels:
+        app: landscaper-webhooks
+    spec:
+      containers:
+        - name: dummy
+          image: dummy:0.1.0
+
+status:
+  observedGeneration: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+...
+---
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: helm-landscaper-helm-deployer
+  namespace: {{ .Namespace }}
+  generation: 1
+  labels:
+    app: landscaper-webhooks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: landscaper-webhooks
+  template:
+    metadata:
+      labels:
+        app: landscaper-webhooks
+    spec:
+      containers:
+        - name: dummy
+          image: dummy:0.1.0
+
+status:
+  observedGeneration: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+...

--- a/pkg/landscaper/controllers/healthcheck/testdata/test2/lshealthcheck.yaml
+++ b/pkg/landscaper/controllers/healthcheck/testdata/test2/lshealthcheck.yaml
@@ -1,0 +1,8 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: LsHealthCheck
+metadata:
+  name: landscaper
+  namespace: {{ .Namespace }}
+status: Init
+description: ""
+lastUpdateTime: "1970-01-01T00:00:00Z"

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -287,6 +289,18 @@ func decodeAndAppendLSObject(data []byte, objects []client.Object, state *State)
 		}
 		state.ConfigMaps[types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}.String()] = cm
 		return append(objects, cm), nil
+	case DeploymentGVK.Kind:
+		deployment := &appsv1.Deployment{}
+		if _, _, err := decoder.Decode(data, nil, deployment); err != nil {
+			return nil, fmt.Errorf("unable to decode file as deployment: %w", err)
+		}
+		return append(objects, deployment), nil
+	case LSHealthCheckGVK.Kind:
+		lsHealthCheck := &lsv1alpha1.LsHealthCheck{}
+		if _, _, err := decoder.Decode(data, nil, lsHealthCheck); err != nil {
+			return nil, fmt.Errorf("unable to decode file as lshealthcheck: %w", err)
+		}
+		return append(objects, lsHealthCheck), nil
 	default:
 		return objects, nil
 	}

--- a/test/utils/envtest/types.go
+++ b/test/utils/envtest/types.go
@@ -5,6 +5,7 @@
 package envtest
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -15,15 +16,17 @@ import (
 )
 
 var (
-	InstallationGVK schema.GroupVersionKind
-	ExecutionGVK    schema.GroupVersionKind
-	DeployItemGVK   schema.GroupVersionKind
-	DataObjectGVK   schema.GroupVersionKind
-	TargetGVK       schema.GroupVersionKind
-	TargetSyncGVK   schema.GroupVersionKind
-	ContextGVK      schema.GroupVersionKind
-	SecretGVK       schema.GroupVersionKind
-	ConfigMapGVK    schema.GroupVersionKind
+	InstallationGVK  schema.GroupVersionKind
+	ExecutionGVK     schema.GroupVersionKind
+	DeployItemGVK    schema.GroupVersionKind
+	DataObjectGVK    schema.GroupVersionKind
+	TargetGVK        schema.GroupVersionKind
+	TargetSyncGVK    schema.GroupVersionKind
+	ContextGVK       schema.GroupVersionKind
+	SecretGVK        schema.GroupVersionKind
+	ConfigMapGVK     schema.GroupVersionKind
+	DeploymentGVK    schema.GroupVersionKind
+	LSHealthCheckGVK schema.GroupVersionKind
 )
 
 func init() {
@@ -45,5 +48,9 @@ func init() {
 	SecretGVK, err = apiutil.GVKForObject(&corev1.Secret{}, api.LandscaperScheme)
 	utilruntime.Must(err)
 	ConfigMapGVK, err = apiutil.GVKForObject(&corev1.ConfigMap{}, api.LandscaperScheme)
+	utilruntime.Must(err)
+	DeploymentGVK, err = apiutil.GVKForObject(&appsv1.Deployment{}, api.LandscaperScheme)
+	utilruntime.Must(err)
+	LSHealthCheckGVK, err = apiutil.GVKForObject(&lsv1alpha1.LsHealthCheck{}, api.LandscaperScheme)
 	utilruntime.Must(err)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority 3

**What this PR does / why we need it**:

The number of replicas for monitoring the health of the landscaper deployments was hard coded.
Use the correct vale for the expected replicas set in the deployment resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Use the correct expected replicas value for lshealthcheck monitoring.
```
