### PR TITLE
new manual component descriptor logic

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "create dummy component descriptor"
+echo "create dummy component descriptor BEGIN"
 
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
@@ -17,6 +17,10 @@ COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}"
 
 VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_DIR="${COMPONENT_DESCRIPTOR_DIR}" python ${SOURCE_PATH}/hack/create-dummy-cd.py
 
-echo "create real component descriptor"
+echo "create dummy component descriptor END"
+
+echo "create real component descriptor BEGIN"
 
 ${SOURCE_PATH}/.ci/component_descriptor_real
+
+echo "create real component descriptor END"

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -13,7 +13,21 @@ echo "component descriptor dummy step"
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
 REPO_CTX="eu.gcr.io/gardener-project/development"
 
-${COMP_CLI}  ca create "${COMPONENT_DESCRIPTOR_DIR}" \
-  --component-name=github.com/gardener/landscaper \
-  --component-version=${VERSION} \
-  --repo-ctx=${REPO_CTX}
+COMPONENT_DESCRIPTOR="
+meta:
+  schemaVersion: v2
+component:
+  name: github.com/gardener/landscaper
+  version: ${VERSION}-dummy
+  provider: internal
+  repositoryContexts:
+  - baseUrl: ${REPO_CTX}
+    componentNameMapping: urlPath
+    type: ociRegistry
+  componentReferences: []
+  resources: []
+  sources: []
+"
+
+echo ${COMPONENT_DESCRIPTOR} > ${COMPONENT_DESCRIPTOR_DIR}
+

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -13,6 +13,6 @@ echo "component descriptor dummy step"
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
 REPO_CTX="eu.gcr.io/gardener-project/development"
-COMPONENT_DESCRIPTOR_FILE="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2"
+COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}
 
-VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_FILE="${COMPONENT_DESCRIPTOR_FILE}" python ${SOURCE_PATH}/hack/create-dummy-cd.py
+VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_DIR="${COMPONENT_DESCRIPTOR_DIR}" python ${SOURCE_PATH}/hack/create-dummy-cd.py

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -9,3 +9,11 @@ set -o nounset
 set -o pipefail
 
 echo "component descriptor dummy step"
+
+VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
+REPO_CTX="eu.gcr.io/gardener-project/development"
+
+${COMP_CLI}  ca create "${COMPONENT_DESCRIPTOR_DIR}" \
+  --component-name=github.com/gardener/landscaper \
+  --component-version=${VERSION} \
+  --repo-ctx=${REPO_CTX}

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -10,26 +10,9 @@ set -o pipefail
 
 echo "component descriptor dummy step"
 
+SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
 REPO_CTX="eu.gcr.io/gardener-project/development"
+COMPONENT_DESCRIPTOR_FILE="${SOURCE_PATH}/../../${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2"
 
-COMPONENT_DESCRIPTOR="
-meta:
-  schemaVersion: v2
-component:
-  name: github.com/gardener/landscaper
-  version: ${VERSION}-dummy
-  provider: internal
-  repositoryContexts:
-  - baseUrl: ${REPO_CTX}
-    componentNameMapping: urlPath
-    type: ociRegistry
-  componentReferences: []
-  resources: []
-  sources: []
-"
-
-COMPONENT_DESCRIPTOR_DIR="$(pwd)"
-
-echo ${COMPONENT_DESCRIPTOR} > ${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2
-
+VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_FILE="${COMPONENT_DESCRIPTOR_FILE}" python ${SOURCE_PATH}/hack/create-dummy-cd.py

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "component descriptor dummy step"
+echo "create dummy component descriptor"
 
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
@@ -16,3 +16,7 @@ REPO_CTX="eu.gcr.io/gardener-project/development"
 COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}"
 
 VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_DIR="${COMPONENT_DESCRIPTOR_DIR}" python ${SOURCE_PATH}/hack/create-dummy-cd.py
+
+echo "create real component descriptor"
+
+${SOURCE_PATH}/.ci/component_descriptor_real

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -13,6 +13,6 @@ echo "component descriptor dummy step"
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
 REPO_CTX="eu.gcr.io/gardener-project/development"
-COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}
+COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}"
 
 VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_DIR="${COMPONENT_DESCRIPTOR_DIR}" python ${SOURCE_PATH}/hack/create-dummy-cd.py

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -29,7 +29,7 @@ component:
   sources: []
 "
 
