### PR TITLE
Execution controller deletes deploy items during delete without uninstall 

### DIFF
--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -322,6 +322,8 @@ func (c *controller) delete(ctx context.Context, lsCtx *lsv1alpha1.Context, depl
 	rt *lsv1alpha1.ResolvedTarget) lserrors.LsError {
 	logger, ctx := logging.FromContextOrNew(ctx, nil)
 	if lsv1alpha1helper.HasDeleteWithoutUninstallAnnotation(deployItem.ObjectMeta) {
+		// this case is not required anymore because those items are removed by the execution controller
+		// but for security reasons not removed
 		logger.Info("Deleting deployitem %s without uninstall", deployItem.Name)
 	} else {
 		if err := c.deployer.Delete(ctx, lsCtx, deployItem, rt); err != nil {

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"os"
 	"strconv"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

If an installation with the delete-without-uninstall annotation is deleted, the deploy items are removed by the execution controller and not by the deployer anymore. This prevents problems e.g. if the targets are already removed and therefore no deployer is responsible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- Execution controller deletes deploy items during delete without uninstall 
```
