### PR TITLE
update integration test image in pipeline to 1.20.6-alpine3.18

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -75,14 +75,14 @@ landscaper:
           - integration-test
           trait_depends:
           - publish
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
           output_dir: 'integration_test'
     pull-request:
       steps:
         integration_test:
           depends:
           - publish
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
           execute:
           - integration-test-new
           output_dir: 'integration_test'
@@ -109,7 +109,7 @@ landscaper:
           - integration-test
           trait_depends:
           - publish
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
           output_dir: 'integration_test'
         update_release:
           inputs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test
/priority 1

**What this PR does / why we need it**:

PR #779 upgrades the golang version to `1.20`. The integration tests for this PR are currently failing, probably due to the fact that the pipeline uses 1.18 golang images for running the tests. In order to be able to get the PR through, we have to update the image on master. Note that this might again break other PR's integration tests until the dependency upgrade PR is merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
