### PR TITLE
Permissions for deployers to list pods

### DIFF
--- a/charts/helm-deployer/templates/clusterrole.yaml
+++ b/charts/helm-deployer/templates/clusterrole.yaml
@@ -40,6 +40,8 @@ rules:
   - "pods"
   verbs:
   - get
+  - watch
+  - list
 
 - apiGroups:
   - landscaper.gardener.cloud

--- a/charts/manifest-deployer/templates/clusterrole.yaml
+++ b/charts/manifest-deployer/templates/clusterrole.yaml
@@ -61,4 +61,6 @@ rules:
     - "pods"
   verbs:
     - get
+    - watch
+    - list
 {{- end }}

--- a/charts/mock-deployer/templates/clusterrole.yaml
+++ b/charts/mock-deployer/templates/clusterrole.yaml
@@ -50,4 +50,6 @@ rules:
     - "pods"
   verbs:
     - get
+    - watch
+    - list
 {{ end }}

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -315,6 +315,11 @@ func (dm *DeployerManagement) EnsureRBACRoles(ctx context.Context) error {
 				Verbs:     []string{"get", "watch", "list", "create", "update", "patch", "delete"},
 			},
 			{
+				APIGroups: []string{corev1.SchemeGroupVersion.Group},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get"},
+			},
+			{
 				APIGroups: []string{lsv1alpha1.SchemeGroupVersion.Group},
 				Resources: []string{"contexts"},
 				Verbs:     []string{"get", "watch", "list"},

--- a/pkg/deployermanagement/controller/deployer_management_reconcile.go
+++ b/pkg/deployermanagement/controller/deployer_management_reconcile.go
@@ -315,11 +315,6 @@ func (dm *DeployerManagement) EnsureRBACRoles(ctx context.Context) error {
 				Verbs:     []string{"get", "watch", "list", "create", "update", "patch", "delete"},
 			},
 			{
-				APIGroups: []string{corev1.SchemeGroupVersion.Group},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get"},
-			},
-			{
 				APIGroups: []string{lsv1alpha1.SchemeGroupVersion.Group},
 				Resources: []string{"contexts"},
 				Verbs:     []string{"get", "watch", "list"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

Adds the permission to list and watch pods to the helm, manifest, and mock deployer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
