### PR TITLE
Reduce error logging

### DIFF
--- a/pkg/deployer/manifest/ensure.go
+++ b/pkg/deployer/manifest/ensure.go
@@ -216,7 +216,11 @@ func (m *Manifest) Delete(ctx context.Context) error {
 			currObj.SetAnnotations(objAnnotations)
 
 			if err := kubeClient.Update(ctx, &currObj); err != nil {
-				logger.Error(err, "unable to update resource with before delete annotations", lc.KeyResource, key.String())
+				if apierrors.IsConflict(err) {
+					logger.Info("unable to update resource with before delete annotations", lc.KeyResource, key.String(), lc.KeyError, err.Error())
+				} else {
+					logger.Error(err, "unable to update resource with before delete annotations", lc.KeyResource, key.String())
+				}
 			}
 		}
 

--- a/pkg/landscaper/controllers/context/controller.go
+++ b/pkg/landscaper/controllers/context/controller.go
@@ -77,8 +77,15 @@ func (c *defaulterController) Reconcile(ctx context.Context, req reconcile.Reque
 		}
 		return nil
 	}); err != nil {
-		return reconcile.Result{}, err
+		if apierrors.IsNotFound(err) {
+			logger.Info("default context not found", "err", err.Error())
+		} else {
+			logger.Error(err, "default context not created of patched")
+		}
+
+		return reconcile.Result{Requeue: true}, nil
 	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -219,10 +219,10 @@ func (c *controller) handleReconcilePhase(ctx context.Context, exec *lsv1alpha1.
 		}
 
 		if !deployItemClassification.HasRunningItems() && deployItemClassification.HasFailedItems() {
-			err = lserrors.NewError(op, "handlePhaseDeleting", "has failed items")
+			err = lserrors.NewError(op, "handlePhaseDeleting", "has failed items", lsv1alpha1.ErrorForInfoOnly)
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecutionPhases.DeleteFailed, err, read_write_layer.W000143)
 		} else if !deployItemClassification.HasRunningItems() && !deployItemClassification.HasRunnableItems() && deployItemClassification.HasPendingItems() {
-			err = lserrors.NewError(op, "handlePhaseDeleting", "has pending items")
+			err = lserrors.NewError(op, "handlePhaseDeleting", "has pending items", lsv1alpha1.ErrorForInfoOnly)
 			return c.setExecutionPhaseAndUpdate(ctx, exec, lsv1alpha1.ExecutionPhases.DeleteFailed, err, read_write_layer.W000144)
 		}
 

--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -68,7 +68,7 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			logger.Debug(err.Error())
 			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, err
+		return lsutil.LogHelper{}.LogStandardErrorAndGetReconcileResult(ctx, err)
 	}
 
 	if lock.LockerEnabled {
@@ -93,19 +93,19 @@ func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			logger.Info(err.Error())
 			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, err
+		return lsutil.LogHelper{}.LogStandardErrorAndGetReconcileResult(ctx, err)
 	}
 
 	if exec.DeletionTimestamp.IsZero() && !kutil.HasFinalizer(exec, lsv1alpha1.LandscaperFinalizer) {
 		controllerutil.AddFinalizer(exec, lsv1alpha1.LandscaperFinalizer)
 		if err := c.Writer().UpdateExecution(ctx, read_write_layer.W000086, exec); err != nil {
-			return reconcile.Result{}, err
+			return lsutil.LogHelper{}.LogStandardErrorAndGetReconcileResult(ctx, err)
 		}
 	}
 
 	if lsv1alpha1helper.HasOperation(exec.ObjectMeta, lsv1alpha1.InterruptOperation) {
 		if err := c.handleInterruptOperation(ctx, exec); err != nil {
-			return reconcile.Result{}, err
+			return lsutil.LogHelper{}.LogStandardErrorAndGetReconcileResult(ctx, err)
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -56,14 +56,14 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		inst.Status.ObservedGeneration = inst.GetGeneration()
 
 		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Failed, fatalError, read_write_layer.W000087)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Failed, fatalError, read_write_layer.W000087, false)
 		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000003)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000003, false)
 		} else if normalError != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000088)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000088, false)
 		}
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.CleanupOrphaned, nil, read_write_layer.W000114); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.CleanupOrphaned, nil, read_write_layer.W000114, false); err != nil {
 			return err
 		}
 	}
@@ -72,26 +72,26 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		fatalError, normalError := c.handlePhaseCleanupOrphaned(ctx, inst)
 
 		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Failed, fatalError, read_write_layer.W000019)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Failed, fatalError, read_write_layer.W000019, false)
 		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000023)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000023, false)
 		} else if normalError != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000024)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000024, false)
 		}
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.ObjectsCreated, nil, read_write_layer.W000025); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.ObjectsCreated, nil, read_write_layer.W000025, false); err != nil {
 			return err
 		}
 	}
 
 	if inst.Status.InstallationPhase == lsv1alpha1.InstallationPhases.ObjectsCreated {
 		if err := c.handlePhaseObjectsCreated(ctx, inst); err != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000116)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000116, false)
 		}
 
 		inst.Status.TransitionTimes = lsutil.SetWaitTransitionTime(inst.Status.TransitionTimes)
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Progressing, nil, read_write_layer.W000117); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Progressing, nil, read_write_layer.W000117, false); err != nil {
 			return err
 		}
 	}
