### PR TITLE
Log as info if an installation was changed during processing

### DIFF
--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -452,7 +452,7 @@ func (c *Controller) handlePhaseCompleting(ctx context.Context, inst *lsv1alpha1
 	}
 
 	if inst.Generation != inst.Status.ObservedGeneration {
-		return lserrors.NewError(currentOperation, "CheckObservedGeneration", "installation spec has been changed"), nil
+		return lserrors.NewError(currentOperation, "CheckObservedGeneration", "installation spec has been changed", lsv1alpha1.ErrorForInfoOnly), nil
 	}
 
 	con := imports.NewConstructor(instOp)

--- a/pkg/utils/loghelper.go
+++ b/pkg/utils/loghelper.go
@@ -4,22 +4,18 @@ import (
 	"context"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lserrors "github.com/gardener/landscaper/apis/errors"
-
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 )
 
 type LogHelper struct {
 }
 
-func (r LogHelper) LogErrorAndGetReconcileResult(ctx context.Context, lsError lserrors.LsError) (reconcile.Result, error) {
-
+func (LogHelper) LogErrorAndGetReconcileResult(ctx context.Context, lsError lserrors.LsError) (reconcile.Result, error) {
 	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "LogErrorAndGetReconcileResult")
 
 	if lsError == nil {
@@ -33,7 +29,7 @@ func (r LogHelper) LogErrorAndGetReconcileResult(ctx context.Context, lsError ls
 	}
 }
 
-func (r LogHelper) LogErrorButNotFoundAsInfo(ctx context.Context, err error, message string) {
+func (LogHelper) LogErrorButNotFoundAsInfo(ctx context.Context, err error, message string) {
 	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "LogErrorButNotFoundAsInfo")
 
 	if err == nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind cleanup
/priority 3

**What this PR does / why we need it**:

If an Installation was changed while it was processed, this was logged as an error. This pull request changes the log level of such messages to info.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- improved logging
```
