### PR TITLE
improve webhook logs

### DIFF
--- a/pkg/utils/webhook/add.go
+++ b/pkg/utils/webhook/add.go
@@ -181,10 +181,6 @@ func RegisterWebhooks(ctx context.Context, webhookServer ctrlwebhook.Server, cli
 		webhookPath := o.WebhookBasePath + elem.ResourceName
 		rsLogger.Info("Registering webhook", "resource", elem.ResourceName, "path", webhookPath)
 		admission := &ctrlwebhook.Admission{Handler: val}
-		//_ = admission.InjectLogger(rsLogger.Logr())
-		//if err := admission.InjectScheme(scheme); err != nil {
-		//	return err
-		//}
 		webhookServer.Register(webhookPath, admission)
 	}
 

--- a/pkg/utils/webhook/webhook.go
+++ b/pkg/utils/webhook/webhook.go
@@ -70,7 +70,7 @@ type InstallationValidator struct{ abstractValidator }
 
 // Handle handles a request to the webhook
 func (iv *InstallationValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	logger := iv.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version)
+	logger := iv.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version, lc.KeyResource, fmt.Sprintf("%s/%s", req.Namespace, req.Name))
 	ctx = logging.NewContext(ctx, logger)
 
 	timeBefore := time.Now()
@@ -104,9 +104,12 @@ func (iv *InstallationValidator) handlePrivate(ctx context.Context, req admissio
 	}
 
 	if errs := validation.ValidateInstallation(inst); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		errMsg := errs.ToAggregate().Error()
+		logger.Info("Denied request", lc.KeyError, errMsg)
+		return admission.Denied(errMsg)
 	}
 
+	logger.Info("Allowed request")
 	return admission.Allowed("Installation is valid")
 }
 
@@ -117,7 +120,7 @@ type DeployItemValidator struct{ abstractValidator }
 
 // Handle handles a request to the webhook
 func (div *DeployItemValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	logger := div.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version)
+	logger := div.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version, lc.KeyResource, fmt.Sprintf("%s/%s", req.Namespace, req.Name))
 	ctx = logging.NewContext(ctx, logger)
 
 	timeBefore := time.Now()
@@ -139,7 +142,9 @@ func (div *DeployItemValidator) handlePrivate(ctx context.Context, req admission
 	}
 
 	if errs := validation.ValidateDeployItem(di); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		errMsg := errs.ToAggregate().Error()
+		logger.Info("Denied request", lc.KeyError, errMsg)
+		return admission.Denied(errMsg)
 	}
 
 	// check if the type was updated for update events
@@ -154,6 +159,7 @@ func (div *DeployItemValidator) handlePrivate(ctx context.Context, req admission
 		}
 	}
 
+	logger.Info("Allowed request")
 	return admission.Allowed("DeployItem is valid")
 }
 
@@ -164,7 +170,7 @@ type ExecutionValidator struct{ abstractValidator }
 
 // Handle handles a request to the webhook
 func (ev *ExecutionValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	logger := ev.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version)
+	logger := ev.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version, lc.KeyResource, fmt.Sprintf("%s/%s", req.Namespace, req.Name))
 	ctx = logging.NewContext(ctx, logger)
 
 	timeBefore := time.Now()
@@ -186,9 +192,12 @@ func (ev *ExecutionValidator) handlePrivate(ctx context.Context, req admission.R
 	}
 
 	if errs := validation.ValidateExecution(exec); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		errMsg := errs.ToAggregate().Error()
+		logger.Info("Denied request", lc.KeyError, errMsg)
+		return admission.Denied(errMsg)
 	}
 
+	logger.Info("Allowed request")
 	return admission.Allowed("Execution is valid")
 }
 
@@ -199,7 +208,7 @@ type TargetValidator struct{ abstractValidator }
 
 // Handle handles a request to the webhook
 func (tv *TargetValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	logger := tv.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version)
+	logger := tv.log.WithValues(lc.KeyResourceGroup, req.Kind.Group, lc.KeyResourceKind, req.Kind.Kind, lc.KeyResourceVersion, req.Kind.Version, lc.KeyResource, fmt.Sprintf("%s/%s", req.Namespace, req.Name))
 	ctx = logging.NewContext(ctx, logger)
 
 	timeBefore := time.Now()
@@ -221,8 +230,11 @@ func (tv *TargetValidator) handlePrivate(ctx context.Context, req admission.Requ
 	}
 
 	if errs := validation.ValidateTarget(t); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		errMsg := errs.ToAggregate().Error()
+		logger.Info("Denied request", lc.KeyError, errMsg)
+		return admission.Denied(errMsg)
 	}
 
+	logger.Info("Allowed request")
 	return admission.Allowed("Target is valid")
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind regression
/priority 3

**What this PR does / why we need it**:
Improves the webhook server's logs.

#779 introduced a regression which removed most of the webhook logs:

(all examples show the logs for a single change to an installation)

Logs before #779:
```
{"level":"debug","ts":"2023-07-17T07:26:01.684Z","logger":"webhook.validation.installations","msg":"received request","UID":"8bd4a8a4-c4ea-44c0-be2f-1fa1e14ed180","kind":"landscaper.gardener.cloud/v1alpha1, Kind=Installation","resource":{"group":"landscaper.gardener.cloud","version":"v1alpha1","resource":"installations"}}
{"level":"debug","ts":"2023-07-17T07:26:01.684Z","logger":"webhook.validation.installations","msg":"Received request","resourceGroup":"landscaper.gardener.cloud","resourceKind":"Installation","resourceVersion":"v1alpha1"}
{"level":"debug","ts":"2023-07-17T07:26:01.685Z","logger":"webhook.validation.installations","msg":"wrote response","code":200,"reason":"Installation is valid","UID":"8bd4a8a4-c4ea-44c0-be2f-1fa1e14ed180","allowed":true}
```

Logs after #779:
```
{"level":"debug","ts":"2023-07-17T07:23:17.967Z","logger":"webhook.validation.installations","msg":"Received request","resourceGroup":"landscaper.gardener.cloud","resourceKind":"Installation","resourceVersion":"v1alpha1"}
```

Only one of the previously three log messages is still displayed, and it's the one which doesn't contain any information about the identity of the resource which caused the message. The now missing messages didn't come from our coding, but from the controller-runtime directly.
Instead of trying to get the controller-runtime logs back, I decided to add new log outputs to our own coding where we have the control over what exactly is displayed. I also upgraded the verbosity of the webhook result message from `debug` to `info`, so the webhook will now by default show whenever it accepted or denied a request.

Logs with this PR:
```
{"level":"debug","ts":"2023-07-18T11:58:02.197Z","logger":"webhook.validation.installations","msg":"Received request","resourceGroup":"landscaper.gardener.cloud","resourceKind":"Installation","resourceVersion":"v1alpha1","resource":"test/root"}
{"level":"info","ts":"2023-07-18T11:58:02.202Z","logger":"webhook.validation.installations","msg":"Allowed request","resourceGroup":"landscaper.gardener.cloud","resourceKind":"Installation","resourceVersion":"v1alpha1","resource":"test/root"}
```
The log messages now always contain namespace/name of the resource causing the log.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improved the logs of the webhook server.
```
