### PR TITLE
Component Library Flag

### DIFF
--- a/apis/core/types_deployitem.go
+++ b/apis/core/types_deployitem.go
@@ -54,6 +54,8 @@ type DeployItemSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// Configuration contains the deployer type specific configuration.

--- a/apis/core/types_deployitem.go
+++ b/apis/core/types_deployitem.go
@@ -53,6 +53,9 @@ type DeployItemSpec struct {
 	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
+
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -58,6 +58,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -58,6 +58,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// DeployItems defines all execution items that need to be scheduled.

--- a/apis/core/types_installation.go
+++ b/apis/core/types_installation.go
@@ -48,7 +48,7 @@ type InstallationSpec struct {
 	Context string `json:"context,omitempty"`
 
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
-	
+
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/apis/core/types_installation.go
+++ b/apis/core/types_installation.go
@@ -47,6 +47,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	//ComponentDescriptor is a reference to the installation's component descriptor

--- a/apis/core/types_installation.go
+++ b/apis/core/types_installation.go
@@ -47,6 +47,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+	
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/apis/core/types_shared.go
+++ b/apis/core/types_shared.go
@@ -349,3 +349,10 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 		Version: r.Version,
 	}
 }
+
+type ComponentLibrary string
+
+const (
+	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
+	ComponentLibraryOCM    ComponentLibrary = "ocm"
+)

--- a/apis/core/v1alpha1/defaults.go
+++ b/apis/core/v1alpha1/defaults.go
@@ -91,7 +91,7 @@ func SetDefaults_Installation(obj *Installation) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 }
 
@@ -103,7 +103,7 @@ func SetDefaults_Execution(obj *Execution) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 }
 
@@ -115,7 +115,7 @@ func SetDefaults_DeployItem(obj *DeployItem) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 
 	// migration - can be removed, after .Status.DeployerPhase has been removed

--- a/apis/core/v1alpha1/defaults.go
+++ b/apis/core/v1alpha1/defaults.go
@@ -89,6 +89,10 @@ func SetDefaults_Installation(obj *Installation) {
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
 	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+	}
 }
 
 // SetDefaults_Execution sets default values for Execution objects
@@ -96,6 +100,10 @@ func SetDefaults_Execution(obj *Execution) {
 	// default the repository context to "default"
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
+	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
 	}
 }
 
@@ -105,6 +113,11 @@ func SetDefaults_DeployItem(obj *DeployItem) {
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
 	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+	}
+
 	// migration - can be removed, after .Status.DeployerPhase has been removed
 	obj.Status.DeployerPhase = nil
 }

--- a/apis/core/v1alpha1/types_deployitem.go
+++ b/apis/core/v1alpha1/types_deployitem.go
@@ -147,6 +147,9 @@ type DeployItemSpec struct {
 	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
+
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/apis/core/v1alpha1/types_deployitem.go
+++ b/apis/core/v1alpha1/types_deployitem.go
@@ -148,6 +148,8 @@ type DeployItemSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// Configuration contains the deployer type specific configuration.

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -159,6 +159,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// DeployItems defines all execution items that need to be scheduled.

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -159,6 +159,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/apis/core/v1alpha1/types_installation.go
+++ b/apis/core/v1alpha1/types_installation.go
@@ -176,6 +176,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/apis/core/v1alpha1/types_installation.go
+++ b/apis/core/v1alpha1/types_installation.go
@@ -176,6 +176,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	//ComponentDescriptor is a reference to the installation's component descriptor

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -369,6 +369,7 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 type ComponentLibrary string
 
 const (
-	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
-	ComponentLibraryOCM    ComponentLibrary = "ocm"
+	ComponentLibraryCNUDIE  ComponentLibrary = "cnudie"
+	ComponentLibraryOCM     ComponentLibrary = "ocm"
+	ComponentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
 )

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -365,3 +365,10 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 		Version: r.Version,
 	}
 }
+
+type ComponentLibrary string
+
+const (
+	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
+	ComponentLibraryOCM    ComponentLibrary = "ocm"
+)

