### PR TITLE
Readiness Checks of the Helm Deployer for StatefulSets and Deployments 

### DIFF
--- a/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/defaultreadinesscheck.go
@@ -200,29 +200,6 @@ func CheckPod(pod *corev1.Pod) error {
 	return nil
 }
 
-var (
-	trueDeploymentConditionTypes = []appsv1.DeploymentConditionType{
-		appsv1.DeploymentAvailable,
-	}
-
-	trueOptionalDeploymentConditionTypes = []appsv1.DeploymentConditionType{
-		appsv1.DeploymentProgressing,
-	}
-
-	falseOptionalDeploymentConditionTypes = []appsv1.DeploymentConditionType{
-		appsv1.DeploymentReplicaFailure,
-	}
-)
-
-func getDeploymentCondition(conditions []appsv1.DeploymentCondition, conditionType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
-	for _, condition := range conditions {
-		if condition.Type == conditionType {
-			return &condition
-		}
-	}
-	return nil
-}
-
 // CheckDeployment checks whether the given Deployment is ready.
 // A Deployment is considered ready if the controller observed its current revision and
 // if the number of updated replicas is equal to the number of replicas.
@@ -231,37 +208,13 @@ func CheckDeployment(dp *appsv1.Deployment) error {
 		return outdatedGeneration(dp.Status.ObservedGeneration, dp.Generation)
 	}
 
-	for _, trueConditionType := range trueDeploymentConditionTypes {
-		conditionType := string(trueConditionType)
-		condition := getDeploymentCondition(dp.Status.Conditions, trueConditionType)
-		if condition == nil {
-			return requiredConditionMissing(conditionType)
-		}
-		if err := checkConditionState(conditionType, string(corev1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
-			return err
-		}
+	replicas := int32(1)
+	if dp.Spec.Replicas != nil {
+		replicas = *dp.Spec.Replicas
 	}
 
-	for _, trueOptionalConditionType := range trueOptionalDeploymentConditionTypes {
-		conditionType := string(trueOptionalConditionType)
-		condition := getDeploymentCondition(dp.Status.Conditions, trueOptionalConditionType)
-		if condition == nil {
-			continue
-		}
-		if err := checkConditionState(conditionType, string(corev1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
-			return err
-		}
-	}
-
-	for _, falseOptionalConditionType := range falseOptionalDeploymentConditionTypes {
-		conditionType := string(falseOptionalConditionType)
-		condition := getDeploymentCondition(dp.Status.Conditions, falseOptionalConditionType)
-		if condition == nil {
-			continue
-		}
-		if err := checkConditionState(conditionType, string(corev1.ConditionFalse), string(condition.Status), condition.Reason, condition.Message); err != nil {
-			return err
-		}
+	if dp.Status.UpdatedReplicas < replicas || dp.Status.AvailableReplicas < replicas {
+		return notEnoughReadyReplicas(dp.Status.AvailableReplicas, replicas)
 	}
 
 	return nil
@@ -281,9 +234,10 @@ func CheckStatefulSet(sts *appsv1.StatefulSet) error {
 		replicas = *sts.Spec.Replicas
 	}
 
-	if sts.Status.ReadyReplicas < replicas {
-		return notEnoughReadyReplicas(sts.Status.ReadyReplicas, replicas)
+	if sts.Status.UpdatedReplicas < replicas || sts.Status.AvailableReplicas < replicas {
+		return notEnoughReadyReplicas(sts.Status.AvailableReplicas, replicas)
 	}
+
 	return nil
 }
 

--- a/pkg/deployer/lib/readinesscheck/defaultreadinesscheck_test.go
+++ b/pkg/deployer/lib/readinesscheck/defaultreadinesscheck_test.go
@@ -66,65 +66,48 @@ var _ = Describe("Default readiness checks", func() {
 				Expect(err).To(matcher)
 			},
 			Entry("ready", &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				}},
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.DeploymentSpec{Replicas: replicas(3)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3},
 			}, BeNil()),
-			Entry("ready with progressing", &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-					},
-				}},
+			Entry("ready with number of replicas unspecified", &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.DeploymentSpec{},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  1},
 			}, BeNil()),
 			Entry("not observed at latest version", &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.DeploymentSpec{Replicas: replicas(3)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 9,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3},
 			}, HaveOccurred()),
-			Entry("not available", &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionFalse,
-					},
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-					},
-				}},
+			Entry("empty status", &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{},
 			}, HaveOccurred()),
