### PR TITLE
add HasAnnotation function to controller-utils library

### DIFF
--- a/controller-utils/pkg/kubernetes/kubernetes.go
+++ b/controller-utils/pkg/kubernetes/kubernetes.go
@@ -361,6 +361,29 @@ func HasLabelWithValue(obj metav1.Object, lab string, value string) bool {
 	return val == value
 }
 
+// HasAnnotation checks if the objects has a annotation
+func HasAnnotation(obj metav1.Object, ann string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[ann]
+	return ok
+}
+
+// HasAnnotationWithValue checks if the objects has a annotation with a value
+func HasAnnotationWithValue(obj metav1.Object, ann string, value string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	val, ok := annotations[ann]
+	if !ok {
+		return false
+	}
+	return val == value
+}
+
 // ConvertToRawExtension converts a object to a raw extension.
 // The type of the object is automatically set given the scheme.
 func ConvertToRawExtension(from runtime.Object, scheme *runtime.Scheme) (*runtime.RawExtension, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Adds a `HasAnnotation` and a `HasAnnotationWithValue` function to the controller-utils library.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
In addition to the already existing `HasLabel` and `HasLabelWithValue`, the controller-utils library now also contains the `HasAnnotation` and `HasAnnotationWithValue` functions.
```
