### PR TITLE
OCM Flag

### DIFF
--- a/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
+++ b/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
@@ -573,6 +573,10 @@
   },
   "description": "LandscaperConfiguration contains all configuration for the landscaper controllers",
   "properties": {
+    "UseOCMLib": {
+      "default": false,
+      "type": "boolean"
+    },
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"

--- a/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
+++ b/apis/.schemes/config-v1alpha1-LandscaperConfiguration.json
@@ -573,10 +573,6 @@
   },
   "description": "LandscaperConfiguration contains all configuration for the landscaper controllers",
   "properties": {
-    "UseOCMLib": {
-      "default": false,
-      "type": "boolean"
-    },
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
@@ -629,6 +625,9 @@
     "repositoryContext": {
       "$ref": "#/definitions/apis-v2-UnstructuredTypedObject",
       "description": "RepositoryContext defines the default repository context that should be used to resolve component descriptors. DEPRECATED: use controllers.context.config.default.repositoryContext instead."
+    },
+    "useOCMLib": {
+      "type": "boolean"
     }
   },
   "required": [

--- a/apis/.schemes/container-v1alpha1-Configuration.json
+++ b/apis/.schemes/container-v1alpha1-Configuration.json
@@ -303,6 +303,9 @@
       },
       "type": "array"
     },
+    "useOCMLib": {
+      "type": "boolean"
+    },
     "waitContainer": {
       "$ref": "#/definitions/container-v1alpha1-ContainerSpec",
       "default": {},

--- a/apis/.schemes/helm-v1alpha1-Configuration.json
+++ b/apis/.schemes/helm-v1alpha1-Configuration.json
@@ -224,6 +224,9 @@
         "default": {}
       },
       "type": "array"
+    },
+    "useOCMLib": {
+      "type": "boolean"
     }
   },
   "title": "helm-v1alpha1-Configuration",

--- a/apis/.schemes/manifest-v1alpha1-Configuration.json
+++ b/apis/.schemes/manifest-v1alpha1-Configuration.json
@@ -173,6 +173,9 @@
         "default": {}
       },
       "type": "array"
+    },
+    "useOCMLib": {
+      "type": "boolean"
     }
   },
   "title": "manifest-v1alpha1-Configuration",