-			Entry("not progressing", &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionFalse,
-					},
-				}},
+			Entry("not enough updated replicas", &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.DeploymentSpec{Replicas: replicas(3)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  3},
 			}, HaveOccurred()),
-			Entry("replica failure", &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
-					{
-						Type:   appsv1.DeploymentReplicaFailure,
-						Status: corev1.ConditionTrue,
-					},
-				}},
+			Entry("not enough available replicas", &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.DeploymentSpec{Replicas: replicas(3)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  2},
 			}, HaveOccurred()),
-			Entry("available | progressing missing", &appsv1.Deployment{}, HaveOccurred()),
 		)
 	})
 
@@ -135,21 +118,47 @@ var _ = Describe("Default readiness checks", func() {
 				Expect(err).To(matcher)
 			},
 			Entry("ready", &appsv1.StatefulSet{
-				Spec:   appsv1.StatefulSetSpec{Replicas: replicas(1)},
-				Status: appsv1.StatefulSetStatus{CurrentReplicas: 1, ReadyReplicas: 1},
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.StatefulSetSpec{Replicas: replicas(3)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3},
 			}, BeNil()),
-			Entry("ready with nil replicas", &appsv1.StatefulSet{
-				Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
+			Entry("ready with number of replicas unspecified", &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.StatefulSetSpec{},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  1},
 			}, BeNil()),
 			Entry("not observed at latest version", &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.StatefulSetSpec{Replicas: replicas(3)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 9,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  3},
 			}, HaveOccurred()),
 			Entry("empty status", &appsv1.StatefulSet{
 				Status: appsv1.StatefulSetStatus{},
 			}, HaveOccurred()),
-			Entry("not enough ready replicas", &appsv1.StatefulSet{
-				Spec:   appsv1.StatefulSetSpec{Replicas: replicas(2)},
-				Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
+			Entry("not enough updated replicas", &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.StatefulSetSpec{Replicas: replicas(3)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  3},
+			}, HaveOccurred()),
+			Entry("not enough available replicas", &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 10},
+				Spec:       appsv1.StatefulSetSpec{Replicas: replicas(3)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 10,
+					UpdatedReplicas:    3,
+					AvailableReplicas:  2},
 			}, HaveOccurred()),
 		)
 	})

--- a/test/integration/deployers/blueprints/blueprints_tests.go
+++ b/test/integration/deployers/blueprints/blueprints_tests.go
@@ -207,7 +207,7 @@ func TestDeployerBlueprint(f *framework.Framework, td testDefinition) {
 		}
 
 		utils.ExpectNoError(state.Create(ctx, inst))
-		utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhases.Succeeded, 2*time.Minute))
+		utils.ExpectNoError(lsutils.WaitForInstallationToFinish(ctx, f.Client, inst, lsv1alpha1.InstallationPhases.Succeeded, 10*time.Minute))
 
 		ginkgo.By("Testing the deployer with a simple deployitem")
 

--- a/test/utils/kubernetes_status.go
+++ b/test/utils/kubernetes_status.go
@@ -88,6 +88,7 @@ func SetDeploymentReady(ctx context.Context, client client.Client, dp *appsv1.De
 		Replicas:           *dp.Spec.Replicas,
 		ReadyReplicas:      *dp.Spec.Replicas,
 		AvailableReplicas:  *dp.Spec.Replicas,
+		UpdatedReplicas:    *dp.Spec.Replicas,
 		Conditions: []appsv1.DeploymentCondition{
 			{
 				Type:   appsv1.DeploymentAvailable,
@@ -130,6 +131,8 @@ func SetStatefulSetReady(ctx context.Context, client client.Client, sts *appsv1.
 		Replicas:           *sts.Spec.Replicas,
 		ReadyReplicas:      *sts.Spec.Replicas,
 		CurrentReplicas:    *sts.Spec.Replicas,
+		AvailableReplicas:  *sts.Spec.Replicas,
+		UpdatedReplicas:    *sts.Spec.Replicas,
 	}
 
 	if _, err := controllerutil.CreateOrPatch(ctx, client, sts, func() error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request fixes the readiness check for StatefulSets and Deployments. The check now takes the number of updated and available replicas into account (fields `status.updatedReplicas` and `status.availableReplicas` of a StatefulSet and Deployment).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- the readiness check for StatefulSets and Deployments now takes the number of updated and available replicas into account.
```