-COMPONENT_DESCRIPTOR_DIR=$(pwd)/${COMPONENT_DESCRIPTOR_DIR}
+COMPONENT_DESCRIPTOR_DIR="$(pwd)"
 
 echo ${COMPONENT_DESCRIPTOR} > ${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2
 

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,88 +8,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "component-cli is required to generate the component descriptors"
-CLI_PATH="$(mktemp -d)"
-COMP_CLI=${CLI_PATH}/component-cli
-echo "Trying to installing component-cli to ${COMP_CLI}"
-OS="$(uname -o | awk '{print tolower($0)}')"
-ARCH="$(uname -m | awk '{print tolower($0)}')"
-
-if [[ ${OS} == *"linux"* ]]; then
-  OS="linux"
-fi
-if [[ ${OS} == *"darwin"* ]]; then
-  OS="darwin"
-fi
-
-if [[ ${ARCH} == *"x86_64"* ]]; then
-  ARCH="amd64"
-fi
-if [[ ${ARCH} == *"arm64"* ]]; then
-  ARCH="arm64"
-fi
-
-curl -L https://github.com/gardener/component-cli/releases/download/v0.48.0/componentcli-${OS}-${ARCH}.gz | gzip -d > ${COMP_CLI}
-chmod +x ${COMP_CLI}
-
-SOURCE_PATH="$(dirname $0)/.."
-VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
-COMMIT_SHA="$(git --git-dir ${SOURCE_PATH}/.git rev-parse HEAD)"
-
-printf "> Building components with version ${VERSION} - ${COMMIT_SHA}\n"
-
-REPO_CTX="${CURRENT_COMPONENT_REPOSITORY}"
-
-# creates a component archive for deployer
-# it expects 1 argument with
-# $1 is the name of the component
-function buildComponentArchive() {
-  COMPONENT_NAME=$1
-  CA_PATH="$(mktemp -d)"
-  printf "> Building component ${COMPONENT_NAME}\n"
-
-  COMPONENT_REFERENCES=""
-
-  if [ -f ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml ]; then
-    COMPONENT_REFERENCES="-c ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml"
-  fi
-
-  ${COMP_CLI} ca "${CA_PATH}" "${CTF_PATH}" \
-    --component-name=github.com/gardener/landscaper/${COMPONENT_NAME} \
-    --component-version=${VERSION} \
-    --repo-ctx=${REPO_CTX} \
-    -s ${SOURCE_PATH}/.landscaper/sources.yaml \
-    -r ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/resources.yaml \
-    COMMIT_SHA=${COMMIT_SHA} \
-    VERSION=${VERSION} \
-    $COMPONENT_REFERENCES
-}
-
-buildComponentArchive "container-deployer"
-buildComponentArchive "helm-deployer"
-buildComponentArchive "manifest-deployer"
-buildComponentArchive "mock-deployer"
-
-# add landscaper component descriptor
-printf "> Create Landscaper ca archive\n"
-LS_CA_PATH="$(mktemp -d)"
-cp ${BASE_DEFINITION_PATH} "${LS_CA_PATH}/component-descriptor.yaml"
-
-printf "> add resources\n"
-${COMP_CLI} ca resources add ${LS_CA_PATH} \
-    VERSION=${VERSION} \
-    ${SOURCE_PATH}/.landscaper/resources.yaml
-
-printf "> add component references\n"
-${COMP_CLI} ca component-references add ${LS_CA_PATH} \
-    VERSION=${VERSION} \
-    ${SOURCE_PATH}/.landscaper/component-references.yaml
-
-cat ${LS_CA_PATH}/component-descriptor.yaml
-
-printf "> Add Landscaper CA to ctf\n"
-${COMP_CLI} ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
-
-# also upload the components to a open source repo
-# todo: remove as soon as the default component repository is public
-${COMP_CLI} ctf push --repo-ctx="eu.gcr.io/gardener-project/development" "${CTF_PATH}"
+echo "component descriptor dummy step"

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -29,5 +29,5 @@ component:
   sources: []
 "
 
-echo ${COMPONENT_DESCRIPTOR} > ${COMPONENT_DESCRIPTOR_DIR}
+echo ${COMPONENT_DESCRIPTOR} > ${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2
 

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -13,6 +13,6 @@ echo "component descriptor dummy step"
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
 REPO_CTX="eu.gcr.io/gardener-project/development"
-COMPONENT_DESCRIPTOR_FILE="${SOURCE_PATH}/../../${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2"
+COMPONENT_DESCRIPTOR_FILE="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2"
 
 VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_FILE="${COMPONENT_DESCRIPTOR_FILE}" python ${SOURCE_PATH}/hack/create-dummy-cd.py

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -29,5 +29,7 @@ component:
   sources: []
 "
 
+COMPONENT_DESCRIPTOR_DIR=$(pwd)/${COMPONENT_DESCRIPTOR_DIR}
+
 echo ${COMPONENT_DESCRIPTOR} > ${COMPONENT_DESCRIPTOR_DIR}/component_descriptor_v2
 

--- a/.ci/component_descriptor_real
+++ b/.ci/component_descriptor_real
@@ -105,8 +105,8 @@ cat ${LS_CA_PATH}/component-descriptor.yaml
 printf "> Add Landscaper CA to ctf\n"
 ${COMP_CLI} ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
 
-printf "> Pulbish Landscaper Components to ${REPO_CTX}\n"
+printf "> Publish Landscaper Components to ${REPO_CTX}\n"
 ${COMP_CLI} ctf push --repo-ctx=${REPO_CTX} "${CTF_PATH}"
 
-printf "> Pulbish Landscaper Components to ${REPO_CTX_DEV}\n"
+printf "> Publish Landscaper Components to ${REPO_CTX_DEV}\n"
 ${COMP_CLI} ctf push --repo-ctx=${REPO_CTX_DEV} "${CTF_PATH}"

--- a/.ci/component_descriptor_real
+++ b/.ci/component_descriptor_real
@@ -94,6 +94,12 @@ ${COMP_CLI} ca component-references add ${LS_CA_PATH} \
     VERSION=${VERSION} \
     ${SOURCE_PATH}/.landscaper/component-references.yaml
 
+printf "> add sources"
+${COMP_CLI} ca sources add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    COMMIT_SHA=${COMMIT_SHA} \
+    ${SOURCE_PATH}/.landscaper/sources.yaml
+
 cat ${LS_CA_PATH}/component-descriptor.yaml
 
 printf "> Add Landscaper CA to ctf\n"

--- a/.ci/component_descriptor_real
+++ b/.ci/component_descriptor_real
@@ -94,7 +94,7 @@ ${COMP_CLI} ca component-references add ${LS_CA_PATH} \
     VERSION=${VERSION} \
     ${SOURCE_PATH}/.landscaper/component-references.yaml
 
-printf "> add sources"
+printf "> add sources\n"
 ${COMP_CLI} ca sources add ${LS_CA_PATH} \
     VERSION=${VERSION} \
     COMMIT_SHA=${COMMIT_SHA} \

--- a/.ci/component_descriptor_real
+++ b/.ci/component_descriptor_real
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "component-cli is required to generate the component descriptors"
+CLI_PATH="$(mktemp -d)"
+COMP_CLI=${CLI_PATH}/component-cli
+echo "Trying to installing component-cli to ${COMP_CLI}"
+OS="$(uname -o | awk '{print tolower($0)}')"
+ARCH="$(uname -m | awk '{print tolower($0)}')"
+
+if [[ ${OS} == *"linux"* ]]; then
+  OS="linux"
+fi
+if [[ ${OS} == *"darwin"* ]]; then
+  OS="darwin"
+fi
+
+if [[ ${ARCH} == *"x86_64"* ]]; then
+  ARCH="amd64"
+fi
+if [[ ${ARCH} == *"arm64"* ]]; then
+  ARCH="arm64"
+fi
+if [[ ${ARCH} == *"aarch64"* ]]; then
+  ARCH="arm64"
+fi
+
+curl -L https://github.com/gardener/component-cli/releases/download/v0.55.0/componentcli-${OS}-${ARCH}.gz | gzip -d > ${COMP_CLI}
+chmod +x ${COMP_CLI}
+
+SOURCE_PATH="$(dirname $0)/.."
+VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
+COMMIT_SHA="$(git --git-dir ${SOURCE_PATH}/.git rev-parse HEAD)"
+
+printf "> Building components with version ${VERSION} - ${COMMIT_SHA}\n"
+
+REPO_CTX="eu.gcr.io/sap-gcp-cp-k8s-stable-hub/landscaper"
+REPO_CTX_DEV="eu.gcr.io/gardener-project/development"
+CTF_PATH="$(mktemp -d)"
+CTF_PATH="${CTF_PATH}/ctf.tar"
+
+# creates a component archive for deployer
+# it expects 1 argument with
+# $1 is the name of the component
+function buildComponentArchive() {
+  COMPONENT_NAME=$1
+  CA_PATH="$(mktemp -d)"
+  printf "> Building component ${COMPONENT_NAME}\n"
+
+  COMPONENT_REFERENCES=""
+
+  if [ -f ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml ]; then
+    COMPONENT_REFERENCES="-c ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml"
+  fi
+
+  ${COMP_CLI} ca "${CA_PATH}" "${CTF_PATH}" \
+    --component-name=github.com/gardener/landscaper/${COMPONENT_NAME} \
+    --component-version=${VERSION} \
+    --repo-ctx=${REPO_CTX} \
+    -s ${SOURCE_PATH}/.landscaper/sources.yaml \
+    -r ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/resources.yaml \
+    COMMIT_SHA=${COMMIT_SHA} \
+    VERSION=${VERSION} \
+    $COMPONENT_REFERENCES
+}
+
+buildComponentArchive "container-deployer"
+buildComponentArchive "helm-deployer"
+buildComponentArchive "manifest-deployer"
+buildComponentArchive "mock-deployer"
+
+# add landscaper component descriptor
+printf "> Create Landscaper Component"
+LS_CA_PATH="$(mktemp -d)"
+${COMP_CLI}  ca create "${LS_CA_PATH}" \
+  --component-name=github.com/gardener/landscaper \
+  --component-version=${VERSION} \
+  --repo-ctx=${REPO_CTX}
+
+printf "> add resources\n"
+${COMP_CLI} ca resources add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    ${SOURCE_PATH}/.landscaper/resources.yaml
+
+printf "> add component references\n"
+${COMP_CLI} ca component-references add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    ${SOURCE_PATH}/.landscaper/component-references.yaml
+
+cat ${LS_CA_PATH}/component-descriptor.yaml
+
+printf "> Add Landscaper CA to ctf\n"
+${COMP_CLI} ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
+
+printf "> Pulbish Landscaper Components to ${REPO_CTX}\n"
+${COMP_CLI} ctf push --repo-ctx=${REPO_CTX} "${CTF_PATH}"
+
+printf "> Pulbish Landscaper Components to ${REPO_CTX_DEV}\n"
+${COMP_CLI} ctf push --repo-ctx=${REPO_CTX_DEV} "${CTF_PATH}"

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -27,3 +27,24 @@ access:
   type: ociRegistry
   imageReference: eu.gcr.io/gardener-project/landscaper/charts/landscaper-agent:${VERSION}
 ---
+type: ociImage
+name: landscaper-controller
+relation: local
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper/landscaper-controller:${VERSION}
+---
+name: landscaper-webhooks-server
+relation: local
+type: ociImage
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper/landscaper-webhooks-server:${VERSION}
+---
+name: landscaper-agent
+relation: local
+type: ociImage
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper/landscaper-agent:${VERSION}
+---

--- a/hack/create-dummy-cd.py
+++ b/hack/create-dummy-cd.py
@@ -20,6 +20,9 @@ cd = {
           "type": "ociRegistry"
         }
       ],
+      "sources": [],
+      "resources": [],
+      "componentReferences": []
     }
 }
 