@@ -100,7 +100,7 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		allSucceeded, err := c.handlePhaseProgressing(ctx, inst)
 		if err != nil {
 			// error or unfinished subobjects => phase remains progressing
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000118)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000118, false)
 		}
 
 		var nextPhase lsv1alpha1.InstallationPhase
@@ -110,7 +110,7 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 			nextPhase = lsv1alpha1.InstallationPhases.Failed
 		}
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, nextPhase, nil, read_write_layer.W000119); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, nextPhase, nil, read_write_layer.W000119, false); err != nil {
 			return err
 		}
 	}
@@ -119,14 +119,14 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		fatalError, normalError := c.handlePhaseCompleting(ctx, inst)
 
 		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Failed, fatalError, read_write_layer.W000120)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Failed, fatalError, read_write_layer.W000120, false)
 		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000005)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000005, false)
 		} else if normalError != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000121)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000121, false)
 		}
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Succeeded, nil, read_write_layer.W000122); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Succeeded, nil, read_write_layer.W000122, false); err != nil {
 			return err
 		}
 
@@ -140,14 +140,14 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		fatalError, normalError := c.handleDeletionPhaseInit(ctx, inst)
 
 		if fatalError != nil && !lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.DeleteFailed, fatalError, read_write_layer.W000123)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.DeleteFailed, fatalError, read_write_layer.W000123, true)
 		} else if fatalError != nil && lsutil.IsRecoverableError(fatalError) {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000006)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, fatalError, read_write_layer.W000006, true)
 		} else if normalError != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000124)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, normalError, read_write_layer.W000124, true)
 		}
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.TriggerDelete, nil, read_write_layer.W000125); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.TriggerDelete, nil, read_write_layer.W000125, true); err != nil {
 			return err
 		}
 	}
@@ -155,12 +155,12 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 	if inst.Status.InstallationPhase == lsv1alpha1.InstallationPhases.TriggerDelete {
 
 		if err := c.handleDeletionPhaseTriggerDeleting(ctx, inst); err != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000126)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000126, true)
 		}
 
 		inst.Status.TransitionTimes = lsutil.SetWaitTransitionTime(inst.Status.TransitionTimes)
 
-		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Deleting, nil, read_write_layer.W000127); err != nil {
+		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.Deleting, nil, read_write_layer.W000127, true); err != nil {
 			return err
 		}
 	}
