### PR TITLE
Trigger target sync with reconcile operation

### DIFF
--- a/docs/usage/TargetSyncs.md
+++ b/docs/usage/TargetSyncs.md
@@ -54,6 +54,8 @@ The entries of such a *TargetSync* object have the following meaning:
 - secretRef: A reference to a secret in the same namespace as the *TargetSync* object, containing a kubeconfig.yaml in its data section under the specified *key*. This kubeconfig must provide access to the Garden project namespace. This secret must be created together with the *TargetSync* object.
 - tokenRotation: Will be explained further below.
 
+For every *TargetSync* object every 5 minutes the corresponding shoots are checked and targets and secrets for new or deleted shoot are created or deleted. The token in the secrets for all other shoots have a live time of 24 hours and are refreshed every 12 hours.
+
 An example demonstrating how to create a *TargetSync* object to create targets for shoot clusters can be found
 [here](https://github.com/gardener/landscaper-examples/tree/master/sync-targets/example2).
 
@@ -75,7 +77,8 @@ The resulting situation is depicted in the following picture:
 ![targets-sync2](images/target-sync2.png)
 
 If the secrets in *Other-Namespace 1* on cluster 2 are changed, i.e. a new secret is created,
-and existing one is modified or deleted, this is synchronized to cluster 1 after at most 5 minutes and the  corresponding secrets and targets are created, updated or deleted.
+or an existing one is modified or deleted, this is synchronized to cluster 1 every 5 minutes and the  corresponding 
+secrets and targets are created, updated or deleted.
 
 Currently, it is assumed that the secrets on cluster 2 contain the access data to the clusters in an entry 
 *kubeconfig* of their data section and the data itself must be a kubeconfig.yaml.
@@ -159,3 +162,7 @@ users:
 ```
 
 Token rotation requires that the corresponding service account is allowed to request new tokens for itself.
+
+## Trigger the Reconciliation of a *TargetSync* object
+
+The reconciliation of a *TargetSync* object usually takes place every 5 minutes. It could be triggered immediately by just modifying its annotations. If you add the special annotation `landscaper.gardener.cloud/operation: reconcile` the *TargetSync* object is also reconciled immediately and the annotation is removed when the operation has finished, i.e. either succeeded or failed.

--- a/pkg/landscaper/controllers/targetsync/targetsync_controller.go
+++ b/pkg/landscaper/controllers/targetsync/targetsync_controller.go
@@ -104,7 +104,7 @@ func (c *TargetSyncController) Reconcile(ctx context.Context, req reconcile.Requ
 				if err == nil {
 					err = err2
 				} else {
-					logger.Error(err, "removing reconcile operation for targetsync object failed")
+					logger.Error(err, "removing reconcile operation for target sync object failed")
 				}
 			}
 		}
@@ -115,7 +115,7 @@ func (c *TargetSyncController) Reconcile(ctx context.Context, req reconcile.Requ
 		}
 	} else {
 		if err := c.handleDelete(ctx, targetSync); err != nil {
-			logger.Error(err, "deleting targetsync object failed")
+			logger.Error(err, "deleting target sync object failed")
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/landscaper/controllers/targetsync/targetsync_controller.go
+++ b/pkg/landscaper/controllers/targetsync/targetsync_controller.go
@@ -104,7 +104,7 @@ func (c *TargetSyncController) Reconcile(ctx context.Context, req reconcile.Requ
 				if err == nil {
 					err = err2
 				} else {
-					logger.Error(err, "removing reconcile operation for target sync object failed")
+					logger.Error(err2, "removing reconcile operation for target sync object failed")
 				}
 			}
 		}

--- a/pkg/landscaper/controllers/targetsync/testdata/state/test1/target-sync.yaml
+++ b/pkg/landscaper/controllers/targetsync/testdata/state/test1/target-sync.yaml
@@ -3,6 +3,8 @@ kind: TargetSync
 metadata:
   name: test-target-sync
   namespace: {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   secretNameExpression: \.kubeconfig$
   secretRef:

--- a/pkg/landscaper/controllers/targetsync/testdata/state/test2/target-sync-1.yaml
+++ b/pkg/landscaper/controllers/targetsync/testdata/state/test2/target-sync-1.yaml
@@ -3,6 +3,8 @@ kind: TargetSync
 metadata:
   name: test-target-sync-1
   namespace: {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   secretNameExpression: \.kubeconfig$
   secretRef:

--- a/pkg/landscaper/controllers/targetsync/testdata/state/test2/target-sync-2.yaml
+++ b/pkg/landscaper/controllers/targetsync/testdata/state/test2/target-sync-2.yaml
@@ -3,6 +3,8 @@ kind: TargetSync
 metadata:
   name: test-target-sync-2
   namespace: {{ .Namespace }}
+  annotations:
+    landscaper.gardener.cloud/operation: reconcile
 spec:
   secretNameExpression: \.kubeconfig$
   secretRef:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Trigger target sync with reconcile operation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- trigger target sync with reconcile operation
```
