### PR TITLE
Log sync object name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@
 - [Deployer Lifecycle Management](technical/deployer_lifecycle_management.md)
 - [Execution Controller](technical/execution_controller.md)
 - [Installation Controller](technical/installation_controller.md)
+- [Scaling of Landscaper Pods](technical/scaling.md)
 - [Target Types](technical/target_types.md)
 - [Types](technical/types.md)
 

--- a/docs/technical/scaling.md
+++ b/docs/technical/scaling.md
@@ -92,8 +92,6 @@ Optimistic locking of the create/update operation ensures that only one replica 
 Unlocking is done at the end of a reconciliation. The processing replica (pod) removes its identifier (pod name) from 
 the SyncObject. It does not delete the SyncObject. 
 
-(No optimistic locking for delete operations.)
-
 ### Controlling the Lock Owner
 
 Other replicas of the same deployer, which do not get the lock, check whether the current owner of the lock still exists. 
@@ -105,8 +103,9 @@ A go function deletes SyncObjects whose corresponding object (the object with th
 
 It does not matter if in the meantime a new object with the same name is being created. The locking of the deleted old object
 and the new object is done by different SyncObjects, because of the different UIDs. 
-(If we would use the object name instead of the UID, the cleanup might delete a SyncObject which is recycled and locks
-a new object with the same name.)
+(If we would use the object name instead of the UID, the cleanup might delete a SyncObject which was just recycled and 
+locks a new object with the same name. The delete operation would not conflict with a parallel update, because there is 
+no optimistic locking for delete operations.)
 
 
 

--- a/docs/technical/scaling.md
+++ b/docs/technical/scaling.md
@@ -1,0 +1,145 @@
+# Scaling of Landscaper Pods
+
+## Horizontal Pod Autoscaling
+
+The horizontal scaling behavior of the Landscaper pods is defined in [HorizontalPodAutoscaler][1] (HPA) objects.
+Each HPA specifies a minimum and maximum number of pods. Within these limits, a new pod will be started if the
+average cpu or memory consumption exceeds 80% of the value specified in the corresponding Deployment.
+The pods are distributed evenly across nodes and zones.
+
+- [Landscaper HPA](../../charts/landscaper/charts/landscaper/templates/hpa-landscaper.yaml):  
+  Currently, we start exactly 1 landscaper pod, because the controllers are not yet prepared to run with multiple 
+  replicas in parallel.  
+- [Webhok HPA](../../charts/landscaper/charts/landscaper/templates/hpa-webhook.yaml):  
+  We run at least 2 webhook pods, because users would directly notice if the webhook were unavailable.
+- [Container deployer HPA](../../charts/container-deployer/templates/hpa.yaml)
+- [Helm deployer HPA](../../charts/helm-deployer/templates/hpa.yaml)
+- [Manifest deployer HPA](../../charts/manifest-deployer/templates/hpa.yaml)
+- [Mock deployer HPA](../../charts/mock-deployer/templates/hpa.yaml)
+
+
+
+## Statistics
+
+### Memory and CPU
+
+The Landscaper logs periodically cpu and memory data from the status of the HPA objects:
+
+```json
+{
+  "level":"info",
+  "ts":"2023-07-13T11:33:30.205Z",
+  "logger":"controllers.landscaper-monitoring",
+  "msg":"HPA Statistics",
+  "resource":"ls-system/helm-default-helm-deployer",
+  "currentReplicas":3,
+  "desiredReplicas":3,
+  "memoryAverageUtilization":20,       // percentage of the value specified in the Deployment
+  "memoryAverageValue":"64625322666m",
+  "cpuAverageUtilization":108,         // percentage of the value specified in the Deployment
+  "cpuAverageValue":"325m"
+}
+```
+
+### Worker Count
+
+Each controller has a certain number of worker threads per pod. These numbers can be configured in the values of the 
+corresponding helm chart. Each controller pod counts how many of these worker threads are currently in use.
+The counter is logged at the beginning of a reconciliation if it exceeds 70% of the maximum.
+To find these logs, search for info messages "worker threads of controller".
+
+```json
+{
+  "level":"info",
+  "msg":"worker threads of controller installations",
+  "reconciledResourceKind":"Installation",
+  "usedWorkerThreads":10
+}
+```
+
+## Locking
+
+There are **controllers** reconciling **objects**, for example the helm deployer reconciles DeployItems. 
+Several **replicas** (pods) of a controller can be started, for example as a consequence of horizontal pod autoscaling. 
+We want to ensure that no object is processed by two replicas of a controller in parallel.
+Therefore, the replicas of a controller must synchronize which of them processes an object. This is done via
+**SyncObject** custom resources. A SyncObject serves as a lock for a controller-object pair.
+
+### One SyncObjects per Controller-Object Pair
+
+There exists (at most) one SyncObject for a controller-object pair.
+
+The name of a SyncObject is composed of two parts:
+- an identifier of the controller (`container`, `helm`, `manifest`, `mock`, `landscaper-helm`, ...)
+- and an identifier of the object, namely its UID. (Not its name!)
+
+As identifier of an object we use its UID, not its name. If you delete an object and then create one with the same name, 
+we consider it as a new object, and it gets new SyncObjects.
+
+Note that two **different** controllers are allowed to process the same object in parallel, for example a 
+deployer and the timeout controller. So, an object can have more than one SyncObject, namely for different controllers. 
+What the synchronisation prevents is that different replicas of the **same** controller process the same object in 
+parallel.
+
+### Locking and Unlocking
+
+If a replica of a controller is about to process an object, it tries to obtain the lock for this controller-object pair.
+This is done by creating/updating the corresponding SyncObject with the identifier of the replica.
+As identifier of a replica we use the pod name.
+
+Optimistic locking of the create/update operation ensures that only one replica can obtain the lock.
+
+Unlocking is done at the end of a reconciliation. The processing replica (pod) removes its identifier (pod name) from 
+the SyncObject. It does not delete the SyncObject. 
+
+(No optimistic locking for delete operations.)
+
+### Controlling the Lock Owner
+
+Other replicas of the same deployer, which do not get the lock, check whether the current owner of the lock still exists. 
+So if a pod dies without unlocking, the other pods will recognise this, and can take over the lock.
+
+### Cleanup
+
+A go function deletes SyncObjects whose corresponding object (the object with the matching UID) does not exist. 
+
+It does not matter if in the meantime a new object with the same name is being created. The locking of the deleted old object
+and the new object is done by different SyncObjects, because of the different UIDs. 
+(If we would use the object name instead of the UID, the cleanup might delete a SyncObject which is recycled and locks
+a new object with the same name.)
+
+
+
+## Responsibility Check Based on Metadata
+
+Every deployer watches all DeployItems. For example, the container deployer receives reconcile events for Helm 
+DeployItems. Therefore, deployers check at first their responsibility for a DeployItem. 
+Moreover, DeployItem can be large, for example due to large Helm values. Therefore, the deployers check their
+responsibility by only reading the small **metadata** of a DeployItem.
+
+The information required for the responsibility check are the deployer type (container, helm, manifest, mock) and the
+name of the Target. These data actually belong to the spec of a DeployItem. We redundantly store them in the metadata as 
+annotations:
+
+- annotation `landscaper.gardener.cloud/deployer-type` contains the deployer type (same value as field `spec.type`)
+- annotation `landscaper.gardener.cloud/deployer-target-name` contains the Target name (same value as field `spec.target.name`)
+
+### Steps of the Responsibility Check
+ 
+- Read the metadata of the DeployItem to get the deployer type and the target name from the annotations.
+- (If new annotations are missing (directly after upgrade), read the full DeployItem.)  
+- Responsibility check 1: check the deployer type, and return if not responsible.  
+- Read the Target.  
+- Responsibility check 2: check target selectors, and return if not responsible.  
+- Resolve Target.  
+- Lock.  
+- Reconcile (the main part).    
+- Unlock.  
+
+
+<!-- References -->
+
+[1]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/  
+
+
+

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -7,6 +7,13 @@ package integration_test
 import (
 	"context"
 	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
+	"github.com/gardener/landscaper/test/framework"
 	"github.com/gardener/landscaper/test/integration/core"
 	"github.com/gardener/landscaper/test/integration/dependencies"
 	"github.com/gardener/landscaper/test/integration/deployers"
@@ -20,13 +27,6 @@ import (
 	"github.com/gardener/landscaper/test/integration/targets"
 	"github.com/gardener/landscaper/test/integration/tutorial"
 	"github.com/gardener/landscaper/test/integration/webhook"
-	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
-	"github.com/gardener/landscaper/test/framework"
 )
 
 var opts *framework.Options


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This pull request 
- adds the SyncObject name to log messages;
- adds technical documentation about the scaling of landscaper pods.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