@@ -171,16 +171,16 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 		allFinished, allDeleted, err := c.handleDeletionPhaseDeleting(ctx, inst)
 
 		if err != nil {
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000128)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000128, true)
 		} else if allDeleted {
 			return nil
 		} else if allFinished {
 			err = lserrors.NewError(op, "UndeletedSubobjects", "not all sub objects were deleted", lsv1alpha1.ErrorForInfoOnly)
-			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.DeleteFailed, err, read_write_layer.W000129)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.DeleteFailed, err, read_write_layer.W000129, true)
 		} else {
 			// retry
 			err = lserrors.NewError(op, "PendingSubobjects", "deletion of some sub objects pending", lsv1alpha1.ErrorForInfoOnly)
-			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000130)
+			return c.setInstallationPhaseAndUpdate(ctx, inst, inst.Status.InstallationPhase, err, read_write_layer.W000130, true)
 		}
 	}
 

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -7,6 +7,7 @@ package installations
 import (
 	"context"
 	"errors"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,6 +127,7 @@ func (c *Controller) handleDeletionPhaseTriggerDeleting(ctx context.Context, ins
 
 func (c *Controller) handleDeletionPhaseDeleting(ctx context.Context, inst *lsv1alpha1.Installation) (allFinished bool, allDeleted bool, lsErr lserrors.LsError) {
 	op := "handleDeletionPhaseDeleting"
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	exec, err := executions.GetExecutionForInstallation(ctx, c.Client(), inst)
 	if err != nil {
@@ -154,7 +156,13 @@ func (c *Controller) handleDeletionPhaseDeleting(ctx context.Context, inst *lsv1
 			if !nextSibling.DeletionTimestamp.IsZero() {
 				lsv1alpha1helper.Touch(&nextSibling.ObjectMeta)
 				if err = c.Writer().UpdateInstallation(ctx, read_write_layer.W000147, nextSibling); err != nil {
-					return false, false, lserrors.NewWrappedError(err, op, "TouchSibling", err.Error())
+					if apierrors.IsConflict(err) {
+						logger.Info(op + " - conflict touching sibling inst")
+					} else if apierrors.IsNotFound(err) {
+						logger.Info(op + " - not found touching sibling inst")
+					} else {
+						return false, false, lserrors.NewWrappedError(err, op, "TouchSibling", err.Error())
+					}
 				}
 			}
 		}

--- a/pkg/landscaper/controllers/installations/reconcile_delete.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete.go
@@ -7,6 +7,7 @@ package installations
 import (
 	"context"
 	"errors"
+
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/landscaper/controllers/installations/retry_helper.go
+++ b/pkg/landscaper/controllers/installations/retry_helper.go
@@ -166,7 +166,7 @@ func (r *retryHelper) updateRetryStatus(ctx context.Context, inst *lsv1alpha1.In
 	return nil
 }
 
-func (r *retryHelper) resetRetryStatus(ctx context.Context, inst *lsv1alpha1.Installation, writeID WriteID) error {
+func (r *retryHelper) resetRetryStatus(ctx context.Context, inst *lsv1alpha1.Installation, writeID read_write_layer.WriteID) error {
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	logger.Info("reset retry status")

--- a/pkg/landscaper/controllers/installations/retry_helper.go
+++ b/pkg/landscaper/controllers/installations/retry_helper.go
@@ -48,7 +48,7 @@ func (r *retryHelper) preProcessRetry(ctx context.Context, inst *lsv1alpha1.Inst
 	if lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) &&
 		!r.hasReconcileReasonRetry(inst.ObjectMeta) {
 		// reconcile was not triggered by the retry mechanism, therefore we reset the retry status
-		if err := r.resetRetryStatus(ctx, inst); err != nil {
+		if err := r.resetRetryStatus(ctx, inst, read_write_layer.W000051); err != nil {
 			return err
 		}
 	}
@@ -81,7 +81,7 @@ func (r *retryHelper) recomputeRetry(ctx context.Context, inst *lsv1alpha1.Insta
 			(inst.Status.InstallationPhase == lsv1alpha1.InstallationPhases.Succeeded && inst.Status.AutomaticReconcileStatus.OnFailed) ||
 			(inst.Status.InstallationPhase.IsFailed() && !inst.Status.AutomaticReconcileStatus.OnFailed) {
 
-			if err := r.resetRetryStatus(ctx, inst); err != nil {
+			if err := r.resetRetryStatus(ctx, inst, read_write_layer.W000027); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -166,12 +166,12 @@ func (r *retryHelper) updateRetryStatus(ctx context.Context, inst *lsv1alpha1.In
 	return nil
 }
 
-func (r *retryHelper) resetRetryStatus(ctx context.Context, inst *lsv1alpha1.Installation) error {
+func (r *retryHelper) resetRetryStatus(ctx context.Context, inst *lsv1alpha1.Installation, writeID WriteID) error {
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	logger.Info("reset retry status")
 	inst.Status.AutomaticReconcileStatus = nil
-	if err := r.writer.UpdateInstallationStatus(ctx, read_write_layer.W000027, inst); err != nil {
+	if err := r.writer.UpdateInstallationStatus(ctx, writeID, inst); err != nil {
 		logger.Error(err, "failed to reset retry status")
 		return err
 	}

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -74,7 +74,7 @@ func (o *ExecutionOperation) RenderDeployItemTemplates(ctx context.Context, inst
 	if err != nil {
 		inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 			TemplatingFailedReason, "Unable to template executions"))
-		return nil, fmt.Errorf("unable to template executions: %w", err)
+		return nil, fmt.Errorf("RenderDeployItemTemplates - unable to template executions: %w", err)
 	}
 
 	if len(executions) == 0 {

--- a/pkg/landscaper/installations/imports/constructor.go
+++ b/pkg/landscaper/installations/imports/constructor.go
@@ -306,7 +306,7 @@ func (c *Constructor) RenderImportExecutions() error {
 	if err != nil {
 		c.Operation.Inst.MergeConditions(lsv1alpha1helper.UpdatedCondition(cond, lsv1alpha1.ConditionFalse,
 			TemplatingFailedReason, "Unable to template executions"))
-		return fmt.Errorf("unable to template executions: %w", err)
+		return fmt.Errorf("RenderImportExecutions - unable to template executions: %w", err)
 	}
 
 	for k, v := range bindings {

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"os"
 	"strconv"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 )

--- a/pkg/utils/loghelper.go
+++ b/pkg/utils/loghelper.go
@@ -29,6 +29,17 @@ func (LogHelper) LogErrorAndGetReconcileResult(ctx context.Context, lsError lser
 	}
 }
 
+func (LogHelper) LogStandardErrorAndGetReconcileResult(ctx context.Context, err error) (reconcile.Result, error) {
+	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "LogErrorAndGetReconcileResult")
+
+	if err == nil {
+		return reconcile.Result{}, nil
+	}
+
+	logger.Error(err, err.Error())
+	return reconcile.Result{Requeue: true}, nil
+}
+
 func (LogHelper) LogErrorButNotFoundAsInfo(ctx context.Context, err error, message string) {
 	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "LogErrorButNotFoundAsInfo")
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind cleanup
/priority 3

**What this PR does / why we need it**:

Reduce error logging.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduce error logging
```
