### PR TITLE
Fix webhook certificate creation.

### DIFF
--- a/controller-utils/pkg/webhook/certificates.go
+++ b/controller-utils/pkg/webhook/certificates.go
@@ -96,10 +96,11 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 		if retry {
 			secret = &corev1.Secret{}
 			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
-				caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
-				if err != nil {
-					return nil, err
-				}
+				return nil, err
+			}
+			caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+			if err != nil {
+				return nil, err
 			}
 		} else {
 			return nil, err

--- a/controller-utils/pkg/webhook/certificates.go
+++ b/controller-utils/pkg/webhook/certificates.go
@@ -12,6 +12,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/pkg/errors"
@@ -57,6 +60,8 @@ func GetDNSNamesFromURL(rawurl string) ([]string, error) {
 func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string,
 	dnsNames []string) ([]byte, error) {
 
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "GenerateCertificates")
+
 	caConfig := &certificates.CertificateSecretConfig{
 		CommonName: "webhook-ca",
 		CertType:   certificates.CACert,
@@ -66,24 +71,33 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 	// The controller stores the generated webhook certificate in a secret in the cluster. It tries to read it. If it does not exist a
 	// new certificate is generated.
 
+	logger.Info("GenerateCertificates: fetch secrets")
+
 	secret := &corev1.Secret{}
 	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+		logger.Info("GenerateCertificates: fetch secrets failed")
 
 		if !apierrors.IsNotFound(err) {
+			logger.Info("GenerateCertificates: fetch failed hard")
 			return nil, errors.Wrapf(err, "error fetching secret for webhook server")
 		}
 
+		logger.Info("GenerateCertificates: generate new cert")
 		caCert, serverCert, err := generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
+			logger.Info("GenerateCertificates: generate new cert failed")
 			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
 		err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, namespace, certSecretName, true)
 		if err == nil {
+			logger.Info("GenerateCertificates: new secret generated")
 			return writeCertificates(certDir, caCert, serverCert)
 		} else {
 			// try to refetch secret if it was created by another replica
+			logger.Info("GenerateCertificates: new secret generation failed")
 			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				logger.Info("GenerateCertificates: fetching new secret failed")
 				return nil, errors.Wrapf(err, "could not fetch secret for webhook")
 			}
 		}
@@ -91,46 +105,63 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 
 	// The secret has been found and we are now trying to read the stored certificate inside it and updates it if
 	// required
+	logger.Info("GenerateCertificates: loadAndUpdateSecret start")
 	caCert, serverCert, retry, err := loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
 	if err != nil {
+
 		if retry {
+			logger.Info("GenerateCertificates: loadAndUpdateSecret failed and retried")
 			secret = &corev1.Secret{}
 			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				logger.Info("GenerateCertificates: fetch updated secret failed")
 				return nil, err
 			}
 			caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
 			if err != nil {
+				logger.Info("GenerateCertificates: loadAndUpdateSecret retry failed")
 				return nil, err
 			}
 		} else {
+			logger.Info("GenerateCertificates: loadAndUpdateSecret failed")
 			return nil, err
 		}
 
 	}
 
+	logger.Info("GenerateCertificates: cert returned")
 	return writeCertificates(certDir, caCert, serverCert)
 }
 
 func loadAndUpdateSecret(ctx context.Context, kubeClient client.Client, secret *corev1.Secret, name string, dnsNames []string,
 	caConfig *certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, bool, error) {
 
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "GenerateCertificates")
+
+	logger.Info("loadAndUpdateSecret: load existing cert")
+
 	caCert, serverCert, err := loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
 	if err != nil {
+		logger.Info("loadAndUpdateSecret: load existing cert failed")
 		return nil, nil, false, errors.Wrapf(err, "error reading data of secret %s/%s", secret.Namespace, secret.Name)
 	}
 
 	// update certificates if the dns names have changed
 	if !sets.NewString(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
+		logger.Info("loadAndUpdateSecret: dns names have changed")
+
 		caCert, serverCert, err = generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
+			logger.Info("loadAndUpdateSecret: generate new cert failed")
 			return nil, nil, false, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
 		if err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, secret.Namespace, secret.Name, false); err != nil {
+			logger.Info("loadAndUpdateSecret: updating secret failed")
 			return nil, nil, true, errors.Wrapf(err, "error updating secret for webhook")
 		}
 	}
 
