### PR TITLE
unblock helm releases stuck in a pending state

### DIFF
--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -560,7 +560,7 @@ var _ = Describe("Template", func() {
 				},
 			}
 
-			Expect(testenv.Client.Create(ctx, testNamespace))
+			Expect(testenv.Client.Create(ctx, testNamespace)).To(Succeed())
 			Expect(testenv.Client.Create(ctx, helmReleaseSecret)).To(Succeed())
 
 			chartBytes, closer := utils.ReadChartFrom("./testdata/testchart4")

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -500,6 +500,8 @@ var _ = Describe("Template", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(state.Create(ctx, target)).To(Succeed())
 
+			testNamespaceName := "test4"
+
 			helmRelease := helmr.Release{
 				Name: "test",
 				Info: &helmr.Info{
@@ -522,7 +524,7 @@ var _ = Describe("Template", func() {
 					},
 				},
 				Version:   1,
-				Namespace: "some-namespace",
+				Namespace: testNamespaceName,
 			}
 
 			helmReleaseMarshaled, err := json.Marshal(helmRelease)
@@ -540,7 +542,7 @@ var _ = Describe("Template", func() {
 			helmReleaseSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sh.helm.release.v1.test.v1",
-					Namespace: "some-namespace",
+					Namespace: testNamespaceName,
 					Labels: map[string]string{
 						"name":    "test",
 						"owner":   "helm",
@@ -556,7 +558,7 @@ var _ = Describe("Template", func() {
 
 			testNamespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "some-namespace",
+					Name: testNamespaceName,
 				},
 			}
 
@@ -574,7 +576,7 @@ var _ = Describe("Template", func() {
 
 			helmConfig := &helmv1alpha1.ProviderConfiguration{
 				Name:            "test",
-				Namespace:       "some-namespace",
+				Namespace:       testNamespaceName,
 				Chart:           chartAccess,
 				CreateNamespace: false,
 				HelmDeployment:  pointer.Bool(true),
@@ -589,7 +591,7 @@ var _ = Describe("Template", func() {
 			Expect(state.Create(ctx, item, envtest.UpdateStatus(true))).To(Succeed())
 
 			Eventually(func() error {
-				if err := testenv.Client.Get(ctx, kutil.ObjectKey("mysecret", "some-namespace"), &corev1.Secret{}); err != nil {
+				if err := testenv.Client.Get(ctx, kutil.ObjectKey("mysecret", testNamespaceName), &corev1.Secret{}); err != nil {
 					return err
 				}
 				return nil

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -5,9 +5,14 @@
 package helm_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"fmt"
+
+	"k8s.io/utils/pointer"
+
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,6 +42,10 @@ import (
 	"github.com/gardener/landscaper/pkg/utils/simplelogger"
 	"github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
+
+	helmc "helm.sh/helm/v3/pkg/chart"
+	helmr "helm.sh/helm/v3/pkg/release"
+	helmt "helm.sh/helm/v3/pkg/time"
 )
 
 func TestConfig(t *testing.T) {
@@ -483,6 +492,108 @@ var _ = Describe("Template", func() {
 
 				return nil
 			}, 10*time.Second, 1*time.Second).Should(Succeed(), "custom readiness checks fulfilled")
+		})
+
+		It("should unblock a pending helm release and finally install the helm chart", func() {
+			Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
+			target, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(state.Create(ctx, target)).To(Succeed())
+
+			helmRelease := helmr.Release{
+				Name: "test",
+				Info: &helmr.Info{
+					FirstDeployed: helmt.Now(),
+					LastDeployed:  helmt.Now(),
+					Description:   "Pending Installation",
+					Status:        helmr.StatusPendingInstall,
+				},
+				Chart: &helmc.Chart{
+					Metadata: &helmc.Metadata{
+						Name:        "testchart",
+						Version:     "0.1.0",
+						Description: "A Helm chart for Kubernetes",
+						APIVersion:  "v2",
+						AppVersion:  "1.16.0",
+						Type:        "application",
+					},
+					Values: map[string]interface{}{
+						"replicaCount": 1,
+					},
+				},
+				Version:   1,
+				Namespace: "some-namespace",
+			}
+
+			helmReleaseMarshaled, err := json.Marshal(helmRelease)
+			Expect(err).ToNot(HaveOccurred())
+
+			var buf bytes.Buffer
+			w, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = w.Write(helmReleaseMarshaled)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(w.Close()).To(Succeed())
+
+			helmReleaseEncoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+
+			helmReleaseSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sh.helm.release.v1.test.v1",
+					Namespace: "some-namespace",
+					Labels: map[string]string{
+						"name":    "test",
+						"owner":   "helm",
+						"status":  "pending-install",
+						"version": "1",
+					},
+				},
+				StringData: map[string]string{
+					"release": helmReleaseEncoded,
+				},
+				Type: "helm.sh/release.v1",
+			}
+
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "some-namespace",
+				},
+			}
+
+			Expect(testenv.Client.Create(ctx, testNamespace))
+			Expect(testenv.Client.Create(ctx, helmReleaseSecret)).To(Succeed())
+
+			chartBytes, closer := utils.ReadChartFrom("./testdata/testchart4")
+			defer closer()
+
+			chartAccess := helmv1alpha1.Chart{
+				Archive: &helmv1alpha1.ArchiveAccess{
+					Raw: base64.StdEncoding.EncodeToString(chartBytes),
+				},
+			}
+
+			helmConfig := &helmv1alpha1.ProviderConfiguration{
+				Name:            "test",
+				Namespace:       "some-namespace",
+				Chart:           chartAccess,
+				CreateNamespace: false,
+				HelmDeployment:  pointer.Bool(true),
+			}
+			item, err := helm.NewDeployItemBuilder().
+				Key(state.Namespace, "myitem").
+				ProviderConfig(helmConfig).
+				Target(target.Namespace, target.Name).
+				GenerateJobID().
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(state.Create(ctx, item, envtest.UpdateStatus(true))).To(Succeed())
+
+			Eventually(func() error {
+				if err := testenv.Client.Get(ctx, kutil.ObjectKey("mysecret", "some-namespace"), &corev1.Secret{}); err != nil {
+					return err
+				}
+				return nil
+			}, 10*time.Second, 1*time.Second).Should(Succeed(), "additional namespace should be created")
 		})
 
 	})

--- a/pkg/deployer/helm/realhelmdeployer/cached_discovery_client.go
+++ b/pkg/deployer/helm/realhelmdeployer/cached_discovery_client.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package realhelmdeployer
 
 import (

--- a/pkg/deployer/helm/realhelmdeployer/client_config_getter.go
+++ b/pkg/deployer/helm/realhelmdeployer/client_config_getter.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package realhelmdeployer
 
 import (

--- a/pkg/deployer/helm/realhelmdeployer/deploy_config.go
+++ b/pkg/deployer/helm/realhelmdeployer/deploy_config.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package realhelmdeployer
 
 import (

--- a/pkg/deployer/helm/realhelmdeployer/helm_secret.go
+++ b/pkg/deployer/helm/realhelmdeployer/helm_secret.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package realhelmdeployer
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"helm.sh/helm/v3/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+)
+
+// The HelmSecretManager manages secrets which are created by Helm to manage releases.
+type HelmSecretManager struct {
+	clientset        *kubernetes.Clientset
+	defaultNamespace string
+}
+
+// NewHelmSecretManager creates a new helm secret manager.
+func NewHelmSecretManager(targetRestConfig *rest.Config, defaultNamespace string, logf func(string, ...interface{})) (*HelmSecretManager, error) {
+	manager := &HelmSecretManager{}
+
+	restClientGetter := newRemoteRESTClientGetter(targetRestConfig, defaultNamespace)
+	kc := kube.New(restClientGetter)
+	kc.Log = logf
+
+	clientset, err := kc.Factory.KubernetesClientSet()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	manager.clientset = clientset
+	manager.defaultNamespace = defaultNamespace
+	return manager, nil
+}
+
+// DeletePendingReleaseSecrets lists all secrets that are created for the given Helm release which are in a pending state.
+// The secret latest (the greatest version) release version is being deleted.
+func (m *HelmSecretManager) DeletePendingReleaseSecrets(ctx context.Context, releaseName string) error {
+	logger, _ := logging.FromContextOrNew(ctx, nil)
+
+	logger.Debug("try delete pending helm releases",
+		lc.KeyResource, types.NamespacedName{Name: releaseName, Namespace: m.defaultNamespace})
+
+	secrets, err := m.clientset.CoreV1().Secrets(m.defaultNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("name=%s, status in (pending-install, pending-upgrade)", releaseName),
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to list helm secrets: %w", err)
+	}
+
+	latestReleaseVersion := 0
+	var latestReleaseVersionSecret *corev1.Secret
+	var version string
+	var hasVersion bool
+
+	for _, secret := range secrets.Items {
+		if secret.Labels == nil {
+			continue
+		}
+
+		version, hasVersion = secret.Labels["version"]
+
+		if !hasVersion {
+			continue
+		}
+
+		releaseVersion, err := strconv.Atoi(version)
+		if err != nil {
+			continue
+		}
+
+		if releaseVersion > latestReleaseVersion {
+			latestReleaseVersion = releaseVersion
+			latestReleaseVersionSecret = &secret
+		}
+	}
+
+	if latestReleaseVersionSecret != nil {
+		logger.Info("deleting pending helm release",
+			lc.KeyResource, types.NamespacedName{Name: latestReleaseVersionSecret.Name, Namespace: latestReleaseVersionSecret.Namespace})
+		err = m.clientset.CoreV1().Secrets(latestReleaseVersionSecret.Namespace).Delete(ctx, latestReleaseVersionSecret.Name, metav1.DeleteOptions{})
+
+		if err != nil {
+			return fmt.Errorf("failed to delete helm secret: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/deployer/helm/realhelmdeployer/helm_secret.go
+++ b/pkg/deployer/helm/realhelmdeployer/helm_secret.go
@@ -50,7 +50,7 @@ func (m *HelmSecretManager) DeletePendingReleaseSecrets(ctx context.Context, rel
 	logger, _ := logging.FromContextOrNew(ctx, nil)
 
 	logger.Debug("try delete pending helm releases",
-		lc.KeyResource, types.NamespacedName{Name: releaseName, Namespace: m.defaultNamespace})
+		lc.KeyResource, types.NamespacedName{Name: releaseName, Namespace: m.defaultNamespace}.String())
 
 	secrets, err := m.clientset.CoreV1().Secrets(m.defaultNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("name=%s, status in (pending-install, pending-upgrade)", releaseName),
@@ -89,7 +89,7 @@ func (m *HelmSecretManager) DeletePendingReleaseSecrets(ctx context.Context, rel
 
 	if latestReleaseVersionSecret != nil {
 		logger.Info("deleting pending helm release",
-			lc.KeyResource, types.NamespacedName{Name: latestReleaseVersionSecret.Name, Namespace: latestReleaseVersionSecret.Namespace})
+			lc.KeyResource, types.NamespacedName{Name: latestReleaseVersionSecret.Name, Namespace: latestReleaseVersionSecret.Namespace}.String())
 		err = m.clientset.CoreV1().Secrets(latestReleaseVersionSecret.Namespace).Delete(ctx, latestReleaseVersionSecret.Name, metav1.DeleteOptions{})
 
 		if err != nil {

--- a/pkg/deployer/helm/realhelmdeployer/real_helm_deployer.go
+++ b/pkg/deployer/helm/realhelmdeployer/real_helm_deployer.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
@@ -372,13 +373,13 @@ func (c *RealHelmDeployer) getHelmSecretManager(ctx context.Context) (*HelmSecre
 }
 
 func (c *RealHelmDeployer) unblockPendingHelmRelease(ctx context.Context, logger logging.Logger) {
-	helmSecretManager, err1 := c.getHelmSecretManager(ctx)
-	if err1 != nil {
-		logger.Error(err1, "get helm secret manager", lc.KeyResource, types.NamespacedName{Name: c.releaseName, Namespace: c.defaultNamespace}.String())
+	helmSecretManager, err := c.getHelmSecretManager(ctx)
+	if err != nil {
+		logger.Error(err, "get helm secret manager", lc.KeyResource, types.NamespacedName{Name: c.releaseName, Namespace: c.defaultNamespace}.String())
 	} else {
-		err1 = helmSecretManager.DeletePendingReleaseSecrets(ctx, c.releaseName)
-		if err1 != nil {
-			logger.Error(err1, "delete helm secret", lc.KeyResource, types.NamespacedName{Name: c.releaseName, Namespace: c.defaultNamespace}.String())
+		err = helmSecretManager.DeletePendingReleaseSecrets(ctx, c.releaseName)
+		if err != nil {
+			logger.Error(err, "delete helm secret", lc.KeyResource, types.NamespacedName{Name: c.releaseName, Namespace: c.defaultNamespace}.String())
 		}
 	}
 }

--- a/pkg/deployer/helm/realhelmdeployer/real_helm_deployer.go
+++ b/pkg/deployer/helm/realhelmdeployer/real_helm_deployer.go
@@ -1,9 +1,14 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package realhelmdeployer
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"strings"
 
@@ -50,6 +55,7 @@ type RealHelmDeployer struct {
 	createNamespace    bool
 	targetRestConfig   *rest.Config
 	apiResourceHandler *resourcemanager.ApiResourceHandler
+	helmSecretManager  *HelmSecretManager
 }
 
 func NewRealHelmDeployer(ch *chart.Chart, providerConfig *helmv1alpha1.ProviderConfiguration, targetRestConfig *rest.Config,
@@ -65,6 +71,7 @@ func NewRealHelmDeployer(ch *chart.Chart, providerConfig *helmv1alpha1.ProviderC
 		createNamespace:    providerConfig.CreateNamespace,
 		targetRestConfig:   targetRestConfig,
 		apiResourceHandler: resourcemanager.CreateApiResourceHandler(clientset),
+		helmSecretManager:  nil,
 	}
 }
 
@@ -144,6 +151,8 @@ func (c *RealHelmDeployer) installRelease(ctx context.Context, values map[string
 
 	rel, err := install.Run(c.chart, values)
 	if err != nil {
+		c.unblockPendingHelmRelease(ctx, logger)
+
 		message := fmt.Sprintf("unable to install helm chart release: %s", err.Error())
 		logger.Info(message)
 		return nil, lserror.NewWrappedError(err, currOp, "Install", message)
@@ -181,6 +190,8 @@ func (c *RealHelmDeployer) upgradeRelease(ctx context.Context, values map[string
 
 	rel, err := upgrade.Run(c.releaseName, c.chart, values)
 	if err != nil {
+		c.unblockPendingHelmRelease(ctx, logger)
+
 		message := fmt.Sprintf("unable to upgrade helm chart release: %s", err.Error())
 		logger.Info(message)
 		return nil, lserror.NewWrappedError(err, currOp, "Install", message)
@@ -344,4 +355,30 @@ func (c *RealHelmDeployer) getResourceStatus(_ context.Context,
 
 func (c *RealHelmDeployer) isReleaseNotFoundErr(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "release: not found")
+}
+
+func (c *RealHelmDeployer) getHelmSecretManager(ctx context.Context) (*HelmSecretManager, error) {
+	var err error
+
+	if c.helmSecretManager == nil {
+		c.helmSecretManager, err = NewHelmSecretManager(c.targetRestConfig, c.defaultNamespace, c.createLogFunc(ctx))
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create helm secret manager: %w", err)
+		}
+	}
+
+	return c.helmSecretManager, nil
+}
+
+func (c *RealHelmDeployer) unblockPendingHelmRelease(ctx context.Context, logger logging.Logger) {
+	helmSecretManager, err1 := c.getHelmSecretManager(ctx)
+	if err1 != nil {
+		logger.Error(err1, "get helm secret manager", lc.KeyResource, types.NamespacedName{Name: c.releaseName, Namespace: c.defaultNamespace}.String())
+	} else {
+		err1 = helmSecretManager.DeletePendingReleaseSecrets(ctx, c.releaseName)
+		if err1 != nil {
+			logger.Error(err1, "delete helm secret", lc.KeyResource, types.NamespacedName{Name: c.releaseName, Namespace: c.defaultNamespace}.String())
+		}
+	}
 }

--- a/pkg/deployer/helm/realhelmdeployer/remote_rest_client_getter.go
+++ b/pkg/deployer/helm/realhelmdeployer/remote_rest_client_getter.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package realhelmdeployer
 
 import (

--- a/pkg/deployer/helm/testdata/testchart4/Chart.yaml
+++ b/pkg/deployer/helm/testdata/testchart4/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: testchart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/pkg/deployer/helm/testdata/testchart4/templates/secret.yaml
+++ b/pkg/deployer/helm/testdata/testchart4/templates/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mysecret
-  namespace: some-namespace
+  namespace: test4
 type: Opaque
 stringData:
   username: abc

--- a/pkg/deployer/helm/testdata/testchart4/templates/secret.yaml
+++ b/pkg/deployer/helm/testdata/testchart4/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+  namespace: some-namespace
+type: Opaque
+stringData:
+  username: abc

--- a/pkg/deployer/helm/testdata/testchart4/values.yaml
+++ b/pkg/deployer/helm/testdata/testchart4/values.yaml
@@ -1,0 +1,5 @@
+# Default values for testchart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind enhancement
/priority 3

**What this PR does / why we need it**:

When a helm deployment (install, upgrade) is running, a helm release secret in a pending state (pending-install, pending-upgrade) is created in the target namespace.
When the helm deployment is interrupted (deployer restart etc.) during the install or upgrade, the helm process will be forever stuck in a pending state until the helm release secret is being deleted.

With this PR the Landscaper helm deployer will try to delete the latest helm release secret that is in a pending state whenever a helm error is encountered.
This unblocks the pending state and retriggers the install, upgrade.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Try to delete pending helm release secret when helm operation was interrupted.
```
