### PR TITLE
add MergeMaps function to controller-utils library

### DIFF
--- a/controller-utils/pkg/utils/utils.go
+++ b/controller-utils/pkg/utils/utils.go
@@ -8,3 +8,18 @@ package utils
 func Ptr[T any](value T) *T {
 	return &value
 }
+
+// MergeMaps merges multiple maps into a single one.
+// In case of duplicate keys, the value from the last argument which had the key overwrites the previous ones.
+// The returned map is a new one, the given maps are not modified.
+func MergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
+	res := map[K]V{}
+
+	for _, m := range maps {
+		for k, v := range m {
+			res[k] = v
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Adds a `MergeMaps` function to the controller-utils library. The function allows to merge multiple maps (with identical key and value types).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
A `MergeMaps` function has been added to the controller-utils library.
```
