### PR TITLE
Create short-lived kubeconfig for integration test cluster

### DIFF
--- a/hack/testcluster/pkg/shootcluster_manager.go
+++ b/hack/testcluster/pkg/shootcluster_manager.go
@@ -18,18 +18,17 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
-
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/jsonpath"
 	"sigs.k8s.io/yaml"
+
+	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
 )
 
 //go:embed resources/shootcluster_template.yaml
@@ -50,6 +49,9 @@ const (
 
 	// name of the file that will be created in the auth directory, containing the kubeconfig of the shoot cluster
 	filenameForKubeconfig = "kubeconfig.yaml"
+
+	subresourceAdminKubeconfig  = "adminkubeconfig"
+	kubeconfigExpirationSeconds = 24 * 60 * 60
 )
 
 var (
@@ -144,14 +146,20 @@ func (o *ShootClusterManager) CreateShootCluster(ctx context.Context) error {
 		return err
 	}
 
-	o.log.Logfln("wait for cluster is ready")
+	o.log.Logfln("wait until test cluster is ready")
 	if err := o.waitUntilShootClusterIsReady(ctx, gardenClientForShoots, clusterName); err != nil {
 		return err
 	}
 
-	o.log.Logfln("write kubeconfig")
+	o.log.Logfln("create short-lived kubeconfig for test cluster")
+	shootKubeconfigBase64, err := o.createShootAdminKubeconfig(ctx, gardenClientForSecrets, clusterName, kubeconfigExpirationSeconds)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	o.log.Logfln("write kubeconfig for test cluster")
 	filePath := path.Join(o.authDirectoryPath, filenameForKubeconfig)
-	if err := o.writeKubeconfig(ctx, gardenClientForSecrets, clusterName, filePath); err != nil {
+	if err := o.writeKubeconfig(ctx, shootKubeconfigBase64, filePath); err != nil {
 		return err
 	}
 
@@ -455,43 +463,50 @@ func (o *ShootClusterManager) readClusterName() (string, error) {
 	return string(clusterName), nil
 }
 
-func (o *ShootClusterManager) writeKubeconfig(ctx context.Context, gardenClientForSecrets dynamic.ResourceInterface,
-	clusterName, filePath string) error {
-	secretName := clusterName + ".kubeconfig"
-	secret, err := gardenClientForSecrets.Get(ctx, secretName, metav1.GetOptions{})
+func (o *ShootClusterManager) writeKubeconfig(_ context.Context, shootKubeconfigBase64, filePath string) error {
+	kubeconfig, err := base64.StdEncoding.DecodeString(shootKubeconfigBase64)
 	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig: error reading secret %s: %w", secretName, err)
-	}
-
-	jp := jsonpath.New("kubeconfig")
-	if err := jp.Parse("{.data.kubeconfig}"); err != nil {
-		return fmt.Errorf("failed to get kubeconfig: template parsing failed: %w", err)
-	}
-
-	result, err := jp.FindResults(secret.Object)
-	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig: result not found: %w", err)
-	}
-
-	if len(result) != 1 || len(result[0]) != 1 {
-		return fmt.Errorf("failed to get kubeconfig: unexpected result length")
-	}
-
-	kubeconfig64, ok := result[0][0].Interface().(string)
-	if !ok {
-		return fmt.Errorf("failed to get kubeconfig: unexpected type")
-	}
-
-	kubeconfig, err := base64.StdEncoding.DecodeString(kubeconfig64)
-	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig: base64 decoding failed")
+		return fmt.Errorf("base64 decoding of lubeconfig for test cluster failed")
 	}
 
 	if err := os.WriteFile(filePath, []byte(kubeconfig), os.ModePerm); err != nil {
-		return fmt.Errorf("failed to write kubeconfig to file %s: %w", filePath, err)
+		return fmt.Errorf("failed to write kubeconfig for test cluster to file %s: %w", filePath, err)
 	}
 
 	return nil
+}
+
+// createShootAdminKubeconfig returns a short-lived admin kubeconfig for the specified shoot as base64 encoded string.
+func (o *ShootClusterManager) createShootAdminKubeconfig(ctx context.Context, dynamicGardenClient dynamic.ResourceInterface,
+	shootName string, kubeconfigExpirationSeconds int64) (string, error) {
+
+	adminKubeconfigRequest := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "authentication.gardener.cloud/v1alpha1",
+			"kind":       "AdminKubeconfigRequest",
+			"metadata": map[string]interface{}{
+				"namespace": o.namespace,
+				"name":      shootName,
+			},
+			"spec": map[string]interface{}{
+				"expirationSeconds": kubeconfigExpirationSeconds,
+			},
+		},
+	}
+
+	result, err := dynamicGardenClient.Create(ctx, &adminKubeconfigRequest, metav1.CreateOptions{}, subresourceAdminKubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("admin kubeconfig request for test cluster failed: %w", err)
+	}
+
+	shootKubeconfigBase64, found, err := unstructured.NestedString(result.Object, "status", "kubeconfig")
+	if err != nil {
+		return "", fmt.Errorf("could not get kubeconfig for test cluster from result: %w", err)
+	} else if !found {
+		return "", fmt.Errorf("could not find kubeconfig for test cluster in result")
+	}
+
+	return shootKubeconfigBase64, nil
 }
 
 func (o *ShootClusterManager) addConfirmAnnotation(shoot *unstructured.Unstructured) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task
/priority 3

**What this PR does / why we need it**:

This pull request changes the way how a kubeconfig for an integration test cluster ist created. Instead of a static kubeconfig we create a short-lived.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