--- a/apis/config/types_landscaper_config.go
+++ b/apis/config/types_landscaper_config.go
@@ -46,7 +46,7 @@ type LandscaperConfiguration struct {
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
 	// +optional
-	UseOCMLib bool
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/apis/config/types_landscaper_config.go
+++ b/apis/config/types_landscaper_config.go
@@ -45,6 +45,8 @@ type LandscaperConfiguration struct {
 	// for the main controllers (Installation and Execution controller).
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
+	// +optional
+	UseOCMLib bool
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/apis/config/v1alpha1/types_landscaper_config.go
+++ b/apis/config/v1alpha1/types_landscaper_config.go
@@ -46,7 +46,7 @@ type LandscaperConfiguration struct {
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
 	// +optional
-	UseOCMLib bool
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/apis/config/v1alpha1/types_landscaper_config.go
+++ b/apis/config/v1alpha1/types_landscaper_config.go
@@ -45,6 +45,8 @@ type LandscaperConfiguration struct {
 	// for the main controllers (Installation and Execution controller).
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
+	// +optional
+	UseOCMLib bool
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/apis/config/v1alpha1/zz_generated.conversion.go
@@ -742,6 +742,7 @@ func autoConvert_v1alpha1_LandscaperConfiguration_To_config_LandscaperConfigurat
 	out.DeployItemTimeouts = (*config.DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
 	out.LsDeployments = (*config.LsDeployments)(unsafe.Pointer(in.LsDeployments))
 	out.HPAMainConfiguration = (*config.HPAMainConfiguration)(unsafe.Pointer(in.HPAMainConfiguration))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -771,6 +772,7 @@ func autoConvert_config_LandscaperConfiguration_To_v1alpha1_LandscaperConfigurat
 	out.DeployItemTimeouts = (*DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
 	out.LsDeployments = (*LsDeployments)(unsafe.Pointer(in.LsDeployments))
 	out.HPAMainConfiguration = (*HPAMainConfiguration)(unsafe.Pointer(in.HPAMainConfiguration))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/apis/core/types_context.go
+++ b/apis/core/types_context.go
@@ -32,6 +32,9 @@ type Context struct {
 	// RepositoryContext defines the context of the component repository to resolve blueprints.
 	// +optional
 	RepositoryContext *cdv2.UnstructuredTypedObject `json:"repositoryContext,omitempty"`
+	// UseOCM defines whether OCM is used to process installations that reference this context.
+	// +optional
+	UseOCM bool `json:"useOCM,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/apis/core/v1alpha1/types_context.go
+++ b/apis/core/v1alpha1/types_context.go
@@ -59,6 +59,9 @@ type Context struct {
 	// RepositoryContext defines the context of the component repository to resolve blueprints.
 	// +optional
 	RepositoryContext *cdv2.UnstructuredTypedObject `json:"repositoryContext,omitempty"`
+	// UseOCM defines whether OCM is used to process installations that reference this context.
+	// +optional
+	UseOCM bool `json:"useOCM,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1462,6 +1462,7 @@ func Convert_core_ConfigMapReference_To_v1alpha1_ConfigMapReference(in *core.Con
 func autoConvert_v1alpha1_Context_To_core_Context(in *Context, out *core.Context, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.RepositoryContext = (*v2.UnstructuredTypedObject)(unsafe.Pointer(in.RepositoryContext))
+	out.UseOCM = in.UseOCM
 	out.RegistryPullSecrets = *(*[]v1.LocalObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Configurations = *(*map[string]core.AnyJSON)(unsafe.Pointer(&in.Configurations))
 	out.ComponentVersionOverwritesReference = in.ComponentVersionOverwritesReference
@@ -1476,6 +1477,7 @@ func Convert_v1alpha1_Context_To_core_Context(in *Context, out *core.Context, s 
 func autoConvert_core_Context_To_v1alpha1_Context(in *core.Context, out *Context, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.RepositoryContext = (*v2.UnstructuredTypedObject)(unsafe.Pointer(in.RepositoryContext))
+	out.UseOCM = in.UseOCM
 	out.RegistryPullSecrets = *(*[]v1.LocalObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Configurations = *(*map[string]AnyJSON)(unsafe.Pointer(&in.Configurations))
 	out.ComponentVersionOverwritesReference = in.ComponentVersionOverwritesReference

--- a/apis/deployer/container/types_config.go
+++ b/apis/deployer/container/types_config.go
@@ -58,6 +58,9 @@ type Configuration struct {
 
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ContainerSpec defines a container specification

--- a/apis/deployer/container/v1alpha1/types_config.go
+++ b/apis/deployer/container/v1alpha1/types_config.go
@@ -60,6 +60,9 @@ type Configuration struct {
 
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ContainerSpec defines a container specification

--- a/apis/deployer/container/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/container/v1alpha1/zz_generated.conversion.go
@@ -157,6 +157,7 @@ func autoConvert_v1alpha1_Configuration_To_container_Configuration(in *Configura
 	if err := Convert_v1alpha1_Controller_To_container_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -187,6 +188,7 @@ func autoConvert_container_Configuration_To_v1alpha1_Configuration(in *container
 	if err := Convert_container_Controller_To_v1alpha1_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/apis/deployer/helm/types_config.go
+++ b/apis/deployer/helm/types_config.go
@@ -31,6 +31,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/apis/deployer/helm/v1alpha1/types_config.go
+++ b/apis/deployer/helm/v1alpha1/types_config.go
@@ -39,6 +39,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -280,6 +280,7 @@ func autoConvert_v1alpha1_Configuration_To_helm_Configuration(in *Configuration,
 	if err := Convert_v1alpha1_Controller_To_helm_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -299,6 +300,7 @@ func autoConvert_helm_Configuration_To_v1alpha1_Configuration(in *helm.Configura
 	if err := Convert_helm_Controller_To_v1alpha1_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/apis/deployer/manifest/types_config.go
+++ b/apis/deployer/manifest/types_config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/apis/deployer/manifest/v1alpha1/types_config.go
+++ b/apis/deployer/manifest/v1alpha1/types_config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/apis/deployer/manifest/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/manifest/v1alpha1/zz_generated.conversion.go
@@ -100,6 +100,7 @@ func autoConvert_v1alpha1_Configuration_To_manifest_Configuration(in *Configurat
 	if err := Convert_v1alpha1_Controller_To_manifest_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -118,6 +119,7 @@ func autoConvert_manifest_Configuration_To_v1alpha1_Configuration(in *manifest.C
 	if err := Convert_manifest_Controller_To_v1alpha1_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/apis/deployer/manifest/v1alpha2/types_config.go
+++ b/apis/deployer/manifest/v1alpha2/types_config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/apis/deployer/manifest/v1alpha2/zz_generated.conversion.go
+++ b/apis/deployer/manifest/v1alpha2/zz_generated.conversion.go
@@ -103,6 +103,7 @@ func autoConvert_v1alpha2_Configuration_To_manifest_Configuration(in *Configurat
 	if err := Convert_v1alpha2_Controller_To_manifest_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -121,6 +122,7 @@ func autoConvert_manifest_Configuration_To_v1alpha2_Configuration(in *manifest.C
 	if err := Convert_manifest_Controller_To_v1alpha2_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -1927,6 +1927,13 @@ func schema_gardener_landscaper_apis_config_LandscaperConfiguration(ref common.R
 							Ref:         ref("github.com/gardener/landscaper/apis/config.HPAMainConfiguration"),
 						},
 					},
+					"UseOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
+						},
+					},
 				},
 				Required: []string{"TypeMeta", "Controllers", "Registry", "BlueprintStore"},
 			},
@@ -2870,6 +2877,13 @@ func schema_landscaper_apis_config_v1alpha1_LandscaperConfiguration(ref common.R
 						SchemaProps: spec.SchemaProps{
 							Description: "HPAMainConfiguration contains the HPA configuration (horizontal pod autoscaling) for the main controllers (Installation and Execution controller).",
 							Ref:         ref("github.com/gardener/landscaper/apis/config/v1alpha1.HPAMainConfiguration"),
+						},
+					},
+					"UseOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 				},

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -3853,6 +3853,13 @@ func schema_landscaper_apis_core_v1alpha1_Context(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/gardener/component-spec/bindings-go/apis/v2.UnstructuredTypedObject"),
 						},
 					},
+					"useOCM": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UseOCM defines whether OCM is used to process installations that reference this context.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"registryPullSecrets": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -1927,11 +1927,10 @@ func schema_gardener_landscaper_apis_config_LandscaperConfiguration(ref common.R
 							Ref:         ref("github.com/gardener/landscaper/apis/config.HPAMainConfiguration"),
 						},
 					},
-					"UseOCMLib": {
+					"useOCMLib": {
 						SchemaProps: spec.SchemaProps{
-							Default: false,
-							Type:    []string{"boolean"},
-							Format:  "",
+							Type:   []string{"boolean"},
+							Format: "",
 						},
 					},
 				},
@@ -2879,11 +2878,10 @@ func schema_landscaper_apis_config_v1alpha1_LandscaperConfiguration(ref common.R
 							Ref:         ref("github.com/gardener/landscaper/apis/config/v1alpha1.HPAMainConfiguration"),
 						},
 					},
-					"UseOCMLib": {
+					"useOCMLib": {
 						SchemaProps: spec.SchemaProps{
-							Default: false,
-							Type:    []string{"boolean"},
-							Format:  "",
+							Type:   []string{"boolean"},
+							Format: "",
 						},
 					},
 				},
@@ -7960,6 +7958,12 @@ func schema_apis_deployer_container_v1alpha1_Configuration(ref common.ReferenceC
 							Ref:         ref("github.com/gardener/landscaper/apis/deployer/container/v1alpha1.Controller"),
 						},
 					},
+					"useOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"defaultImage", "initContainer", "waitContainer", "garbageCollection"},
 			},
@@ -8745,6 +8749,12 @@ func schema_apis_deployer_helm_v1alpha1_Configuration(ref common.ReferenceCallba
 							Ref:         ref("github.com/gardener/landscaper/apis/deployer/helm/v1alpha1.Controller"),
 						},
 					},
+					"useOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -9272,6 +9282,12 @@ func schema_apis_deployer_manifest_v1alpha1_Configuration(ref common.ReferenceCa
 							Ref:         ref("github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1.Controller"),
 						},
 					},
+					"useOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -9521,6 +9537,12 @@ func schema_apis_deployer_manifest_v1alpha2_Configuration(ref common.ReferenceCa
 							Description: "Controller contains configuration concerning the controller framework.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2.Controller"),
+						},
+					},
+					"useOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
 						},
 					},
 				},

--- a/charts/container-deployer/templates/_helpers.tpl
+++ b/charts/container-deployer/templates/_helpers.tpl
@@ -103,6 +103,9 @@ hpa:
 controller:
 {{ .Values.deployer.controller | toYaml | indent 2 }}
 {{- end }}
+{{- if .Values.useOCMLib }}
+useOCMLib: true
+{{- end }}
 {{- end }}
 
 {{- define "deployer-image" -}}

--- a/charts/container-deployer/values.yaml
+++ b/charts/container-deployer/values.yaml
@@ -108,3 +108,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+useOCMLib: false

--- a/charts/helm-deployer/templates/_helpers.tpl
+++ b/charts/helm-deployer/templates/_helpers.tpl
@@ -95,6 +95,9 @@ hpa:
 controller:
 {{ .Values.deployer.controller | toYaml | indent 2 }}
 {{- end }}
+{{- if .Values.useOCMLib }}
+useOCMLib: true
+{{- end }}
 {{- end }}
 
 {{- define "deployer-image" -}}

--- a/charts/helm-deployer/values.yaml
+++ b/charts/helm-deployer/values.yaml
@@ -99,3 +99,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+useOCMLib: false

--- a/charts/landscaper/charts/landscaper/templates/_helpers.tpl
+++ b/charts/landscaper/charts/landscaper/templates/_helpers.tpl
@@ -188,6 +188,10 @@ hpaMain:
 {{ .Values.hpaMain | toYaml | indent 2 }}
 {{- end }}
 
+{{- if .Values.landscaper.useOCMLib }}
+useOCMLib: true
+{{- end }}
+
 {{- end }}
 
 {{- define "landscaper-image" -}}

--- a/charts/landscaper/charts/landscaper/values.yaml
+++ b/charts/landscaper/charts/landscaper/values.yaml
@@ -83,6 +83,8 @@ landscaper:
 #        kind: DeployerRegistration
 #        ...
 
+  useOCMLib: false
+
   deployItemTimeouts:
     # how long deployers may take to react on changes to deploy items
     pickup: 60m

--- a/charts/manifest-deployer/templates/_helpers.tpl
+++ b/charts/manifest-deployer/templates/_helpers.tpl
@@ -84,6 +84,9 @@ hpa:
 controller:
 {{ .Values.deployer.controller | toYaml | indent 2 }}
 {{- end }}
+{{- if .Values.useOCMLib }}
+useOCMLib: true
+{{- end }}
 {{- end }}
 
 {{- define "deployer-image" -}}

--- a/charts/manifest-deployer/values.yaml
+++ b/charts/manifest-deployer/values.yaml
@@ -94,3 +94,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+useOCMLib: false

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
@@ -46,7 +46,7 @@ type LandscaperConfiguration struct {
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
 	// +optional
-	UseOCMLib bool
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
@@ -45,6 +45,8 @@ type LandscaperConfiguration struct {
 	// for the main controllers (Installation and Execution controller).
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
+	// +optional
+	UseOCMLib bool
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_context.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_context.go
@@ -32,6 +32,9 @@ type Context struct {
 	// RepositoryContext defines the context of the component repository to resolve blueprints.
 	// +optional
 	RepositoryContext *cdv2.UnstructuredTypedObject `json:"repositoryContext,omitempty"`
+	// UseOCM defines whether OCM is used to process installations that reference this context.
+	// +optional
+	UseOCM bool `json:"useOCM,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_context.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_context.go
@@ -59,6 +59,9 @@ type Context struct {
 	// RepositoryContext defines the context of the component repository to resolve blueprints.
 	// +optional
 	RepositoryContext *cdv2.UnstructuredTypedObject `json:"repositoryContext,omitempty"`
+	// UseOCM defines whether OCM is used to process installations that reference this context.
+	// +optional
+	UseOCM bool `json:"useOCM,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1462,6 +1462,7 @@ func Convert_core_ConfigMapReference_To_v1alpha1_ConfigMapReference(in *core.Con
 func autoConvert_v1alpha1_Context_To_core_Context(in *Context, out *core.Context, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.RepositoryContext = (*v2.UnstructuredTypedObject)(unsafe.Pointer(in.RepositoryContext))
+	out.UseOCM = in.UseOCM
 	out.RegistryPullSecrets = *(*[]v1.LocalObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Configurations = *(*map[string]core.AnyJSON)(unsafe.Pointer(&in.Configurations))
 	out.ComponentVersionOverwritesReference = in.ComponentVersionOverwritesReference
@@ -1476,6 +1477,7 @@ func Convert_v1alpha1_Context_To_core_Context(in *Context, out *core.Context, s 
 func autoConvert_core_Context_To_v1alpha1_Context(in *core.Context, out *Context, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.RepositoryContext = (*v2.UnstructuredTypedObject)(unsafe.Pointer(in.RepositoryContext))
+	out.UseOCM = in.UseOCM
 	out.RegistryPullSecrets = *(*[]v1.LocalObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Configurations = *(*map[string]AnyJSON)(unsafe.Pointer(&in.Configurations))
 	out.ComponentVersionOverwritesReference = in.ComponentVersionOverwritesReference

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -333,6 +333,18 @@ github.com/gardener/component-spec/bindings-go/apis/v2.UnstructuredTypedObject
 </tr>
 <tr>
 <td>
+<code>useOCM</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseOCM defines whether OCM is used to process installations that reference this context.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>registryPullSecrets</code></br>
 <em>
 <a href="https://v1-22.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_contexts.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_contexts.yaml
@@ -59,6 +59,10 @@ spec:
               to resolve blueprints.
             type: object
             x-kubernetes-preserve-unknown-fields: true
+          useOCM:
+            description: UseOCM defines whether OCM is used to process installations
+              that reference this context.
+            type: boolean
         type: object
     served: true
     storage: true

--- a/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
@@ -46,7 +46,7 @@ type LandscaperConfiguration struct {
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
 	// +optional
-	UseOCMLib bool
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/types_landscaper_config.go
@@ -45,6 +45,8 @@ type LandscaperConfiguration struct {
 	// for the main controllers (Installation and Execution controller).
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
+	// +optional
+	UseOCMLib bool
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_landscaper_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_landscaper_config.go
@@ -46,7 +46,7 @@ type LandscaperConfiguration struct {
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
 	// +optional
-	UseOCMLib bool
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_landscaper_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/types_landscaper_config.go
@@ -45,6 +45,8 @@ type LandscaperConfiguration struct {
 	// for the main controllers (Installation and Execution controller).
 	// +optional
 	HPAMainConfiguration *HPAMainConfiguration `json:"hpaMain,omitempty"`
+	// +optional
+	UseOCMLib bool
 }
 
 // LsDeployments contains the names of the landscaper deployments.

--- a/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/config/v1alpha1/zz_generated.conversion.go
@@ -742,6 +742,7 @@ func autoConvert_v1alpha1_LandscaperConfiguration_To_config_LandscaperConfigurat
 	out.DeployItemTimeouts = (*config.DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
 	out.LsDeployments = (*config.LsDeployments)(unsafe.Pointer(in.LsDeployments))
 	out.HPAMainConfiguration = (*config.HPAMainConfiguration)(unsafe.Pointer(in.HPAMainConfiguration))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -771,6 +772,7 @@ func autoConvert_config_LandscaperConfiguration_To_v1alpha1_LandscaperConfigurat
 	out.DeployItemTimeouts = (*DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
 	out.LsDeployments = (*LsDeployments)(unsafe.Pointer(in.LsDeployments))
 	out.HPAMainConfiguration = (*HPAMainConfiguration)(unsafe.Pointer(in.HPAMainConfiguration))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/types_context.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_context.go
@@ -32,6 +32,9 @@ type Context struct {
 	// RepositoryContext defines the context of the component repository to resolve blueprints.
 	// +optional
 	RepositoryContext *cdv2.UnstructuredTypedObject `json:"repositoryContext,omitempty"`
+	// UseOCM defines whether OCM is used to process installations that reference this context.
+	// +optional
+	UseOCM bool `json:"useOCM,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_context.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_context.go
@@ -59,6 +59,9 @@ type Context struct {
 	// RepositoryContext defines the context of the component repository to resolve blueprints.
 	// +optional
 	RepositoryContext *cdv2.UnstructuredTypedObject `json:"repositoryContext,omitempty"`
+	// UseOCM defines whether OCM is used to process installations that reference this context.
+	// +optional
+	UseOCM bool `json:"useOCM,omitempty"`
 	// RegistryPullSecrets defines a list of registry credentials that are used to
 	// pull blueprints, component descriptors and jsonschemas from the respective registry.
 	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1462,6 +1462,7 @@ func Convert_core_ConfigMapReference_To_v1alpha1_ConfigMapReference(in *core.Con
 func autoConvert_v1alpha1_Context_To_core_Context(in *Context, out *core.Context, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.RepositoryContext = (*v2.UnstructuredTypedObject)(unsafe.Pointer(in.RepositoryContext))
+	out.UseOCM = in.UseOCM
 	out.RegistryPullSecrets = *(*[]v1.LocalObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Configurations = *(*map[string]core.AnyJSON)(unsafe.Pointer(&in.Configurations))
 	out.ComponentVersionOverwritesReference = in.ComponentVersionOverwritesReference
@@ -1476,6 +1477,7 @@ func Convert_v1alpha1_Context_To_core_Context(in *Context, out *core.Context, s 
 func autoConvert_core_Context_To_v1alpha1_Context(in *core.Context, out *Context, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.RepositoryContext = (*v2.UnstructuredTypedObject)(unsafe.Pointer(in.RepositoryContext))
+	out.UseOCM = in.UseOCM
 	out.RegistryPullSecrets = *(*[]v1.LocalObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Configurations = *(*map[string]AnyJSON)(unsafe.Pointer(&in.Configurations))
 	out.ComponentVersionOverwritesReference = in.ComponentVersionOverwritesReference

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/types_config.go
@@ -58,6 +58,9 @@ type Configuration struct {
 
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ContainerSpec defines a container specification

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/types_config.go
@@ -60,6 +60,9 @@ type Configuration struct {
 
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ContainerSpec defines a container specification

--- a/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/container/v1alpha1/zz_generated.conversion.go
@@ -157,6 +157,7 @@ func autoConvert_v1alpha1_Configuration_To_container_Configuration(in *Configura
 	if err := Convert_v1alpha1_Controller_To_container_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -187,6 +188,7 @@ func autoConvert_container_Configuration_To_v1alpha1_Configuration(in *container
 	if err := Convert_container_Controller_To_v1alpha1_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/types_config.go
@@ -31,6 +31,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/types_config.go
@@ -39,6 +39,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -280,6 +280,7 @@ func autoConvert_v1alpha1_Configuration_To_helm_Configuration(in *Configuration,
 	if err := Convert_v1alpha1_Controller_To_helm_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -299,6 +300,7 @@ func autoConvert_helm_Configuration_To_v1alpha1_Configuration(in *helm.Configura
 	if err := Convert_helm_Controller_To_v1alpha1_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/types_config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1/types_config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha1/zz_generated.conversion.go
@@ -100,6 +100,7 @@ func autoConvert_v1alpha1_Configuration_To_manifest_Configuration(in *Configurat
 	if err := Convert_v1alpha1_Controller_To_manifest_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -118,6 +119,7 @@ func autoConvert_manifest_Configuration_To_v1alpha1_Configuration(in *manifest.C
 	if err := Convert_manifest_Controller_To_v1alpha1_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2/types_config.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2/types_config.go
@@ -36,6 +36,8 @@ type Configuration struct {
 	HPAConfiguration *HPAConfiguration `json:"hpa,omitempty"`
 	// Controller contains configuration concerning the controller framework.
 	Controller Controller `json:"controller,omitempty"`
+	// +optional
+	UseOCMLib bool `json:"useOCMLib,omitempty"`
 }
 
 // ExportConfiguration defines the export configuration for the deployer.

--- a/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2/zz_generated.conversion.go
@@ -103,6 +103,7 @@ func autoConvert_v1alpha2_Configuration_To_manifest_Configuration(in *Configurat
 	if err := Convert_v1alpha2_Controller_To_manifest_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -121,6 +122,7 @@ func autoConvert_manifest_Configuration_To_v1alpha2_Configuration(in *manifest.C
 	if err := Convert_manifest_Controller_To_v1alpha2_Controller(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area oci
/kind enhancement
/priority 3

**What this PR does / why we need it**:

This pull request adds an optional boolean flag `UseOCM` to the Context custom resource.

It also adds a boolean config parameter `useOCMLib` to the landscaper helm chart and the charts of the deployers (container, helm, manifest).


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
