### PR TITLE
Compress Executions

### DIFF
--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -5,8 +5,12 @@
 package core
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/landscaper/apis/utils"
 )
 
 // ExecutionManagedByLabel is the label of a deploy item that contains the name of the managed execution.
@@ -52,8 +56,12 @@ type ExecutionSpec struct {
 	// Context defines the current context of the execution.
 	// +optional
 	Context string `json:"context,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
+
+	// DeployItemsCompressed as zipped byte array
+	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
 
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
@@ -156,4 +164,54 @@ type OnDeleteConfig struct {
 	// Works only in the context of an existing target sync object which is used to check the Garden project with
 	// the shoot cluster resources
 	SkipUninstallIfClusterRemoved bool `json:"skipUninstallIfClusterRemoved,omitempty"`
+}
+
+func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
+	type Alias ExecutionSpec
+	a := (*Alias)(r)
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if len(a.DeployItemsCompressed) > 0 {
+		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
+		if err != nil {
+			return err
+		}
+
+		deployItems := DeployItemTemplateList{}
+		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
+			return err
+		}
+
+		a.DeployItemsCompressed = nil
+		a.DeployItems = deployItems
+	}
+
+	return nil
+}
+
+func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
+	// Copy the ExecutionSpec type. The copied type has the standard marshaling behaviour,
+	// whereas ExecutionSpec has the custom marshaling behaviour defined in this method.
+	type Alias ExecutionSpec
+	a := Alias(r)
+
+	if len(r.DeployItems) > 0 {
+		diBytes, err := json.Marshal(r.DeployItems)
+		if err != nil {
+			return nil, err
+		}
+
+		diZippedBytes, err := utils.Gzip(diBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		a.DeployItems = nil
+		a.DeployItemsCompressed = diZippedBytes
+	}
+
+	return json.Marshal(a)
 }

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -171,18 +172,18 @@ func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
 	a := (*Alias)(r)
 
 	if err := json.Unmarshal(data, &a); err != nil {
-		return err
+		return fmt.Errorf("unable to unmarshal execution spec: %w", err)
 	}
 
 	if len(a.DeployItemsCompressed) > 0 {
 		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to gunzip deployitems of execution spec: %w", err)
 		}
 
 		deployItems := DeployItemTemplateList{}
 		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
-			return err
+			return fmt.Errorf("unable to unmarshal deployitems of execution spec: %w", err)
 		}
 
 		a.DeployItemsCompressed = nil
@@ -201,12 +202,12 @@ func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
 	if len(r.DeployItems) > 0 {
 		diBytes, err := json.Marshal(r.DeployItems)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to marshal deployitems of execution spec: %w", err)
 		}
 
 		diZippedBytes, err := utils.Gzip(diBytes)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to gzip deployitems of execution spec: %w", err)
 		}
 
 		a.DeployItems = nil

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -6,6 +6,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -277,18 +278,18 @@ func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
 	a := (*Alias)(r)
 
 	if err := json.Unmarshal(data, &a); err != nil {
-		return err
+		return fmt.Errorf("unable to unmarshal execution spec: %w", err)
 	}
 
 	if len(a.DeployItemsCompressed) > 0 {
 		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to gunzip deployitems of execution spec: %w", err)
 		}
 
 		deployItems := DeployItemTemplateList{}
 		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
-			return err
+			return fmt.Errorf("unable to unmarshal deployitems of execution spec: %w", err)
 		}
 
 		a.DeployItemsCompressed = nil
@@ -307,12 +308,12 @@ func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
 	if len(r.DeployItems) > 0 {
 		diBytes, err := json.Marshal(r.DeployItems)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to marshal deployitems of execution spec: %w", err)
 		}
 
 		diZippedBytes, err := utils.Gzip(diBytes)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to gzip deployitems of execution spec: %w", err)
 		}
 
 		a.DeployItems = nil

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -5,10 +5,13 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	lsschema "github.com/gardener/landscaper/apis/schema"
+	"github.com/gardener/landscaper/apis/utils"
 )
 
 // ExecutionManagedByLabel is the label of a deploy item that contains the name of the managed execution.
@@ -158,6 +161,9 @@ type ExecutionSpec struct {
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 
+	// DeployItemsCompressed as zipped byte array
+	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
+
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -264,4 +270,54 @@ type OnDeleteConfig struct {
 	// Works only in the context of an existing target sync object which is used to check the Garden project with
 	// the shoot cluster resources
 	SkipUninstallIfClusterRemoved bool `json:"skipUninstallIfClusterRemoved,omitempty"`
+}
+
+func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
+	type Alias ExecutionSpec
+	a := (*Alias)(r)
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if len(a.DeployItemsCompressed) > 0 {
+		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
+		if err != nil {
+			return err
+		}
+
+		deployItems := DeployItemTemplateList{}
+		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
+			return err
+		}
+
+		a.DeployItemsCompressed = nil
+		a.DeployItems = deployItems
+	}
+
+	return nil
+}
+
+func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
+	// Copy the ExecutionSpec type. The copied type has the standard marshaling behaviour,
+	// whereas ExecutionSpec has the custom marshaling behaviour defined in this method.
+	type Alias ExecutionSpec
+	a := Alias(r)
+
+	if len(r.DeployItems) > 0 {
+		diBytes, err := json.Marshal(r.DeployItems)
+		if err != nil {
+			return nil, err
+		}
+
+		diZippedBytes, err := utils.Gzip(diBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		a.DeployItems = nil
+		a.DeployItemsCompressed = diZippedBytes
+	}
+
+	return json.Marshal(a)
 }

--- a/apis/core/v1alpha1/types_execution_test.go
+++ b/apis/core/v1alpha1/types_execution_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1_test
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+)
+
+var _ = Describe("Executions", func() {
+
+	Context("Marshal", func() {
+
+		It("marshal and unmarshal an execution spec with compression", func() {
+			exec := lsv1alpha1.Execution{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testName",
+					Namespace: "testNamespace",
+				},
+				Spec: lsv1alpha1.ExecutionSpec{
+					Context: "testContext",
+					DeployItems: []lsv1alpha1.DeployItemTemplate{
+						{
+							Name: "di1",
+							Type: "diType1",
+							Target: &lsv1alpha1.ObjectReference{
+								Name:      "testTargetName1",
+								Namespace: "testTargetNamespace1",
+							},
+							Labels:             nil,
+							Configuration:      nil,
+							DependsOn:          nil,
+							Timeout:            &lsv1alpha1.Duration{5 * time.Minute},
+							UpdateOnChangeOnly: true,
+						},
+						{
+							Name: "di2",
+							Type: "diType2",
+							Target: &lsv1alpha1.ObjectReference{
+								Name:      "testTargetName2",
+								Namespace: "testTargetNamespace2",
+							},
+							DependsOn:          []string{"di1"},
+							Timeout:            &lsv1alpha1.Duration{5 * time.Minute},
+							UpdateOnChangeOnly: false,
+						},
+					},
+				},
+			}
+
+			execBytes, err := json.Marshal(exec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execBytes).NotTo(BeNil())
+
+			exec2 := lsv1alpha1.Execution{}
+			err = json.Unmarshal(execBytes, &exec2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exec2).To(Equal(exec))
+		})
+
+		It("should marshal an execution without deployitems", func() {
+			exec := lsv1alpha1.Execution{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testName",
+					Namespace: "testNamespace",
+				},
+				Spec: lsv1alpha1.ExecutionSpec{
+					Context:     "testContext",
+					DeployItems: nil,
+				},
+			}
+
+			execBytes, err := json.Marshal(exec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execBytes).NotTo(BeNil())
+
+			exec2 := lsv1alpha1.Execution{}
+			err = json.Unmarshal(execBytes, &exec2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exec2).To(Equal(exec))
+		})
+
+		It("should unmarshal an uncompressed execution spec", func() {
+			type ExecutionSpecAlt lsv1alpha1.ExecutionSpec
+
+			type ExecutionAlt struct {
+				metav1.ObjectMeta `json:"metadata,omitempty"`
+				Spec              ExecutionSpecAlt `json:"spec,omitempty"`
+			}
+
+			exec := ExecutionAlt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testName",
+					Namespace: "testNamespace",
+				},
+				Spec: ExecutionSpecAlt{
+					Context: "testContext",
+					DeployItems: []lsv1alpha1.DeployItemTemplate{
+						{
+							Name: "di1",
+							Type: "diType1",
+							Target: &lsv1alpha1.ObjectReference{
+								Name:      "testTargetName1",
+								Namespace: "testTargetNamespace1",
+							},
+							Labels:             nil,
+							Configuration:      nil,
+							DependsOn:          nil,
+							Timeout:            &lsv1alpha1.Duration{5 * time.Minute},
+							UpdateOnChangeOnly: true,
+						},
+						{
+							Name: "di2",
+							Type: "diType2",
+							Target: &lsv1alpha1.ObjectReference{
+								Name:      "testTargetName2",
+								Namespace: "testTargetNamespace2",
+							},
+							DependsOn:          []string{"di1"},
+							Timeout:            &lsv1alpha1.Duration{5 * time.Minute},
+							UpdateOnChangeOnly: false,
+						},
+					},
+				},
+			}
+
+			execBytes, err := json.Marshal(exec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execBytes).NotTo(BeNil())
+
+			exec2 := lsv1alpha1.Execution{}
+			err = json.Unmarshal(execBytes, &exec2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exec2.ObjectMeta).To(Equal(exec.ObjectMeta))
+			Expect(ExecutionSpecAlt(exec2.Spec)).To(Equal(exec.Spec))
+		})
+	})
+
+})

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2164,6 +2164,7 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
+	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
@@ -2171,6 +2172,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
+	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1274,6 +1274,11 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeployItemsCompressed != nil {
+		in, out := &in.DeployItemsCompressed, &out.DeployItemsCompressed
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RegistryPullSecrets != nil {
 		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
 		*out = make([]ObjectReference, len(*in))

--- a/apis/core/zz_generated.deepcopy.go
+++ b/apis/core/zz_generated.deepcopy.go
@@ -1274,6 +1274,11 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeployItemsCompressed != nil {
+		in, out := &in.DeployItemsCompressed, &out.DeployItemsCompressed
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RegistryPullSecrets != nil {
 		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
 		*out = make([]ObjectReference, len(*in))

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4888,6 +4888,13 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 							},
 						},
 					},
+					"deployItemsCompressed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DeployItemsCompressed as zipped byte array",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
 					"registryPullSecrets": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",

--- a/apis/utils/gzip.go
+++ b/apis/utils/gzip.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func Gunzip(data []byte) ([]byte, error) {
+	b := bytes.NewBuffer(data)
+
+	var r io.Reader
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, err
+	}
+
+	var res bytes.Buffer
+	_, err = res.ReadFrom(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Bytes(), nil
+}
+
+func Gzip(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+
+	_, err := gz.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = gz.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err = gz.Close(); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -5,8 +5,12 @@
 package core
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/landscaper/apis/utils"
 )
 
 // ExecutionManagedByLabel is the label of a deploy item that contains the name of the managed execution.
@@ -52,8 +56,12 @@ type ExecutionSpec struct {
 	// Context defines the current context of the execution.
 	// +optional
 	Context string `json:"context,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
+
+	// DeployItemsCompressed as zipped byte array
+	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
 
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
@@ -156,4 +164,54 @@ type OnDeleteConfig struct {
 	// Works only in the context of an existing target sync object which is used to check the Garden project with
 	// the shoot cluster resources
 	SkipUninstallIfClusterRemoved bool `json:"skipUninstallIfClusterRemoved,omitempty"`
+}
+
+func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
+	type Alias ExecutionSpec
+	a := (*Alias)(r)
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if len(a.DeployItemsCompressed) > 0 {
+		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
+		if err != nil {
+			return err
+		}
+
+		deployItems := DeployItemTemplateList{}
+		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
+			return err
+		}
+
+		a.DeployItemsCompressed = nil
+		a.DeployItems = deployItems
+	}
+
+	return nil
+}
+
+func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
+	// Copy the ExecutionSpec type. The copied type has the standard marshaling behaviour,
+	// whereas ExecutionSpec has the custom marshaling behaviour defined in this method.
+	type Alias ExecutionSpec
+	a := Alias(r)
+
+	if len(r.DeployItems) > 0 {
+		diBytes, err := json.Marshal(r.DeployItems)
+		if err != nil {
+			return nil, err
+		}
+
+		diZippedBytes, err := utils.Gzip(diBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		a.DeployItems = nil
+		a.DeployItemsCompressed = diZippedBytes
+	}
+
+	return json.Marshal(a)
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -5,10 +5,13 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	lsschema "github.com/gardener/landscaper/apis/schema"
+	"github.com/gardener/landscaper/apis/utils"
 )
 
 // ExecutionManagedByLabel is the label of a deploy item that contains the name of the managed execution.
