### PR TITLE
Metrics in Helm Chart Templates and Values

### DIFF
--- a/charts/container-deployer/templates/hpa.yaml
+++ b/charts/container-deployer/templates/hpa.yaml
@@ -16,4 +16,15 @@ spec:
   minReplicas: 1
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
-  {{- .Values.hpa.metrics | toYaml | nindent 4 }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageMemoryUtilization }}

--- a/charts/container-deployer/values.yaml
+++ b/charts/container-deployer/values.yaml
@@ -100,19 +100,8 @@ resources:
 
 hpa:
   maxReplicas: 1
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+  averageCpuUtilization: 80
+  averageMemoryUtilization: 80
 
 nodeSelector: {}
 

--- a/charts/helm-deployer/templates/hpa.yaml
+++ b/charts/helm-deployer/templates/hpa.yaml
@@ -16,4 +16,15 @@ spec:
   minReplicas: 1
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
-  {{- .Values.hpa.metrics | toYaml | nindent 4 }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageMemoryUtilization }}

--- a/charts/helm-deployer/values.yaml
+++ b/charts/helm-deployer/values.yaml
@@ -91,19 +91,8 @@ resources:
 
 hpa:
   maxReplicas: 1
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+  averageCpuUtilization: 80
+  averageMemoryUtilization: 80
 
 nodeSelector: {}
 

--- a/charts/landscaper/charts/landscaper/templates/hpa-main-controller.yaml
+++ b/charts/landscaper/charts/landscaper/templates/hpa-main-controller.yaml
@@ -16,4 +16,15 @@ spec:
   minReplicas: 1
   maxReplicas: {{ .Values.hpaMain.maxReplicas }}
   metrics:
-  {{- .Values.hpaMain.metrics | toYaml | nindent 4 }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpaMain.averageCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpaMain.averageMemoryUtilization }}

--- a/charts/landscaper/charts/landscaper/templates/hpa-webhook.yaml
+++ b/charts/landscaper/charts/landscaper/templates/hpa-webhook.yaml
@@ -16,4 +16,15 @@ spec:
   minReplicas: 2
   maxReplicas: {{ .Values.webhooksServer.hpa.maxReplicas }}
   metrics:
-  {{- .Values.webhooksServer.hpa.metrics | toYaml | nindent 4 }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.webhooksServer.hpa.averageCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.webhooksServer.hpa.averageMemoryUtilization }}

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -163,6 +163,9 @@ webhooksServer:
 
   hpa:
     maxReplicas: 10
+    averageCpuUtilization: 80
+    averageMemoryUtilization: 80
+
     metrics:
       - type: Resource
         resource:
@@ -229,19 +232,8 @@ resourcesMain:
 
 hpaMain:
   maxReplicas: 1
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+  averageCpuUtilization: 80
+  averageMemoryUtilization: 80
 
 nodeSelector: {}
 

--- a/charts/manifest-deployer/templates/hpa.yaml
+++ b/charts/manifest-deployer/templates/hpa.yaml
@@ -16,4 +16,15 @@ spec:
   minReplicas: 1
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
-  {{- .Values.hpa.metrics | toYaml | nindent 4 }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageMemoryUtilization }}

--- a/charts/manifest-deployer/values.yaml
+++ b/charts/manifest-deployer/values.yaml
@@ -86,19 +86,8 @@ resources:
 
 hpa:
   maxReplicas: 1
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+  averageCpuUtilization: 80
+  averageMemoryUtilization: 80
 
 nodeSelector: {}
 

--- a/charts/mock-deployer/templates/hpa.yaml
+++ b/charts/mock-deployer/templates/hpa.yaml
@@ -16,4 +16,15 @@ spec:
   minReplicas: 1
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
-  {{- .Values.hpa.metrics | toYaml | nindent 4 }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageCpuUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.averageMemoryUtilization }}

--- a/charts/mock-deployer/values.yaml
+++ b/charts/mock-deployer/values.yaml
@@ -79,19 +79,8 @@ resources: {}
 
 hpa:
   maxReplicas: 1
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
+  averageCpuUtilization: 80
+  averageMemoryUtilization: 80
 
 nodeSelector: {}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind task
/priority 3

**What this PR does / why we need it**:

This pull request improves the templating of HPA objects. Only the configurable values remain in the `values.yaml`, whereas the main part of the `metrics` section is moved into the HPA templates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
