### PR TITLE
Higher default pickup timeout 

### DIFF
--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -83,9 +83,9 @@ landscaper:
 #        kind: DeployerRegistration
 #        ...
 
-#  deployItemTimeouts:
-#    # how long deployers may take to react on changes to deploy items
-#    pickup: 5m
+  deployItemTimeouts:
+    # how long deployers may take to react on changes to deploy items
+    pickup: 60m
 #    # default for how long deployers may take to process a deploy item before failing, can be overwritten via the deploy item's 'spec.timeout' field
 #    progressingDefault: 10m
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Higher default pickup timeout. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- higher default pickup timeout
```
