### PR TITLE
Update to golang:1.19.8

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -51,7 +51,7 @@ landscaper:
             image: eu.gcr.io/gardener-project/landscaper/mock-deployer-controller
     steps:
       verify:
-        image: 'golang:1.19.5'
+        image: 'golang:1.19.8'
       publish-helm-charts:
         depends:
         - verify

--- a/.test-defs/create-cluster.yaml
+++ b/.test-defs/create-cluster.yaml
@@ -16,4 +16,4 @@ spec:
     --id=$TM_TESTRUN_ID$CLUSTER_NAME
     --timeout=10m
 
-  image: golang:1.19.5
+  image: golang:1.19.8

--- a/.test-defs/create-registry.yaml
+++ b/.test-defs/create-registry.yaml
@@ -17,4 +17,4 @@ spec:
     --dns-format=external
     --timeout=10m
 
-  image: golang:1.19.5
+  image: golang:1.19.8

--- a/.test-defs/delete-cluster.yaml
+++ b/.test-defs/delete-cluster.yaml
@@ -15,4 +15,4 @@ spec:
     --id=$TM_TESTRUN_ID$CLUSTER_NAME
     --timeout=10m
 
-  image: golang:1.19.5
+  image: golang:1.19.8

--- a/.test-defs/delete-registry.yaml
+++ b/.test-defs/delete-registry.yaml
@@ -15,4 +15,4 @@ spec:
     --id=$TM_TESTRUN_ID
     --timeout=10m
 
-  image: golang:1.19.5
+  image: golang:1.19.8

--- a/.test-defs/integration.yaml
+++ b/.test-defs/integration.yaml
@@ -16,4 +16,4 @@ spec:
     --ls-namespace=ls-system
     --ls-version=$(./hack/get-version.sh)
 
-  image: golang:1.19.5
+  image: golang:1.19.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### BUILDER ####
-FROM golang:1.19.5 AS builder
+FROM golang:1.19.8 AS builder
 
 WORKDIR /go/src/github.com/gardener/landscaper
 COPY . .


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind impediment
/priority 2

**What this PR does / why we need it**:
Update to golang 1.19.8 removes [CVE-2023-24538](https://nvd.nist.gov/vuln/detail/CVE-2023-24538)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Update to golang 1.19.8 eliminates CVE-2023-24538
```
