### PR TITLE
Reduce error logs

### DIFF
--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -160,6 +160,8 @@ const (
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 	// ErrorUnfinished indicates that there are unfinished sub-objects.
 	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
+	// ErrorForInfoOnly indicates that the error is no real error but an info and should be logged only on infor level.
+	ErrorForInfoOnly ErrorCode = "ERR_FOR_INFO_ONLY"
 )
 
 // Condition holds the information about the state of a resource.

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -167,6 +167,8 @@ const (
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 	// ErrorUnfinished indicates that there are unfinished sub-objects.
 	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
+	// ErrorForInfoOnly indicates that the error is no real error but an info and should be logged only on infor level.
+	ErrorForInfoOnly ErrorCode = "ERR_FOR_INFO_ONLY"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -160,6 +160,8 @@ const (
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 	// ErrorUnfinished indicates that there are unfinished sub-objects.
 	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
+	// ErrorForInfoOnly indicates that the error is no real error but an info and should be logged only on infor level.
+	ErrorForInfoOnly ErrorCode = "ERR_FOR_INFO_ONLY"
 )
 
 // Condition holds the information about the state of a resource.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -167,6 +167,8 @@ const (
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 	// ErrorUnfinished indicates that there are unfinished sub-objects.
 	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
+	// ErrorForInfoOnly indicates that the error is no real error but an info and should be logged only on infor level.
+	ErrorForInfoOnly ErrorCode = "ERR_FOR_INFO_ONLY"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes

--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -26,7 +26,7 @@ spec:
           type: n1-standard-2
           image:
             name: gardenlinux
-            version: 934.6.0
+            version: 934.7.0
           architecture: amd64
         zones:
           - europe-west1-b

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -131,7 +131,7 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecutionPhases.Failed, err, read_write_layer.W000135)
 		} else if !deployItemClassification.AllSucceeded() {
 			// remain in progressing in all other cases
-			err = lserrors.NewError(op, "handlePhaseProgressing", "some running items", lsv1alpha1.ErrorUnfinished)
+			err = lserrors.NewError(op, "handlePhaseProgressing", "some running items", lsv1alpha1.ErrorUnfinished, lsv1alpha1.ErrorForInfoOnly)
 			return c.setExecutionPhaseAndUpdate(ctx, exec, exec.Status.ExecutionPhase, err, read_write_layer.W000136)
 		} else {
 			// all succeeded; go to next phase
@@ -304,10 +304,6 @@ func (c *controller) setExecutionPhaseAndUpdate(ctx context.Context, exec *lsv1a
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	exec.Status.LastError = lserrors.TryUpdateLsError(exec.Status.LastError, lsErr)
-
-	if lsErr != nil && !lserrors.ContainsErrorCode(lsErr, lsv1alpha1.ErrorUnfinished) {
-		logger.Error(lsErr, "setExecutionPhaseAndUpdate")
-	}
 
 	if phase != exec.Status.ExecutionPhase {
 		now := metav1.Now()

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -75,7 +75,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		// Execution is unfinished
 
 		err := c.handleReconcilePhase(ctx, exec)
-		return reconcile.Result{}, err
+		return lsutil.LogHelper{}.LogErrorAndGetReconcileResult(ctx, err)
 	} else {
 		// Execution is finished; nothing to do
 		return reconcile.Result{}, nil

--- a/pkg/landscaper/controllers/execution/reconcile_test.go
+++ b/pkg/landscaper/controllers/execution/reconcile_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(state.Create(ctx, exec)).To(Succeed())
 		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Progressing))
@@ -81,7 +81,7 @@ var _ = Describe("Reconcile", func() {
 		testutils.ExpectNoError(state.Client.Status().Update(ctx, di))
 
 		// reconcile execution and check that it is failed
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Failed))
 		Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
@@ -122,7 +122,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(state.Create(ctx, exec)).To(Succeed())
 			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			// expect a deploy item
 			items := &lsv1alpha1.DeployItemList{}
@@ -155,7 +155,7 @@ var _ = Describe("Reconcile", func() {
 			Expect(state.Create(ctx, exec)).To(Succeed())
 			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			// expect a deploy item
 			items := &lsv1alpha1.DeployItemList{}
@@ -190,7 +190,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
 
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 		Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Progressing))
 		Expect(exec.Status.JobIDFinished).NotTo(Equal(exec.Status.JobID))
@@ -208,7 +208,7 @@ var _ = Describe("Reconcile", func() {
 		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
 
 		// then reconcile the execution and expect the execution to be Failed
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Failed))
 		Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
@@ -237,7 +237,7 @@ var _ = Describe("Reconcile", func() {
 		di.Status.JobIDFinished = exec.Status.JobID
 		testutils.ExpectNoError(testenv.Client.Status().Update(ctx, di))
 
-		_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+		testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Failed))
 		Expect(exec.Status.JobIDFinished).To(Equal(exec.Status.JobID))
@@ -262,7 +262,7 @@ var _ = Describe("Reconcile", func() {
 
 			// Reconcile the execution with two orphaned deploy items di-b and di-c
 			Expect(testutils.UpdateJobIdForExecution(ctx, testenv, exec)).To(Succeed())
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			// Check execution state
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
@@ -308,7 +308,7 @@ var _ = Describe("Reconcile", func() {
 			currentJobID := exec.Status.JobID
 			Expect(exec.Status.JobIDFinished).NotTo(Equal(currentJobID))
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(exec.Status.JobID).To(Equal(currentJobID))
@@ -339,7 +339,7 @@ var _ = Describe("Reconcile", func() {
 			di2.Status.Phase = lsv1alpha1.DeployItemPhases.Progressing
 			Expect(state.Client.Status().Update(ctx, di1)).To(Succeed())
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(exec.Status.JobID).To(Equal(currentJobID))
@@ -357,7 +357,7 @@ var _ = Describe("Reconcile", func() {
 			di2.Status.Phase = lsv1alpha1.DeployItemPhases.Succeeded
 			Expect(state.Client.Status().Update(ctx, di2)).To(Succeed())
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(exec.Status.JobID).To(Equal(currentJobID))
@@ -401,7 +401,7 @@ var _ = Describe("Reconcile", func() {
 			currentJobID = exec.Status.JobID
 			Expect(exec.Status.JobIDFinished).NotTo(Equal(currentJobID))
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(exec.Status.JobID).To(Equal(currentJobID))
@@ -426,7 +426,7 @@ var _ = Describe("Reconcile", func() {
 			di1.Status.Phase = lsv1alpha1.DeployItemPhases.Succeeded
 			Expect(state.Client.Status().Update(ctx, di1)).To(Succeed())
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(exec.Status.JobID).To(Equal(currentJobID))
@@ -451,7 +451,7 @@ var _ = Describe("Reconcile", func() {
 			di2.Status.Phase = lsv1alpha1.DeployItemPhases.Succeeded
 			Expect(state.Client.Status().Update(ctx, di2)).To(Succeed())
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(exec))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(exec))
 
 			Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(exec), exec)).To(Succeed())
 			Expect(exec.Status.JobID).To(Equal(currentJobID))

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -192,10 +192,8 @@ func (c *Controller) reconcileInstallation(ctx context.Context, inst *lsv1alpha1
 
 	// handle reconcile
 	if inst.Status.JobID != inst.Status.JobIDFinished {
-
 		err := c.handleReconcilePhase(ctx, inst)
-		return reconcile.Result{}, err
-
+		return utils.LogHelper{}.LogErrorAndGetReconcileResult(ctx, err)
 	} else {
 		// job finished; nothing to do
 		return reconcile.Result{}, nil

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -259,8 +259,8 @@ func (c *Controller) init(ctx context.Context, inst *lsv1alpha1.Installation) (*
 		return nil, nil, "", nil, nil, normalError
 	}
 
-	if lsErr := rh.AllPredecessorsFinished(inst, predecessorMap); err != nil {
-		normalError := lsErr
+	if err = rh.AllPredecessorsFinished(inst, predecessorMap); err != nil {
+		normalError := lserrors.NewWrappedError(err, currentOperation, "AllPredecessorsFinished", err.Error())
 		return nil, nil, "", nil, nil, normalError
 	}
 

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -422,7 +422,8 @@ func (c *Controller) handlePhaseProgressing(ctx context.Context, inst *lsv1alpha
 
 		if exec.Status.JobIDFinished != exec.Status.JobID {
 			message := fmt.Sprintf("execution %s / %s is not finished yet", exec.Namespace, exec.Name)
-			return false, lserrors.NewError(currentOperation, "JobIDFinished", message, lsv1alpha1.ErrorUnfinished)
+			return false, lserrors.NewError(currentOperation, "JobIDFinished", message,
+				lsv1alpha1.ErrorUnfinished, lsv1alpha1.ErrorForInfoOnly)
 		}
 
 		allSucceeded = allSucceeded && (exec.Status.ExecutionPhase == lsv1alpha1.ExecutionPhases.Succeeded)

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -170,11 +170,11 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		} else if allDeleted {
 			return nil
 		} else if allFinished {
-			err = lserrors.NewError(op, "UndeletedSubobjects", "not all sub objects were deleted")
+			err = lserrors.NewError(op, "UndeletedSubobjects", "not all sub objects were deleted", lsv1alpha1.ErrorForInfoOnly)
 			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.DeleteFailed, err, read_write_layer.W000129)
 		} else {
 			// retry
-			err = lserrors.NewError(op, "PendingSubobjects", "deletion of some sub objects pending")
+			err = lserrors.NewError(op, "PendingSubobjects", "deletion of some sub objects pending", lsv1alpha1.ErrorForInfoOnly)
 			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000130)
 		}
 	}
@@ -406,7 +406,8 @@ func (c *Controller) handlePhaseProgressing(ctx context.Context, inst *lsv1alpha
 		if next.Status.JobIDFinished != next.Status.JobID {
 			// Hack: being unfinished should not be treated as an error
 			message := fmt.Sprintf("installation %s / %s is not finished yet", next.Namespace, next.Name)
-			return false, lserrors.NewError(currentOperation, "JobIDFinished", message, lsv1alpha1.ErrorUnfinished)
+			return false, lserrors.NewError(currentOperation, "JobIDFinished", message,
+				lsv1alpha1.ErrorUnfinished, lsv1alpha1.ErrorForInfoOnly)
 		}
 
 		allSucceeded = allSucceeded && (next.Status.InstallationPhase == lsv1alpha1.InstallationPhases.Succeeded)

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -259,8 +259,8 @@ func (c *Controller) init(ctx context.Context, inst *lsv1alpha1.Installation) (*
 		return nil, nil, "", nil, nil, normalError
 	}
 
-	if err = rh.AllPredecessorsFinished(inst, predecessorMap); err != nil {
-		normalError := lserrors.NewWrappedError(err, currentOperation, "AllPredecessorsFinished", err.Error())
+	if lsErr := rh.AllPredecessorsFinished(inst, predecessorMap); err != nil {
+		normalError := lsErr
 		return nil, nil, "", nil, nil, normalError
 	}
 

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Delete", func() {
 			testutils.ExpectNoError(testenv.Client.Delete(ctx, inst))
 
 			testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(inst))
 
 			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
 			Expect(lsutils.IsInstallationPhase(inst, lsv1alpha1.InstallationPhases.Deleting)).To(BeTrue())
@@ -120,14 +120,14 @@ var _ = Describe("Delete", func() {
 			Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
 
 			inst := state.Installations[state.Namespace+"/a"]
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(inst))
 
 			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
 			Expect(lsutils.IsInstallationPhase(inst, lsv1alpha1.InstallationPhases.DeleteFailed)).To(BeTrue())
 			Expect(lsutils.IsInstallationJobIDsIdentical(inst)).To(BeTrue())
 
 			inst = state.Installations[state.Namespace+"/root"]
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(inst))
 
 			testutils.ExpectNoError(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst))
 			Expect(lsutils.IsInstallationPhase(inst, lsv1alpha1.InstallationPhases.DeleteFailed)).To(BeTrue())

--- a/pkg/landscaper/controllers/installations/retry_helper_test.go
+++ b/pkg/landscaper/controllers/installations/retry_helper_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Retry handler", func() {
 			Expect(inst.Status.AutomaticReconcileStatus.LastReconcileTime.Time.UnixMilli()).To(Equal(t4.UnixMilli()))
 
 			// reconcile fails; max number of retries reached
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(inst))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(inst))
 			Expect(state.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst)).To(Succeed())
 			Expect(inst.ObjectMeta.Annotations).NotTo(HaveKeyWithValue(v1alpha1.OperationAnnotation, string(v1alpha1.ReconcileOperation)))
 			Expect(inst.ObjectMeta.Annotations).NotTo(HaveKey(v1alpha1.ReconcileReasonAnnotation))

--- a/pkg/landscaper/controllers/targetsync/targetsync_controller_test.go
+++ b/pkg/landscaper/controllers/targetsync/targetsync_controller_test.go
@@ -232,7 +232,7 @@ var _ = Describe("TargetSync Controller", func() {
 			testutils.ExpectNoError(state.Client.Get(ctx, kutil.ObjectKeyFromObject(tgs1), tgs1))
 			Expect(helper.HasOperation(tgs1.ObjectMeta, lsv1alpha1.ReconcileOperation)).To(BeTrue())
 
-			_ = testutils.ShouldNotReconcile(ctx, ctrl, testutils.RequestFromObject(tgs1))
+			testutils.ShouldReconcileButRetry(ctx, ctrl, testutils.RequestFromObject(tgs1))
 
 			testutils.ExpectNoError(state.Client.Get(ctx, kutil.ObjectKeyFromObject(tgs1), tgs1))
 			Expect(tgs1.Status.LastErrors).NotTo(BeEmpty())

--- a/pkg/landscaper/installations/reconcilehelper/reconcilehelper.go
+++ b/pkg/landscaper/installations/reconcilehelper/reconcilehelper.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	lserror "github.com/gardener/landscaper/apis/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -159,24 +161,30 @@ func (rh *ReconcileHelper) GetPredecessors(installation *lsv1alpha1.Installation
 	return predecessorMap, nil
 }
 
-func (rh *ReconcileHelper) AllPredecessorsFinished(installation *lsv1alpha1.Installation, predecessorMap map[string]*installations.InstallationAndImports) error {
+func (rh *ReconcileHelper) AllPredecessorsFinished(installation *lsv1alpha1.Installation,
+	predecessorMap map[string]*installations.InstallationAndImports) lserror.LsError {
 	// iterate over siblings which is depended on (either directly or transitively) and check if they are 'ready'
 	for name := range predecessorMap {
 		predecessor := predecessorMap[name]
+		reason := string(installations.NotCompletedDependents)
+
 		if installations.IsRootInstallation(installation) {
 			if lsv1alpha1helper.HasOperation(predecessor.GetInstallation().ObjectMeta, lsv1alpha1.ReconcileOperation) {
-				return installations.NewNotCompletedDependentsErrorf(nil, "depending on installation %q which has reconcile annotation",
+				msg := fmt.Sprintf("depending on installation %q which has reconcile annotation",
 					kutil.ObjectKeyFromObject(predecessor.GetInstallation()).String())
+				return lserror.NewWrappedError(nil, reason, reason, msg, lsv1alpha1.ErrorForInfoOnly)
 			}
 
 			if predecessor.GetInstallation().Status.JobID != predecessor.GetInstallation().Status.JobIDFinished {
-				return installations.NewNotCompletedDependentsErrorf(nil, "depending on installation %q which not finished current job %q",
+				msg := fmt.Sprintf("depending on installation %q which not finished current job %q",
 					kutil.ObjectKeyFromObject(predecessor.GetInstallation()).String(), installation.Status.JobID)
+				return lserror.NewWrappedError(nil, reason, reason, msg, lsv1alpha1.ErrorForInfoOnly)
 			}
 		} else {
 			if installation.Status.JobID != predecessor.GetInstallation().Status.JobIDFinished {
-				return installations.NewNotCompletedDependentsErrorf(nil, "depending on installation %q which not finished current job %q",
+				msg := fmt.Sprintf("depending on installation %q which not finished current job %q",
 					kutil.ObjectKeyFromObject(predecessor.GetInstallation()).String(), installation.Status.JobID)
+				return lserror.NewWrappedError(nil, reason, reason, msg, lsv1alpha1.ErrorForInfoOnly)
 			}
 		}
 	}
@@ -189,8 +197,10 @@ func (rh *ReconcileHelper) AllPredecessorsSucceeded(installation *lsv1alpha1.Ins
 		predecessor := predecessorMap[name]
 
 		if predecessor.GetInstallation().Status.InstallationPhase != lsv1alpha1.InstallationPhases.Succeeded {
-			return installations.NewNotCompletedDependentsErrorf(nil, "depending on installation %q which is not succeeded",
+			reason := string(installations.NotCompletedDependents)
+			msg := fmt.Sprintf("depending on installation %q which is not succeeded",
 				kutil.ObjectKeyFromObject(predecessor.GetInstallation()).String())
+			return lserror.NewWrappedError(nil, reason, reason, msg, lsv1alpha1.ErrorForInfoOnly)
 		}
 	}
 

--- a/pkg/utils/loghelper.go
+++ b/pkg/utils/loghelper.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lserrors "github.com/gardener/landscaper/apis/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+)
+
+type LogHelper struct {
+}
+
+func (r LogHelper) LogErrorAndGetReconcileResult(ctx context.Context, lsError lserrors.LsError) (reconcile.Result, error) {
+
+	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "LogErrorAndGetReconcileResult")
+
+	if lsError == nil {
+		return reconcile.Result{}, nil
+	} else if lserrors.ContainsErrorCode(lsError, lsv1alpha1.ErrorForInfoOnly) {
+		logger.Info(lsError.Error())
+		return reconcile.Result{Requeue: true}, nil
+	} else {
+		logger.Error(lsError, lsError.Error())
+		return reconcile.Result{Requeue: true}, nil
+	}
+}

--- a/pkg/utils/loghelper.go
+++ b/pkg/utils/loghelper.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -28,5 +30,17 @@ func (r LogHelper) LogErrorAndGetReconcileResult(ctx context.Context, lsError ls
 	} else {
 		logger.Error(lsError, lsError.Error())
 		return reconcile.Result{Requeue: true}, nil
+	}
+}
+
+func (r LogHelper) LogErrorButNotFoundAsInfo(ctx context.Context, err error, message string) {
+	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "LogErrorButNotFoundAsInfo")
+
+	if err == nil {
+		return
+	} else if apierrors.IsNotFound(err) {
+		logger.Info(message + ": " + err.Error())
+	} else {
+		logger.Error(err, message)
 	}
 }

--- a/pkg/utils/read_write_layer/write.go
+++ b/pkg/utils/read_write_layer/write.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/gardener/landscaper/apis/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -215,6 +217,10 @@ func errorWithWriteID(err error, writeID WriteID) errors.LsError {
 	errorCodes := []lsv1alpha1.ErrorCode{}
 	if isRecoverableError(err) {
 		errorCodes = append(errorCodes, lsv1alpha1.ErrorWebhook)
+	}
+
+	if apierrors.IsConflict(err) {
+		errorCodes = append(errorCodes, lsv1alpha1.ErrorForInfoOnly)
 	}
 
 	lsError := errors.NewWrappedError(err, "errorWithWriteID", "write",

--- a/test/landscaper/e2e/inlinecd_test.go
+++ b/test/landscaper/e2e/inlinecd_test.go
@@ -86,9 +86,9 @@ var _ = Describe("Inline Component Descriptor", func() {
 		inst := &lsv1alpha1.Installation{}
 		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
 		Expect(testutils.AddReconcileAnnotation(ctx, testenv, inst)).To(Succeed())
-		testutils.ShouldReconcile(ctx, instActuator, instReq)        // add finalizer
-		testutils.ShouldReconcile(ctx, instActuator, instReq)        // remove reconcile annotation and generate jobID
-		_ = testutils.ShouldNotReconcile(ctx, instActuator, instReq) // create execution; returns error because execution is unfinished
+		testutils.ShouldReconcile(ctx, instActuator, instReq)         // add finalizer
+		testutils.ShouldReconcile(ctx, instActuator, instReq)         // remove reconcile annotation and generate jobID
+		testutils.ShouldReconcileButRetry(ctx, instActuator, instReq) // create execution; returns error because execution is unfinished
 
 		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
 		Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhases.Progressing))
@@ -111,7 +111,7 @@ var _ = Describe("Inline Component Descriptor", func() {
 		Expect(exec.Status.JobIDFinished).To(BeEmpty())
 
 		// reconcile execution
-		_ = testutils.ShouldNotReconcile(ctx, execActuator, execReq) // not finished
+		testutils.ShouldReconcileButRetry(ctx, execActuator, execReq) // not finished
 
 		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Progressing))
@@ -161,8 +161,8 @@ var _ = Describe("Inline Component Descriptor", func() {
 		Expect(testenv.Client.Delete(ctx, inst)).To(Succeed())
 
 		// the installation controller should propagate the deletion to the execution
-		testutils.ShouldReconcile(ctx, instActuator, instReq)        // generate jobID for deletion
-		_ = testutils.ShouldNotReconcile(ctx, instActuator, instReq) // delete execution
+		testutils.ShouldReconcile(ctx, instActuator, instReq)         // generate jobID for deletion
+		testutils.ShouldReconcileButRetry(ctx, instActuator, instReq) // delete execution
 
 		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
 		Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhases.Deleting))

--- a/test/landscaper/e2e/simple_test.go
+++ b/test/landscaper/e2e/simple_test.go
@@ -85,9 +85,9 @@ var _ = Describe("Simple", func() {
 		inst := &lsv1alpha1.Installation{}
 		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
 		Expect(testutils.AddReconcileAnnotation(ctx, testenv, inst)).To(Succeed())
-		testutils.ShouldReconcile(ctx, instActuator, instReq)        // add finalizer
-		testutils.ShouldReconcile(ctx, instActuator, instReq)        // remove reconcile annotation and generate jobID
-		_ = testutils.ShouldNotReconcile(ctx, instActuator, instReq) // create execution; returns error because execution is unfinished
+		testutils.ShouldReconcile(ctx, instActuator, instReq)         // add finalizer
+		testutils.ShouldReconcile(ctx, instActuator, instReq)         // remove reconcile annotation and generate jobID
+		testutils.ShouldReconcileButRetry(ctx, instActuator, instReq) // create execution; returns error because execution is unfinished
 
 		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
 		Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhases.Progressing))
@@ -110,7 +110,7 @@ var _ = Describe("Simple", func() {
 		Expect(exec.Status.JobIDFinished).To(BeEmpty())
 
 		// reconcile execution
-		_ = testutils.ShouldNotReconcile(ctx, execActuator, execReq) // not finished
+		testutils.ShouldReconcileButRetry(ctx, execActuator, execReq) // not finished
 
 		Expect(testenv.Client.Get(ctx, execReq.NamespacedName, exec)).To(Succeed())
 		Expect(exec.Status.ExecutionPhase).To(Equal(lsv1alpha1.ExecutionPhases.Progressing))
@@ -160,8 +160,8 @@ var _ = Describe("Simple", func() {
 		Expect(testenv.Client.Delete(ctx, inst)).To(Succeed())
 
 		// the installation controller should propagate the deletion to the execution
-		testutils.ShouldReconcile(ctx, instActuator, instReq)        // generate jobID for deletion
-		_ = testutils.ShouldNotReconcile(ctx, instActuator, instReq) // delete execution
+		testutils.ShouldReconcile(ctx, instActuator, instReq)         // generate jobID for deletion
+		testutils.ShouldReconcileButRetry(ctx, instActuator, instReq) // delete execution
 
 		Expect(testenv.Client.Get(ctx, instReq.NamespacedName, inst)).To(Succeed())
 		Expect(inst.Status.InstallationPhase).To(Equal(lsv1alpha1.InstallationPhases.Deleting))

--- a/test/utils/controller.go
+++ b/test/utils/controller.go
@@ -39,6 +39,12 @@ func ShouldNotReconcile(ctx context.Context, reconciler reconcile.Reconciler, re
 	return err
 }
 
+func ShouldReconcileButRetry(ctx context.Context, reconciler reconcile.Reconciler, req reconcile.Request, optionalDescription ...interface{}) {
+	result, err := reconciler.Reconcile(ctx, req)
+	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred(), optionalDescription...)
+	gomega.ExpectWithOffset(1, result.Requeue).To(gomega.BeTrue())
+}
+
 // Request creates a new reconcile.Request
 func Request(name, namespace string) reconcile.Request {
 	req := reconcile.Request{}

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -160,6 +160,8 @@ const (
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 	// ErrorUnfinished indicates that there are unfinished sub-objects.
 	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
+	// ErrorForInfoOnly indicates that the error is no real error but an info and should be logged only on infor level.
+	ErrorForInfoOnly ErrorCode = "ERR_FOR_INFO_ONLY"
 )
 
 // Condition holds the information about the state of a resource.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -167,6 +167,8 @@ const (
 	ErrorWebhook ErrorCode = "ERR_WEBHOOK"
 	// ErrorUnfinished indicates that there are unfinished sub-objects.
 	ErrorUnfinished ErrorCode = "ERR_UNFINISHED"
+	// ErrorForInfoOnly indicates that the error is no real error but an info and should be logged only on infor level.
+	ErrorForInfoOnly ErrorCode = "ERR_FOR_INFO_ONLY"
 )
 
 // UnrecoverableErrorCodes defines unrecoverable error codes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This PR reduces the error logs. Golang errors not signaling an error of the landscaper are logged as infos.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- reduce number of the error logs
```
