### PR TITLE
Reduce error and info logs

### DIFF
--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -257,7 +257,7 @@ func StartReconcileFromContext(ctx context.Context, req reconcile.Request) (Logg
 // StartReconcile works like StartReconcileFromContext, but it is called on an existing logger instead of fetching one from the context.
 func (l Logger) StartReconcile(req reconcile.Request, keysAndValues ...interface{}) Logger {
 	newLogger := l.WithValues(lc.KeyReconciledResource, req.NamespacedName).WithValues(keysAndValues...)
-	newLogger.Info(lc.MsgStartReconcile)
+	newLogger.Debug(lc.MsgStartReconcile)
 	return newLogger
 }
 

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -124,10 +124,10 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 		}
 
 		if !deployItemClassification.HasRunningItems() && deployItemClassification.HasFailedItems() {
-			err = lserrors.NewError(op, "handlePhaseProgressing", "has failed or missing deploy items")
+			err = lserrors.NewError(op, "handlePhaseProgressing", "has failed or missing deploy items", lsv1alpha1.ErrorForInfoOnly)
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecutionPhases.Failed, err, read_write_layer.W000134)
 		} else if !deployItemClassification.HasRunningItems() && !deployItemClassification.HasRunnableItems() && deployItemClassification.HasPendingItems() {
-			err = lserrors.NewError(op, "handlePhaseProgressing", "items could not be started")
+			err = lserrors.NewError(op, "handlePhaseProgressing", "items could not be started", lsv1alpha1.ErrorForInfoOnly)
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecutionPhases.Failed, err, read_write_layer.W000135)
 		} else if !deployItemClassification.AllSucceeded() {
 			// remain in progressing in all other cases

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -298,10 +298,6 @@ func (c *Controller) setInstallationPhaseAndUpdate(ctx context.Context, inst *ls
 		[]interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(inst).String()},
 		lc.KeyMethod, op)
 
-	if lsError != nil && !lserrors.ContainsErrorCode(lsError, lsv1alpha1.ErrorUnfinished) {
-		logger.Error(lsError, op+lsError.Error())
-	}
-
 	inst.Status.LastError = lserrors.TryUpdateLsError(inst.Status.LastError, lsError)
 
 	if inst.Status.LastError != nil {

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -214,15 +214,22 @@ func checkIfSiblingImports(inst *lsv1alpha1.Installation, siblings []*installati
 //     This is achieved by a fatal error.
 //   - Otherwise, the existence of "sibling" means that "inst" cannot yet be deleted, but must be checked again later.
 //     This is achieved by a normal error.
-func checkSuccessorSibling(inst *lsv1alpha1.Installation, sibling *installations.InstallationAndImports) (fatalError lserrors.LsError, normalError lserrors.LsError) {
+func checkSuccessorSibling(inst *lsv1alpha1.Installation,
+	sibling *installations.InstallationAndImports) (fatalError lserrors.LsError, normalError lserrors.LsError) {
+
 	op := "CheckSuccessorSibling"
 
 	if inst.Status.JobID == sibling.GetInstallation().Status.JobIDFinished &&
 		sibling.GetInstallation().Status.InstallationPhase == lsv1alpha1.InstallationPhases.DeleteFailed {
-		return lserrors.NewWrappedError(SiblingDeleteError,
-			op, "SiblingDeleteError", SiblingDeleteError.Error()), nil
+
+		err := lserrors.NewWrappedError(SiblingDeleteError, op, "SiblingDeleteError",
+			SiblingDeleteError.Error(), lsv1alpha1.ErrorForInfoOnly)
+
+		return err, nil
 	}
 
-	return nil, lserrors.NewWrappedError(SiblingImportError,
-		op, "SiblingImport", SiblingImportError.Error())
+	err := lserrors.NewWrappedError(SiblingImportError, op, "SiblingImport", SiblingImportError.Error(),
+		lsv1alpha1.ErrorForInfoOnly)
+
+	return nil, err
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Reduce error and info logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- reduce error and infor logs
```
