### PR TITLE
Improve targetsync docu

### DIFF
--- a/docs/usage/TargetSyncs.md
+++ b/docs/usage/TargetSyncs.md
@@ -137,7 +137,7 @@ spec:
 
 ## Token Rotation
 
-If the field `tokenRotation.enabled` is set tu `true`, the token in the kubeconfig of the secret referenced by
+If the field `tokenRotation.enabled` is set to `true`, the token in the kubeconfig of the secret referenced by
 the *TargetSync* object in `spec.secretRef` is rotated every 60 days, whereby the lifetime of new every token is 60 days. It is assumed that the kubeconfig in the secret has the following format (this is the format if you download the kubeconfig of a Gardener service account, from the Gardener dashboard):
 
 ```yaml
@@ -155,13 +155,15 @@ clusters:
     cluster:
       server: https://...
 users:
-  - name: <service account name>
+  - name: <service account name> 
     user:
       token: >-
         eyJhbGciOiJSUzI1NiIsImtpZCI6IjBCOXVYUkd2ck0zdC1TMVUtMXFESWRNc1BPYzR...
 ```
 
-Token rotation requires that the corresponding service account is allowed to request new tokens for itself.
+**Attention:** 
+  - The name in the users section must be the same as the service account name in the Gardener project for which this kubeconfig (token) was created.  
+  - Token rotation requires that the corresponding service account is allowed to request new tokens for itself.
 
 ## Trigger the Reconciliation of a *TargetSync* object
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Improve targetsync docu. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
- Improve targetsync docu
```