--- a/hack/create-dummy-cd.py
+++ b/hack/create-dummy-cd.py
@@ -1,0 +1,27 @@
+import os
+import yaml
+
+version = os.environ["VERSION"]
+repo_ctx = os.environ["REPO_CTX"]
+component_descriptor_file = os.environ["COMPONENT_DESCRIPTOR_FILE"]
+
+cd = {
+    "meta": {
+      "schemaVersion": "v2"
+    },
+    "component": {
+      "name": "github.com/gardener/landscaper",
+      "version": version,
+      "provider": "internal",
+      "repositoryContexts": [
+        {
+          "baseUrl": repo_ctx,
+          "componentNameMapping": "urlPath",
+          "type": "ociRegistry"
+        }
+      ],
+    }
+}
+
+with open(component_descriptor_file, "w+") as cd_file:
+    cd_file.write(yaml.safe_dump(cd))

--- a/hack/create-dummy-cd.py
+++ b/hack/create-dummy-cd.py
@@ -3,28 +3,15 @@ import yaml
 
 version = os.environ["VERSION"]
 repo_ctx = os.environ["REPO_CTX"]
-component_descriptor_file = os.environ["COMPONENT_DESCRIPTOR_FILE"]
+component_descriptor_dir = os.environ["COMPONENT_DESCRIPTOR_DIR"]
 
