### PR TITLE
New image registry

### DIFF
--- a/.ci/component_descriptor_real
+++ b/.ci/component_descriptor_real
@@ -41,7 +41,7 @@ COMMIT_SHA="$(git --git-dir ${SOURCE_PATH}/.git rev-parse HEAD)"
 
 printf "> Building components with version ${VERSION} - ${COMMIT_SHA}\n"
 
-REPO_CTX="eu.gcr.io/sap-gcp-cp-k8s-stable-hub/landscaper"
+REPO_CTX="eu.gcr.io/sap-gcp-laas-core-live/landscaper"
 REPO_CTX_DEV="eu.gcr.io/gardener-project/development"
 CTF_PATH="$(mktemp -d)"
 CTF_PATH="${CTF_PATH}/ctf.tar"

--- a/hack/generate-cd.sh
+++ b/hack/generate-cd.sh
@@ -8,7 +8,7 @@ set -e
 
 SOURCE_PATH="$(dirname $0)/.."
 oci_images=$@
-REPO_CTX="eu.gcr.io/sap-gcp-cp-k8s-stable-hub/landscaper"
+REPO_CTX="eu.gcr.io/sap-gcp-laas-core-live/landscaper"
 CA_PATH="$(mktemp -d)"
 BASE_DEFINITION_PATH="${CA_PATH}/component-descriptor.yaml"
 

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/component-descriptor-12.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/component-descriptor-12.yaml
@@ -3,7 +3,7 @@ component:
   name: github.com/gardener/gardener-extension-provider-aws
   provider: internal
   repositoryContexts:
-  - baseUrl: eu.gcr.io/sap-gcp-cp-k8s-stable-hub/examples/landscaper/temp
+  - baseUrl: eu.gcr.io/sap-gcp-laas-core-live/examples/landscaper/temp
     type: ociRegistry
   resources:
   - access:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind cleanup
/priority 3

**What this PR does / why we need it**:

Stores component descriptors in new image registry sap-gcp-laas-core-live.
Old sap-gcp-cp-k8s-stable-hub will disappear.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer

```