@@ -158,6 +161,9 @@ type ExecutionSpec struct {
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 
+	// DeployItemsCompressed as zipped byte array
+	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
+
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -264,4 +270,54 @@ type OnDeleteConfig struct {
 	// Works only in the context of an existing target sync object which is used to check the Garden project with
 	// the shoot cluster resources
 	SkipUninstallIfClusterRemoved bool `json:"skipUninstallIfClusterRemoved,omitempty"`
+}
+
+func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
+	type Alias ExecutionSpec
+	a := (*Alias)(r)
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if len(a.DeployItemsCompressed) > 0 {
+		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
+		if err != nil {
+			return err
+		}
+
+		deployItems := DeployItemTemplateList{}
+		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
+			return err
+		}
+
+		a.DeployItemsCompressed = nil
+		a.DeployItems = deployItems
+	}
+
+	return nil
+}
+
+func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
+	// Copy the ExecutionSpec type. The copied type has the standard marshaling behaviour,
+	// whereas ExecutionSpec has the custom marshaling behaviour defined in this method.
+	type Alias ExecutionSpec
+	a := Alias(r)
+
+	if len(r.DeployItems) > 0 {
+		diBytes, err := json.Marshal(r.DeployItems)
+		if err != nil {
+			return nil, err
+		}
+
+		diZippedBytes, err := utils.Gzip(diBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		a.DeployItems = nil
+		a.DeployItemsCompressed = diZippedBytes
+	}
+
+	return json.Marshal(a)
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2164,6 +2164,7 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
+	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
@@ -2171,6 +2172,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
+	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1274,6 +1274,11 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeployItemsCompressed != nil {
+		in, out := &in.DeployItemsCompressed, &out.DeployItemsCompressed
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RegistryPullSecrets != nil {
 		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
 		*out = make([]ObjectReference, len(*in))

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1274,6 +1274,11 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeployItemsCompressed != nil {
+		in, out := &in.DeployItemsCompressed, &out.DeployItemsCompressed
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RegistryPullSecrets != nil {
 		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
 		*out = make([]ObjectReference, len(*in))

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/utils/gzip.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/utils/gzip.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func Gunzip(data []byte) ([]byte, error) {
+	b := bytes.NewBuffer(data)
+
+	var r io.Reader
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, err
+	}
+
+	var res bytes.Buffer
+	_, err = res.ReadFrom(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Bytes(), nil
+}
+
+func Gzip(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+
+	_, err := gz.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = gz.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err = gz.Close(); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/controller-utils/vendor/modules.txt
+++ b/controller-utils/vendor/modules.txt
@@ -27,6 +27,7 @@ github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/core
 github.com/gardener/landscaper/apis/core/v1alpha1
 github.com/gardener/landscaper/apis/schema
+github.com/gardener/landscaper/apis/utils
 # github.com/ghodss/yaml v1.0.0
 ## explicit
 github.com/ghodss/yaml

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -928,6 +928,17 @@ DeployItemTemplateList
 </tr>
 <tr>
 <td>
+<code>deployItemsCompressed</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>DeployItemsCompressed as zipped byte array</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>registryPullSecrets</code></br>
 <em>
 <a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
@@ -3562,6 +3573,17 @@ DeployItemTemplateList
 </td>
 <td>
 <p>DeployItems defines all execution items that need to be scheduled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deployItemsCompressed</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>DeployItemsCompressed as zipped byte array</p>
 </td>
 </tr>
 <tr>

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -109,6 +109,10 @@ spec:
                   - config
                   type: object
                 type: array
+              deployItemsCompressed:
+                description: DeployItemsCompressed as zipped byte array
+                format: byte
+                type: string
               registryPullSecrets:
                 description: 'RegistryPullSecrets defines a list of registry credentials
                   that are used to pull blueprints, component descriptors and jsonschemas

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -5,8 +5,12 @@
 package core
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/landscaper/apis/utils"
 )
 
 // ExecutionManagedByLabel is the label of a deploy item that contains the name of the managed execution.
@@ -52,8 +56,12 @@ type ExecutionSpec struct {
 	// Context defines the current context of the execution.
 	// +optional
 	Context string `json:"context,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
+
+	// DeployItemsCompressed as zipped byte array
+	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
 
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
@@ -156,4 +164,54 @@ type OnDeleteConfig struct {
 	// Works only in the context of an existing target sync object which is used to check the Garden project with
 	// the shoot cluster resources
 	SkipUninstallIfClusterRemoved bool `json:"skipUninstallIfClusterRemoved,omitempty"`
+}
+
+func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
+	type Alias ExecutionSpec
+	a := (*Alias)(r)
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if len(a.DeployItemsCompressed) > 0 {
+		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
+		if err != nil {
+			return err
+		}
+
+		deployItems := DeployItemTemplateList{}
+		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
+			return err
+		}
+
+		a.DeployItemsCompressed = nil
+		a.DeployItems = deployItems
+	}
+
+	return nil
+}
+
+func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
+	// Copy the ExecutionSpec type. The copied type has the standard marshaling behaviour,
+	// whereas ExecutionSpec has the custom marshaling behaviour defined in this method.
+	type Alias ExecutionSpec
+	a := Alias(r)
+
+	if len(r.DeployItems) > 0 {
+		diBytes, err := json.Marshal(r.DeployItems)
+		if err != nil {
+			return nil, err
+		}
+
+		diZippedBytes, err := utils.Gzip(diBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		a.DeployItems = nil
+		a.DeployItemsCompressed = diZippedBytes
+	}
+
+	return json.Marshal(a)
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -5,10 +5,13 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	lsschema "github.com/gardener/landscaper/apis/schema"
+	"github.com/gardener/landscaper/apis/utils"
 )
 
 // ExecutionManagedByLabel is the label of a deploy item that contains the name of the managed execution.
@@ -158,6 +161,9 @@ type ExecutionSpec struct {
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 
+	// DeployItemsCompressed as zipped byte array
+	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
+
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -264,4 +270,54 @@ type OnDeleteConfig struct {
 	// Works only in the context of an existing target sync object which is used to check the Garden project with
 	// the shoot cluster resources
 	SkipUninstallIfClusterRemoved bool `json:"skipUninstallIfClusterRemoved,omitempty"`
+}
+
+func (r *ExecutionSpec) UnmarshalJSON(data []byte) error {
+	type Alias ExecutionSpec
+	a := (*Alias)(r)
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if len(a.DeployItemsCompressed) > 0 {
+		diBytes, err := utils.Gunzip(a.DeployItemsCompressed)
+		if err != nil {
+			return err
+		}
+
+		deployItems := DeployItemTemplateList{}
+		if err := json.Unmarshal(diBytes, &deployItems); err != nil {
+			return err
+		}
+
+		a.DeployItemsCompressed = nil
+		a.DeployItems = deployItems
+	}
+
+	return nil
+}
+
+func (r ExecutionSpec) MarshalJSON() ([]byte, error) {
+	// Copy the ExecutionSpec type. The copied type has the standard marshaling behaviour,
+	// whereas ExecutionSpec has the custom marshaling behaviour defined in this method.
+	type Alias ExecutionSpec
+	a := Alias(r)
+
+	if len(r.DeployItems) > 0 {
+		diBytes, err := json.Marshal(r.DeployItems)
+		if err != nil {
+			return nil, err
+		}
+
+		diZippedBytes, err := utils.Gzip(diBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		a.DeployItems = nil
+		a.DeployItemsCompressed = diZippedBytes
+	}
+
+	return json.Marshal(a)
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2164,6 +2164,7 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
+	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
@@ -2171,6 +2172,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
+	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1274,6 +1274,11 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeployItemsCompressed != nil {
+		in, out := &in.DeployItemsCompressed, &out.DeployItemsCompressed
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RegistryPullSecrets != nil {
 		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
 		*out = make([]ObjectReference, len(*in))

--- a/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1274,6 +1274,11 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeployItemsCompressed != nil {
+		in, out := &in.DeployItemsCompressed, &out.DeployItemsCompressed
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	if in.RegistryPullSecrets != nil {
 		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
 		*out = make([]ObjectReference, len(*in))

--- a/vendor/github.com/gardener/landscaper/apis/utils/gzip.go
+++ b/vendor/github.com/gardener/landscaper/apis/utils/gzip.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func Gunzip(data []byte) ([]byte, error) {
+	b := bytes.NewBuffer(data)
+
+	var r io.Reader
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, err
+	}
+
+	var res bytes.Buffer
+	_, err = res.ReadFrom(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Bytes(), nil
+}
+
+func Gzip(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+
+	_, err := gz.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = gz.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err = gz.Close(); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,6 +209,7 @@ github.com/gardener/landscaper/apis/deployer/utils/readinesschecks/validation
 github.com/gardener/landscaper/apis/errors
 github.com/gardener/landscaper/apis/mediatype
 github.com/gardener/landscaper/apis/schema
+github.com/gardener/landscaper/apis/utils
 # github.com/gardener/landscaper/controller-utils v0.0.0-00010101000000-000000000000 => ./controller-utils
 ## explicit; go 1.19
 github.com/gardener/landscaper/controller-utils/pkg/crdmanager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

An Execution cannot be created if it exceeds the maximum allowed size for a custom resource. For example, this can happen if an Execution has several DeployItems with large Helm values. 

To remedy this issue, we compress the list of DeployItems inside an Execution. This is done during the marshalling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- compression of executions
```