-cd = {
-    "meta": {
-      "schemaVersion": "v2"
-    },
-    "component": {
-      "name": "github.com/gardener/landscaper",
-      "version": version,
-      "provider": "internal",
-      "repositoryContexts": [
-        {
-          "baseUrl": repo_ctx,
-          "componentNameMapping": "urlPath",
-          "type": "ociRegistry"
-        }
-      ],
-      "sources": [],
-      "resources": [],
-      "componentReferences": []
-    }
-}
+cd = None
 
-with open(component_descriptor_file, "w+") as cd_file:
+with open(os.path.join(component_descriptor_dir, "base_component_descriptor_v2"), "r") as base_cd_file:
+    cd = yaml.safe_load(base_cd_file.read())
+
+cd["component"]["version"] = version
+cd["component"]["repositoryContexts"][0]["baseUrl"] = repo_ctx
+
+with open(os.path.join(component_descriptor_dir, "component_descriptor_v2"), "w+") as cd_file:
     cd_file.write(yaml.safe_dump(cd))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind cleanup
/priority 3

**What this PR does / why we need it**:

Since landscaper is still using component-cli, this PR uses its own component upload logic instead of the implicit functionality of the CICD pipeline tools.

The implicit pipeline logic will now upload a dummy component with a version ending with "-dummy".
This is done because the pipeline relies on this component to create a release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
