### PR TITLE
Fix nilpointer during cleanup of orphaned subinstallations

### DIFF
--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -314,16 +314,16 @@ func (c *Controller) handlePhaseCleanupOrphaned(ctx context.Context, inst *lsv1a
 		return nil, nil
 	}
 
-	// all deletions failed
+	// Consider the remaining subinstallations to be deleted. If they are all finished with phase DeleteFailed,
+	// we are stuck and return an error.
 	allFailed := true
 	for _, next := range subInstsToDelete {
 		if next.Status.JobIDFinished != inst.Status.JobID || next.Status.InstallationPhase != lsv1alpha1.InstallationPhases.DeleteFailed {
 			allFailed = false
 		}
 	}
-
 	if allFailed {
-		return lserrors.NewWrappedError(err, currentOperation, "AllOrphanedSubinstallationsFailed", err.Error()), nil
+		return lserrors.NewError(currentOperation, "AllOrphanedSubinstallationsFailed", "all orphaned subinstallations failed"), nil
 	}
 
 	for _, next := range subInstsToDelete {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority 3

**What this PR does / why we need it**:

This pull request fixes a nilpointer in the installation controller. The error occurs in the error handling of the cleanup of orphaned subinstallations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- bugfix in the error handling during the cleanup of orphaned subinstallations
```
