### PR TITLE
readiness checks retry on kubernetes client errors

### DIFF
--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -165,7 +165,7 @@ func getObjectsByTypedReference(ctx context.Context, cl client.Client, key []lsv
 			if apierrors.IsNotFound(err) {
 				return nil, NewObjectNotReadyError(obj, err)
 			} else {
-				return nil, lserror.NewWrappedError(err, "GetObjectsByTypedReference", "failed to get object", err.Error())
+				return nil, NewRecoverableError(err)
 			}
 		}
 		results = append(results, obj)
@@ -185,7 +185,7 @@ func getObjectsByLabels(ctx context.Context, cl client.Client, selector *health.
 	if err := cl.List(ctx, objList, &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(selector.Labels),
 	}); err != nil {
-		return nil, lserror.NewWrappedError(err, "GetObjectsByLabels", "failed to list objects", err.Error())
+		return nil, NewRecoverableError(err)
 	}
 
 	if len(objList.Items) == 0 {

--- a/pkg/deployer/lib/readinesscheck/readiness_test.go
+++ b/pkg/deployer/lib/readinesscheck/readiness_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package readinesscheck
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	mock_client "github.com/gardener/landscaper/controller-utils/pkg/kubernetes/mock"
+)
+
+func createUnstructuredPod() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "core",
+		Version: "v1",
+		Kind:    "Pod",
+	})
+	obj.SetName("Foo")
+	obj.SetNamespace("default")
+
+	return obj
+}
+
+var _ = Describe("IsObjectReady", func() {
+
+	var (
+		ctrl       *gomock.Controller
+		fakeClient *mock_client.MockClient
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		fakeClient = mock_client.NewMockClient(ctrl)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+
+	})
+
+	It("should return a recoverable error in case of k8s client errors", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "core",
+			Version: "v1",
+			Kind:    "Pod",
+		})
+		obj.SetName("Foo")
+		obj.SetNamespace("default")
+
+		fakeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("network error"))
+		err := IsObjectReady(ctx, fakeClient, obj, func(u *unstructured.Unstructured) error {
+			return nil
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(reflect.TypeOf(err)).To(Equal(reflect.TypeOf(&RecoverableError{})))
+	})
+
+	It("should return an object not ready error in case the object is not ready", func() {
+		obj := createUnstructuredPod()
+
+		fakeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		err := IsObjectReady(ctx, fakeClient, obj, func(u *unstructured.Unstructured) error {
+			return NewObjectNotReadyError(u, fmt.Errorf("this is not expected"))
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(reflect.TypeOf(err)).To(Equal(reflect.TypeOf(&ObjectNotReadyError{})))
+	})
+})
+
+type MockInterruptionChecker struct {
+}
+
+func (c *MockInterruptionChecker) Check(_ context.Context) error {
+	return nil
+}
+
+var _ = Describe("WaitForObjectsReady", func() {
+	var (
+		ctrl       *gomock.Controller
+		fakeClient *mock_client.MockClient
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		fakeClient = mock_client.NewMockClient(ctrl)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+
+	})
+
+	It("should wait for objects being ready", func() {
+		getObjectFuncCalls := 0
+		getObjectsFunc := func() ([]*unstructured.Unstructured, error) {
+			if getObjectFuncCalls == 0 {
+				getObjectFuncCalls += 1
+				return nil, NewObjectNotReadyError(createUnstructuredPod(), fmt.Errorf("it is not ready"))
+			}
+			list := []*unstructured.Unstructured{
+				createUnstructuredPod(),
+			}
+			return list, nil
+		}
+
+		checkObjectsFunc := func(u *unstructured.Unstructured) error {
+			return nil
+		}
+
+		fakeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("network error"))
+		fakeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		err := WaitForObjectsReady(ctx, 10*time.Second, fakeClient,
+			getObjectsFunc,
+			checkObjectsFunc,
+			&MockInterruptionChecker{})
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployer
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Preciously the readiness check was aborted when there was any error reported by the kubectl client api.
These errors are now considered recoverable and do not abort the readiness check.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Kubernetes client errors will be considered recoverable and will no longer abort the readiness checks.
```