--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -371,5 +371,5 @@ type ComponentLibrary string
 const (
 	ComponentLibraryCNUDIE  ComponentLibrary = "cnudie"
 	ComponentLibraryOCM     ComponentLibrary = "ocm"
-	ComponentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
+	componentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
 )

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1709,6 +1709,7 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Type = core.DeployItemType(in.Type)
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
@@ -1726,6 +1727,7 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Type = DeployItemType(in.Type)
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
@@ -2215,6 +2217,7 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
@@ -2223,6 +2226,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
@@ -2537,6 +2541,7 @@ func Convert_core_InstallationList_To_v1alpha1_InstallationList(in *core.Install
 
 func autoConvert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *InstallationSpec, out *core.InstallationSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.ComponentDescriptor = (*core.ComponentDescriptorDefinition)(unsafe.Pointer(in.ComponentDescriptor))
 	if err := Convert_v1alpha1_BlueprintDefinition_To_core_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
@@ -2561,6 +2566,7 @@ func Convert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *Installation
 
 func autoConvert_core_InstallationSpec_To_v1alpha1_InstallationSpec(in *core.InstallationSpec, out *InstallationSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.ComponentDescriptor = (*ComponentDescriptorDefinition)(unsafe.Pointer(in.ComponentDescriptor))
 	if err := Convert_core_BlueprintDefinition_To_v1alpha1_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4282,6 +4282,12 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"componentLibrary": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configuration contains the deployer type specific configuration.",
@@ -5165,6 +5171,12 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"componentLibrary": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"deployItems": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DeployItems defines all execution items that need to be scheduled.",
@@ -5805,6 +5817,12 @@ func schema_landscaper_apis_core_v1alpha1_InstallationSpec(ref common.ReferenceC
 							Description: "Context defines the current context of the installation.",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"componentLibrary": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"componentDescriptor": {

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4284,8 +4284,9 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 					},
 					"componentLibrary": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"config": {
@@ -5173,8 +5174,9 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 					},
 					"componentLibrary": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"deployItems": {
@@ -5821,8 +5823,9 @@ func schema_landscaper_apis_core_v1alpha1_InstallationSpec(ref common.ReferenceC
 					},
 					"componentLibrary": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"componentDescriptor": {

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -54,6 +54,8 @@ type DeployItemSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// Configuration contains the deployer type specific configuration.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -53,6 +53,9 @@ type DeployItemSpec struct {
 	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
+
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -58,6 +58,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -58,6 +58,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// DeployItems defines all execution items that need to be scheduled.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -47,6 +47,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	//ComponentDescriptor is a reference to the installation's component descriptor

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -47,6 +47,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -349,3 +349,10 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 		Version: r.Version,
 	}
 }
+
+type ComponentLibrary string
+
+const (
+	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
+	ComponentLibraryOCM    ComponentLibrary = "ocm"
+)

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -91,7 +91,7 @@ func SetDefaults_Installation(obj *Installation) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 }
 
@@ -103,7 +103,7 @@ func SetDefaults_Execution(obj *Execution) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 }
 
@@ -115,7 +115,7 @@ func SetDefaults_DeployItem(obj *DeployItem) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 
 	// migration - can be removed, after .Status.DeployerPhase has been removed

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -89,6 +89,10 @@ func SetDefaults_Installation(obj *Installation) {
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
 	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+	}
 }
 
 // SetDefaults_Execution sets default values for Execution objects
@@ -96,6 +100,10 @@ func SetDefaults_Execution(obj *Execution) {
 	// default the repository context to "default"
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
+	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
 	}
 }
 
@@ -105,6 +113,11 @@ func SetDefaults_DeployItem(obj *DeployItem) {
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
 	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+	}
+
 	// migration - can be removed, after .Status.DeployerPhase has been removed
 	obj.Status.DeployerPhase = nil
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -147,6 +147,9 @@ type DeployItemSpec struct {
 	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
+
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -148,6 +148,8 @@ type DeployItemSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// Configuration contains the deployer type specific configuration.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -159,6 +159,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// DeployItems defines all execution items that need to be scheduled.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -159,6 +159,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -176,6 +176,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -176,6 +176,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	//ComponentDescriptor is a reference to the installation's component descriptor

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -369,6 +369,7 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 type ComponentLibrary string
 
 const (
-	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
-	ComponentLibraryOCM    ComponentLibrary = "ocm"
+	ComponentLibraryCNUDIE  ComponentLibrary = "cnudie"
+	ComponentLibraryOCM     ComponentLibrary = "ocm"
+	ComponentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
 )

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -365,3 +365,10 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 		Version: r.Version,
 	}
 }
