### PR TITLE
Disable client cache

### DIFF
--- a/pkg/utils/read_write_layer/logger.go
+++ b/pkg/utils/read_write_layer/logger.go
@@ -20,7 +20,7 @@ const (
 // and falls back to creating a new one if that fails.
 // The keys and values are only added in case of the fallback.
 func (w *Writer) getLogger(ctx context.Context, keysAndValues ...interface{}) logging.Logger {
-	log, _ := logging.FromContextOrNew(ctx, keysAndValues)
+	log, _ := logging.FromContextOrNew(ctx, nil, keysAndValues)
 	return log
 }
 

--- a/pkg/utils/uncached_client.go
+++ b/pkg/utils/uncached_client.go
@@ -6,6 +6,8 @@ import (
 )
 
 func NewUncachedClient(config *rest.Config, options client.Options) (client.Client, error) {
+	options.Cache = nil
+
 	c, err := client.New(config, options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request disables caching for the clients used by the landscaper controllers.

With the upgrade of the controller runtime to `sigs.k8s.io/controller-runtime v0.15.0`, the options structure of a controller manager has changed, in particular the `NewClient` function. Since the upgrade, our clients worked again with a cache, which is the default behaviour. But working on outdated cached data, can have strange effects. For example, the execution controller sporadically creates DeployItems multiple times (they have generated names). Therefore, the this pull requests disables the cache again.

The pull request also improves logging in the read-write layer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