+	logger.Info("loadAndUpdateSecret: return cert data")
 	return caCert, serverCert, false, nil
 }
 

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
@@ -96,10 +96,11 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 		if retry {
 			secret = &corev1.Secret{}
 			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
-				caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
-				if err != nil {
-					return nil, err
-				}
+				return nil, err
+			}
+			caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+			if err != nil {
+				return nil, err
 			}
 		} else {
 			return nil, err

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
@@ -12,6 +12,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/pkg/errors"
@@ -57,6 +60,8 @@ func GetDNSNamesFromURL(rawurl string) ([]string, error) {
 func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string,
 	dnsNames []string) ([]byte, error) {
 
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "GenerateCertificates")
+
 	caConfig := &certificates.CertificateSecretConfig{
 		CommonName: "webhook-ca",
 		CertType:   certificates.CACert,
@@ -66,24 +71,33 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 	// The controller stores the generated webhook certificate in a secret in the cluster. It tries to read it. If it does not exist a
 	// new certificate is generated.
 
+	logger.Info("GenerateCertificates: fetch secrets")
+
 	secret := &corev1.Secret{}
 	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+		logger.Info("GenerateCertificates: fetch secrets failed")
 
 		if !apierrors.IsNotFound(err) {
+			logger.Info("GenerateCertificates: fetch failed hard")
 			return nil, errors.Wrapf(err, "error fetching secret for webhook server")
 		}
 
+		logger.Info("GenerateCertificates: generate new cert")
 		caCert, serverCert, err := generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
+			logger.Info("GenerateCertificates: generate new cert failed")
 			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
 		err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, namespace, certSecretName, true)
 		if err == nil {
+			logger.Info("GenerateCertificates: new secret generated")
 			return writeCertificates(certDir, caCert, serverCert)
 		} else {
 			// try to refetch secret if it was created by another replica
+			logger.Info("GenerateCertificates: new secret generation failed")
 			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				logger.Info("GenerateCertificates: fetching new secret failed")
 				return nil, errors.Wrapf(err, "could not fetch secret for webhook")
 			}
 		}
@@ -91,46 +105,63 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 
 	// The secret has been found and we are now trying to read the stored certificate inside it and updates it if
 	// required
+	logger.Info("GenerateCertificates: loadAndUpdateSecret start")
 	caCert, serverCert, retry, err := loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
 	if err != nil {
+
 		if retry {
+			logger.Info("GenerateCertificates: loadAndUpdateSecret failed and retried")
 			secret = &corev1.Secret{}
 			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				logger.Info("GenerateCertificates: fetch updated secret failed")
 				return nil, err
 			}
 			caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
 			if err != nil {
+				logger.Info("GenerateCertificates: loadAndUpdateSecret retry failed")
 				return nil, err
 			}
 		} else {
+			logger.Info("GenerateCertificates: loadAndUpdateSecret failed")
 			return nil, err
 		}
 
 	}
 
+	logger.Info("GenerateCertificates: cert returned")
 	return writeCertificates(certDir, caCert, serverCert)
 }
 
 func loadAndUpdateSecret(ctx context.Context, kubeClient client.Client, secret *corev1.Secret, name string, dnsNames []string,
 	caConfig *certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, bool, error) {
 
+	logger, ctx := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "GenerateCertificates")
+
+	logger.Info("loadAndUpdateSecret: load existing cert")
+
 	caCert, serverCert, err := loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
 	if err != nil {
+		logger.Info("loadAndUpdateSecret: load existing cert failed")
 		return nil, nil, false, errors.Wrapf(err, "error reading data of secret %s/%s", secret.Namespace, secret.Name)
 	}
 
 	// update certificates if the dns names have changed
 	if !sets.NewString(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
+		logger.Info("loadAndUpdateSecret: dns names have changed")
+
 		caCert, serverCert, err = generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
+			logger.Info("loadAndUpdateSecret: generate new cert failed")
 			return nil, nil, false, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
 		if err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, secret.Namespace, secret.Name, false); err != nil {
+			logger.Info("loadAndUpdateSecret: updating secret failed")
 			return nil, nil, true, errors.Wrapf(err, "error updating secret for webhook")
 		}
 	}
 
+	logger.Info("loadAndUpdateSecret: return cert data")
 	return caCert, serverCert, false, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug
/priority 3

**What this PR does / why we need it**:

Fix webhook certificate creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- Fix webhook certificate creation
```