+
+type ComponentLibrary string
+
+const (
+	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
+	ComponentLibraryOCM    ComponentLibrary = "ocm"
+)

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -371,5 +371,5 @@ type ComponentLibrary string
 const (
 	ComponentLibraryCNUDIE  ComponentLibrary = "cnudie"
 	ComponentLibraryOCM     ComponentLibrary = "ocm"
-	ComponentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
+	componentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
 )

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1709,6 +1709,7 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Type = core.DeployItemType(in.Type)
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
@@ -1726,6 +1727,7 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Type = DeployItemType(in.Type)
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
@@ -2215,6 +2217,7 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
@@ -2223,6 +2226,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
@@ -2537,6 +2541,7 @@ func Convert_core_InstallationList_To_v1alpha1_InstallationList(in *core.Install
 
 func autoConvert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *InstallationSpec, out *core.InstallationSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.ComponentDescriptor = (*core.ComponentDescriptorDefinition)(unsafe.Pointer(in.ComponentDescriptor))
 	if err := Convert_v1alpha1_BlueprintDefinition_To_core_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
@@ -2561,6 +2566,7 @@ func Convert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *Installation
 
 func autoConvert_core_InstallationSpec_To_v1alpha1_InstallationSpec(in *core.InstallationSpec, out *InstallationSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.ComponentDescriptor = (*ComponentDescriptorDefinition)(unsafe.Pointer(in.ComponentDescriptor))
 	if err := Convert_core_BlueprintDefinition_To_v1alpha1_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -546,6 +546,8 @@ ComponentLibrary
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.</p>
 </td>
 </tr>
 <tr>
@@ -937,6 +939,8 @@ ComponentLibrary
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.</p>
 </td>
 </tr>
 <tr>
@@ -1079,6 +1083,8 @@ ComponentLibrary
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.</p>
 </td>
 </tr>
 <tr>
@@ -2840,6 +2846,8 @@ ComponentLibrary
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.</p>
 </td>
 </tr>
 <tr>
@@ -3780,6 +3788,8 @@ ComponentLibrary
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.</p>
 </td>
 </tr>
 <tr>
@@ -4566,6 +4576,8 @@ ComponentLibrary
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -538,6 +538,18 @@ string
 </tr>
 <tr>
 <td>
+<code>componentLibrary</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ComponentLibrary">
+ComponentLibrary
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>config</code></br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
@@ -917,6 +929,18 @@ string
 </tr>
 <tr>
 <td>
+<code>componentLibrary</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ComponentLibrary">
+ComponentLibrary
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>deployItems</code></br>
 <em>
 <a href="#landscaper.gardener.cloud/v1alpha1.DeployItemTemplateList">
@@ -1043,6 +1067,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>Context defines the current context of the installation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>componentLibrary</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ComponentLibrary">
+ComponentLibrary
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 <tr>
@@ -2258,6 +2294,16 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="landscaper.gardener.cloud/v1alpha1.ComponentLibrary">ComponentLibrary
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#landscaper.gardener.cloud/v1alpha1.DeployItemSpec">DeployItemSpec</a>, 
+<a href="#landscaper.gardener.cloud/v1alpha1.ExecutionSpec">ExecutionSpec</a>, 
+<a href="#landscaper.gardener.cloud/v1alpha1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>
+</p>
 <h3 id="landscaper.gardener.cloud/v1alpha1.ComponentVersionOverwrite">ComponentVersionOverwrite
 </h3>
 <p>
@@ -2782,6 +2828,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>Context defines the current context of the deployitem.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>componentLibrary</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ComponentLibrary">
+ComponentLibrary
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 <tr>
@@ -3714,6 +3772,18 @@ string
 </tr>
 <tr>
 <td>
+<code>componentLibrary</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ComponentLibrary">
+ComponentLibrary
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>deployItems</code></br>
 <em>
 <a href="#landscaper.gardener.cloud/v1alpha1.DeployItemTemplateList">
@@ -4484,6 +4554,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>Context defines the current context of the installation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>componentLibrary</code></br>
+<em>
+<a href="#landscaper.gardener.cloud/v1alpha1.ComponentLibrary">
+ComponentLibrary
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 <tr>

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
@@ -36,6 +36,8 @@ spec:
             description: DeployItemSpec contains the definition of a deploy item.
             properties:
               componentLibrary:
+                description: ComponentLibrary defines whether the cnudie or ocm component
+                  library should be used during reconciliation.
                 type: string
               config:
                 description: Configuration contains the deployer type specific configuration.

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
@@ -35,6 +35,8 @@ spec:
           spec:
             description: DeployItemSpec contains the definition of a deploy item.
             properties:
+              componentLibrary:
+                type: string
               config:
                 description: Configuration contains the deployer type specific configuration.
                 type: object

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -32,6 +32,8 @@ spec:
           spec:
             description: Spec defines a execution and its items
             properties:
+              componentLibrary:
+                type: string
               context:
                 description: Context defines the current context of the execution.
                 type: string

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -33,6 +33,8 @@ spec:
             description: Spec defines a execution and its items
             properties:
               componentLibrary:
+                description: ComponentLibrary defines whether the cnudie or ocm component
+                  library should be used during reconciliation.
                 type: string
               context:
                 description: Context defines the current context of the execution.

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
@@ -467,6 +467,8 @@ spec:
                     type: object
                 type: object
               componentLibrary:
+                description: ComponentLibrary defines whether the cnudie or ocm component
+                  library should be used during reconciliation.
                 type: string
               context:
                 description: Context defines the current context of the installation.

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
@@ -466,6 +466,8 @@ spec:
                     - version
                     type: object
                 type: object
+              componentLibrary:
+                type: string
               context:
                 description: Context defines the current context of the installation.
                 type: string

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -53,6 +53,7 @@ func (o *Operation) updateDeployItem(ctx context.Context, item executionItem) ls
 		ApplyDeployItemTemplate(item.DeployItem, item.Info)
 		kutil.SetMetaDataLabel(&item.DeployItem.ObjectMeta, lsv1alpha1.ExecutionManagedByLabel, o.exec.Name)
 		item.DeployItem.Spec.Context = o.exec.Spec.Context
+		item.DeployItem.Spec.ComponentLibrary = o.exec.Spec.ComponentLibrary
 		if len(clusterName) > 0 {
 			metav1.SetMetaDataAnnotation(&item.DeployItem.ObjectMeta, clusterNameAnnotation, clusterName)
 		}

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -169,6 +169,7 @@ func (o *ExecutionOperation) Ensure(ctx context.Context, inst *installations.Ins
 
 	if _, err := o.Writer().CreateOrUpdateExecution(ctx, read_write_layer.W000022, exec, func() error {
 		exec.Spec.Context = inst.GetInstallation().Spec.Context
+		exec.Spec.ComponentLibrary = inst.GetInstallation().Spec.ComponentLibrary
 		exec.Spec.DeployItems = versionedDeployItemTemplateList
 
 		if lsv1alpha1helper.HasOperation(inst.GetInstallation().ObjectMeta, lsv1alpha1.ForceReconcileOperation) {

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -287,6 +287,7 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 		}
 		subInst.Spec = lsv1alpha1.InstallationSpec{
 			Context:             inst.Spec.Context,
+			ComponentLibrary:    inst.Spec.ComponentLibrary,
 			RegistryPullSecrets: inst.Spec.RegistryPullSecrets,
 			ComponentDescriptor: subCdDef,
 			Blueprint:           *subBlueprint,

--- a/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -54,6 +54,8 @@ type DeployItemSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// Configuration contains the deployer type specific configuration.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -53,6 +53,9 @@ type DeployItemSpec struct {
 	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
+
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -58,6 +58,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -58,6 +58,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// DeployItems defines all execution items that need to be scheduled.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -47,6 +47,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	//ComponentDescriptor is a reference to the installation's component descriptor

--- a/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -47,6 +47,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_shared.go
@@ -349,3 +349,10 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 		Version: r.Version,
 	}
 }
+
+type ComponentLibrary string
+
+const (
+	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
+	ComponentLibraryOCM    ComponentLibrary = "ocm"
+)

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -91,7 +91,7 @@ func SetDefaults_Installation(obj *Installation) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 }
 
@@ -103,7 +103,7 @@ func SetDefaults_Execution(obj *Execution) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 }
 
@@ -115,7 +115,7 @@ func SetDefaults_DeployItem(obj *DeployItem) {
 	}
 
 	if len(obj.Spec.ComponentLibrary) == 0 {
-		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+		obj.Spec.ComponentLibrary = componentLibraryDefault
 	}
 
 	// migration - can be removed, after .Status.DeployerPhase has been removed

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/defaults.go
@@ -89,6 +89,10 @@ func SetDefaults_Installation(obj *Installation) {
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
 	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+	}
 }
 
 // SetDefaults_Execution sets default values for Execution objects
@@ -96,6 +100,10 @@ func SetDefaults_Execution(obj *Execution) {
 	// default the repository context to "default"
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
+	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
 	}
 }
 
