### PR TITLE
Document context and related functions

### DIFF
--- a/apis/core/v1alpha1/types_component_version_overwrite.go
+++ b/apis/core/v1alpha1/types_component_version_overwrite.go
@@ -11,6 +11,20 @@ import (
 	lsschema "github.com/gardener/landscaper/apis/schema"
 )
 
+// Component Version Overwrites is a convenience feature for development and testing.
+// Assuming one is working on a Component Version (or rather a resource accessed through a Component Version). This
+// Component Version might itself be referenced transitively in the installation (in other words, the Component Version
+// might not be specified in the spec.ComponentDescriptor.ref but referenced by a Component Reference within that
+// Component Descriptor).
+// Instead of having to adjust all Component Versions in this reference chain, Component Version
+// Overwrites allows to substitute the specific Component Versions accessed by the landscaper at runtime. Thus, it e.g.
+// allows to specify that the ComponentVersion within a specific repositoryContext (e.g.
+// repositoryContext.type: ociRegistry and repositoryContext.baseUrl: example.com) and with componentName: example and
+// version: 1.0.0 shall be substituted by the ComponentVersion with componentName: substitute and version: 1.0.0.
+// This substitution can be arbitrarily specific. So, if one only specifies repositoryContexts, all Component Versions
+// will be taken from the respective substitute repositoryContext instead (thus, the ComponentVersions are substituted
+// by their representations in the substitute repository).
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentVersionOverwritesList contains a list of ComponentVersionOverwrites

--- a/apis/core/v1alpha1/types_installation.go
+++ b/apis/core/v1alpha1/types_installation.go
@@ -173,6 +173,10 @@ type Installation struct {
 // InstallationSpec defines a component installation.
 type InstallationSpec struct {
 	// Context defines the current context of the installation.
+	// Name of a configuration resource, serving as reference to the respective configuration resource.
+	// The configuration resource contains data such as the location of the component descriptors referenced in the
+	// installation as well as corresponding access data like credentials for the component descriptors and other
+	// artifacts like images or blueprints.
 	// +optional
 	Context string `json:"context,omitempty"`
 

--- a/pkg/landscaper/installations/context.go
+++ b/pkg/landscaper/installations/context.go
@@ -206,13 +206,17 @@ func (o *Operation) IsRoot() bool {
 var MissingRepositoryContextError = errors.New("RepositoryContextMissing")
 
 // GetExternalContext resolves the context for an installation and applies defaults or overwrites if applicable.
-// The Context of an installation can be specified in multiple locations:
+// The Context of an installation can be specified:
 //  1. in the installation directly (by specifying the name of a context custom resource in .spec.context)
 //  2. in the default context (if there is no context specified (1), this specification is implicitly supplemented as
 //     "default", which is a context created in every namespace)
-//  3. in the component descriptor (by specifying a repository context in
-//     .spec.componentDescriptor.ref.repositoryContext)
-// All these cases are covered by this function.
+//
+// The repositoryContext (thus, the location to look for the referenced ComponentVersions) is commonly part of this
+// Context.
+// If spec.componentDescriptor.ref specifies a repositoryContext, this repositoryContext overwrites the
+// repositoryContext specified by the context custom resource.
+// If the context custom resource specified in the installation contains ComponentVersionOverwrites, their
+// repositoryContext again overwrites either of the previous described repositoryContexts.
 func GetExternalContext(ctx context.Context, kubeClient client.Client, inst *lsv1alpha1.Installation) (ExternalContext, error) {
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
 	lsCtx := &lsv1alpha1.Context{}

--- a/pkg/landscaper/installations/context.go
+++ b/pkg/landscaper/installations/context.go
@@ -206,11 +206,19 @@ func (o *Operation) IsRoot() bool {
 var MissingRepositoryContextError = errors.New("RepositoryContextMissing")
 
 // GetExternalContext resolves the context for an installation and applies defaults or overwrites if applicable.
+// The Context of an installation can be specified in multiple locations:
+//  1. in the installation directly (by specifying the name of a context custom resource in .spec.context)
+//  2. in the default context (if there is no context specified (1), this specification is implicitly supplemented as
+//     "default", which is a context created in every namespace)
+//  3. in the component descriptor (by specifying a repository context in
+//     .spec.componentDescriptor.ref.repositoryContext)
+// All these cases are covered by this function.
 func GetExternalContext(ctx context.Context, kubeClient client.Client, inst *lsv1alpha1.Installation) (ExternalContext, error) {
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
 	lsCtx := &lsv1alpha1.Context{}
 	var overwriter componentoverwrites.Overwriter
 	var cvo *lsv1alpha1.ComponentVersionOverwrites
+
 	if len(inst.Spec.Context) != 0 {
 		if err := kubeClient.Get(ctx, kutil.ObjectKey(inst.Spec.Context, inst.Namespace), lsCtx); err != nil {
 			return ExternalContext{}, lserrors.NewWrappedError(err,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind technical-debt
/priority 3

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
