### PR TITLE
add more documentation on how to configure the global deploy item timeout

### DIFF
--- a/docs/deployer/container.md
+++ b/docs/deployer/container.md
@@ -34,8 +34,7 @@ spec:
   target:
     # only used to determine which instance of the container deployer is responsible,
     # unless it is used explicitly in the custom code
-    name: my-cluster
-    namespace: test
+    import: my-cluster
 
   config:
     apiVersion: container.deployer.landscaper.gardener.cloud/v1alpha1

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -25,8 +25,13 @@ spec:
   type: landscaper.gardener.cloud/helm
   
   target: # has to be of type landscaper.gardener.cloud/kubernetes-cluster
-    name: my-cluster
-    namespace: test
+    import: my-cluster
+
+  # Defines the global timeout value. When the deployment (including readiness-checks and exports) takes
+  # longer than this specified time, the deployment will be considered failed. Default: 10 minutes
+  # This timeout value shall be greater than the longest deployer specific timeout specified for this deploy item.
+  # If, for example, the readiness-checks timeout is set to "15m" and the export timeout is set to "10m", set the global timeout to "20m".
+  timeout: 20m
 
   config:
     apiVersion: helm.deployer.landscaper.gardener.cloud/v1alpha1

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -23,8 +23,13 @@ spec:
   type: landscaper.gardener.cloud/kubernetes-manifest
 
   target: # has to be of type landscaper.gardener.cloud/kubernetes-cluster
-    name: my-cluster
-    namespace: test
+    import: my-cluster
+
+  # Defines the global timeout value. When the deployment (including readiness-checks and exports) takes
+  # longer than this specified time, the deployment will be considered failed. Default: 10 minutes
+  # This timeout value shall be greater than the longest deployer specific timeout specified for this deploy item.
+  # If, for example, the readiness-checks timeout is set to "15m" and the export timeout is set to "10m", set the global timeout to "20m".
+  timeout: 20m
 
   config:
     apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2

--- a/docs/guided-tour/error-handling/timeout-error/README.md
+++ b/docs/guided-tour/error-handling/timeout-error/README.md
@@ -182,3 +182,6 @@ For more details, see [DeployItem Timeouts](../../../usage/DeployItemTimeouts.md
 There are further timeouts for readiness checks, for collecting export values, and for helm operations. These timeouts
 are deployer specific, see [Manifest Deployer](../../../deployer/manifest.md) and 
 [Helm Deployer](../../../deployer/helm.md).
+
+Note: Set the DeployItem timeout to a value that is greater than the greatest deployer specific timeout.
+If, for example, the readiness-checks timeout is set to "15m" and the export timeout is set to "10m", set the global timeout to "20m".


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Update the documentation with more details on how to configure the global deploy item timeout correctly-

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