@@ -105,6 +113,11 @@ func SetDefaults_DeployItem(obj *DeployItem) {
 	if len(obj.Spec.Context) == 0 {
 		obj.Spec.Context = DefaultContextName
 	}
+
+	if len(obj.Spec.ComponentLibrary) == 0 {
+		obj.Spec.ComponentLibrary = ComponentLibraryDefault
+	}
+
 	// migration - can be removed, after .Status.DeployerPhase has been removed
 	obj.Status.DeployerPhase = nil
 }

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -147,6 +147,9 @@ type DeployItemSpec struct {
 	// Context defines the current context of the deployitem.
 	// +optional
 	Context string `json:"context,omitempty"`
+
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -148,6 +148,8 @@ type DeployItemSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// Configuration contains the deployer type specific configuration.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -159,6 +159,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	// DeployItems defines all execution items that need to be scheduled.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -159,6 +159,8 @@ type ExecutionSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	// DeployItems defines all execution items that need to be scheduled.
 	DeployItems DeployItemTemplateList `json:"deployItems,omitempty"`
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -176,6 +176,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
+
 	//ComponentDescriptor is a reference to the installation's component descriptor
 	// +optional
 	ComponentDescriptor *ComponentDescriptorDefinition `json:"componentDescriptor,omitempty"`

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -176,6 +176,8 @@ type InstallationSpec struct {
 	// +optional
 	Context string `json:"context,omitempty"`
 
+	// ComponentLibrary defines whether the cnudie or ocm component library should be used during reconciliation.
+	// +optional
 	ComponentLibrary ComponentLibrary `json:"componentLibrary,omitempty"`
 
 	//ComponentDescriptor is a reference to the installation's component descriptor

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -369,6 +369,7 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 type ComponentLibrary string
 
 const (
-	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
-	ComponentLibraryOCM    ComponentLibrary = "ocm"
+	ComponentLibraryCNUDIE  ComponentLibrary = "cnudie"
+	ComponentLibraryOCM     ComponentLibrary = "ocm"
+	ComponentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
 )

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -365,3 +365,10 @@ func (r VersionedResourceReference) ObjectMeta() cdv2.ObjectMeta {
 		Version: r.Version,
 	}
 }
+
+type ComponentLibrary string
+
+const (
+	ComponentLibraryCNUDIE ComponentLibrary = "cnudie"
+	ComponentLibraryOCM    ComponentLibrary = "ocm"
+)

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_shared.go
@@ -371,5 +371,5 @@ type ComponentLibrary string
 const (
 	ComponentLibraryCNUDIE  ComponentLibrary = "cnudie"
 	ComponentLibraryOCM     ComponentLibrary = "ocm"
-	ComponentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
+	componentLibraryDefault ComponentLibrary = ComponentLibraryCNUDIE
 )

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1709,6 +1709,7 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Type = core.DeployItemType(in.Type)
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
@@ -1726,6 +1727,7 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Type = DeployItemType(in.Type)
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
@@ -2215,6 +2217,7 @@ func Convert_core_ExecutionList_To_v1alpha1_ExecutionList(in *core.ExecutionList
 
 func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out *core.ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
@@ -2223,6 +2226,7 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 
 func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec, out *ExecutionSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
 	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
@@ -2537,6 +2541,7 @@ func Convert_core_InstallationList_To_v1alpha1_InstallationList(in *core.Install
 
 func autoConvert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *InstallationSpec, out *core.InstallationSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = core.ComponentLibrary(in.ComponentLibrary)
 	out.ComponentDescriptor = (*core.ComponentDescriptorDefinition)(unsafe.Pointer(in.ComponentDescriptor))
 	if err := Convert_v1alpha1_BlueprintDefinition_To_core_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
@@ -2561,6 +2566,7 @@ func Convert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *Installation
 
 func autoConvert_core_InstallationSpec_To_v1alpha1_InstallationSpec(in *core.InstallationSpec, out *InstallationSpec, s conversion.Scope) error {
 	out.Context = in.Context
+	out.ComponentLibrary = ComponentLibrary(in.ComponentLibrary)
 	out.ComponentDescriptor = (*ComponentDescriptorDefinition)(unsafe.Pointer(in.ComponentDescriptor))
 	if err := Convert_core_BlueprintDefinition_To_v1alpha1_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area oci
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This pull request extends the Installation, Execution, and DeployItem spec with a field `ComponentLibrary`. At a root Installation, a user can set this field to specify whether the `cnudie` or `ocm` component library should be used during the reconciliation. The default is currently `cnudie`. Each object passes the field to its subobjects. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
