### PR TITLE
enforce KeyResource values to be of type string

### DIFF
--- a/pkg/deployer/container/garbage_collector.go
+++ b/pkg/deployer/container/garbage_collector.go
@@ -154,7 +154,7 @@ func (gc *GarbageCollector) cleanupRBACResources(obj client.Object) reconcile.Re
 
 // cleanupSecret deletes secrets that do not have a parent deploy item anymore.
 func (gc *GarbageCollector) cleanupSecret(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := gc.log.WithValues(lc.KeyResourceKind, "Secret", lc.KeyResource, req.NamespacedName)
+	logger := gc.log.WithValues(lc.KeyResourceKind, "Secret", lc.KeyResource, req.NamespacedName.String())
 	obj := &corev1.Secret{}
 	if err := gc.hostClient.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -179,7 +179,7 @@ func (gc *GarbageCollector) cleanupSecret(ctx context.Context, req reconcile.Req
 
 // cleanupPod deletes pods that do not have a parent deploy item anymore.
 func (gc *GarbageCollector) cleanupPod(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := gc.log.WithValues(lc.KeyResourceKind, "Pod", lc.KeyResource, req.NamespacedName)
+	logger := gc.log.WithValues(lc.KeyResourceKind, "Pod", lc.KeyResource, req.NamespacedName.String())
 	obj := &corev1.Pod{}
 	if err := gc.hostClient.Get(ctx, req.NamespacedName, obj); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/utils/monitoring/monitor.go
+++ b/pkg/utils/monitoring/monitor.go
@@ -62,7 +62,7 @@ func (m *Monitor) monitorHpas(ctx context.Context) {
 		shouldLog := false
 
 		keyValueList := []interface{}{
-			lc.KeyResource, client.ObjectKey{Namespace: m.namespace, Name: hpa.Spec.ScaleTargetRef.Name},
+			lc.KeyResource, client.ObjectKey{Namespace: m.namespace, Name: hpa.Spec.ScaleTargetRef.Name}.String(),
 			keyCurrentReplicas, hpa.Status.CurrentReplicas,
 			keyDesiredReplicas, hpa.Status.DesiredReplicas,
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority 3

**What this PR does / why we need it**:

Logging parameter types must be consistent. There have been some logs where the `KeyResource` value was not of type string.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
enforce KeyResource values to be of type string
```
