### PR TITLE
implement kubeconfig getter templating functions with expiration timestamp

### DIFF
--- a/docs/usage/Templating.md
+++ b/docs/usage/Templating.md
@@ -185,7 +185,7 @@ The following additional functions are available:
   returns the kubeconfig wrapped in a Target. You can find the full example 
   [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/shoot-admin-kubeconfig).  
 
-- **`getShootAdminKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+- **`getShootAdminKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): object`**
   works like `getShootAdminKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
   ```yaml
   kubeconfig: |
@@ -223,7 +223,7 @@ The following additional functions are available:
   You can find the full example
   [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/service-account-kubeconfig).
 
-- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): object`**
   works like `getServiceAccountKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
   ```yaml
   kubeconfig: |
@@ -320,7 +320,7 @@ or
   It constructs two export values: `shootAdminKubeconfig` returns the kubeconfig as string, and `shootAdminTarget` 
   returns the kubeconfig wrapped in a Target.
 
-- **`getShootAdminKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+- **`getShootAdminKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): object`**
   works like `getShootAdminKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
   ```yaml
   kubeconfig: |
@@ -353,7 +353,7 @@ or
           kubeconfig: (( serviceAccountKubeconfig ))
   ```
 
-- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): object`**
   works like `getServiceAccountKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
   ```yaml
   kubeconfig: |

--- a/docs/usage/Templating.md
+++ b/docs/usage/Templating.md
@@ -163,10 +163,10 @@ The following additional functions are available:
   The kubeconfig is returned as base64 encoded string.  
 
   Arguments:
-  - `shootName` the name of the shoot cluster  
-  - `shootNamespace` the namespace of the Gardener project to which the Shoot belongs: `garden-<PROJECT NAME>`  
-  - `expirationSeconds` the number of seconds after which the kubeconfig expires.  
-  - `target` a Target that contains a kubeconfig for the Gardener project to which the Shoot belongs.  
+  - `shootName` the name of the shoot cluster
+  - `shootNamespace` the namespace of the Gardener project to which the Shoot belongs: `garden-<PROJECT NAME>`
+  - `expirationSeconds` the number of seconds after which the kubeconfig expires
+  - `target` a Target that contains a kubeconfig for the Gardener project to which the Shoot belongs
 
   Here is an example of an export execution that uses the `getShootAdminKubeconfig` function. 
   ```yaml
@@ -185,16 +185,27 @@ The following additional functions are available:
   returns the kubeconfig wrapped in a Target. You can find the full example 
   [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/shoot-admin-kubeconfig).  
 
+- **`getShootAdminKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+  works like `getShootAdminKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
+  ```yaml
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    ...
+  expirationTimestamp: 1695369282 # seconds from epoch
+  expirationTimestampReadable: "2023-09-22 09:54:42+02:00" # RFC3339
+  ```
+
 - **`getServiceAccountKubeconfig(serviceAccountName, serviceAccountNamespace string, expirationSeconds int, target Target): string`**
   returns a kubeconfig for a cluster. The kubeconfig will contain a token obtained by a 
   [token request](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) 
   for the specified ServiceAccount. The kubeconfig is returned as base64 encoded string.
 
   Arguments:
-  - `serviceAccountName` the name of the ServiceAccount  
-  - `serviceAccountNamespace` the namespace of the ServiceAccount  
-  - `expirationSeconds` the number of seconds after which the kubeconfig expires.  
-  - `target` a Target that contains a kubeconfig for the cluster.  
+  - `serviceAccountName` the name of the ServiceAccount
+  - `serviceAccountNamespace` the namespace of the ServiceAccount
+  - `expirationSeconds` the number of seconds after which the kubeconfig expires
+  - `target` a Target that contains a kubeconfig for the cluster
 
   Example:
   ```yaml
@@ -211,6 +222,17 @@ The following additional functions are available:
   ```
   You can find the full example
   [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/service-account-kubeconfig).
+
+- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+  works like `getServiceAccountKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
+  ```yaml
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    ...
+  expirationTimestamp: 1695369282 # seconds from epoch
+  expirationTimestampReadable: "2023-09-22 09:54:42+02:00" # RFC3339
+  ```
 
 
 ##### State
@@ -273,6 +295,74 @@ or
 - **`ociRefVersion(ref string): string`**
   parses an oci reference and returns the version.
   e.g. `host:5000/myrepo/myimage:1.0.0` -> `"1.0.0"`
+
+- **`getShootAdminKubeconfig(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+  returns a temporary admin kubeconfig for a Gardener Shoot cluster as described 
+  [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md#shootsadminkubeconfig-subresource). 
+  The kubeconfig is returned as base64 encoded string.  
+
+  Arguments:
+  - `shootName` the name of the shoot cluster
+  - `shootNamespace` the namespace of the Gardener project to which the Shoot belongs: `garden-<PROJECT NAME>`
+  - `expirationSeconds` the number of seconds after which the kubeconfig expires
+  - `target` a Target that contains a kubeconfig for the Gardener project to which the Shoot belongs
+
+  Here is an example of an export execution that uses the `getShootAdminKubeconfig` function. 
+  ```yaml
+  export-execution.yaml: |
+    exports:
+      shootAdminKubeconfig: (( base64(getShootAdminKubeconfig(.imports.shootName, .imports.shootNamespace, 86400, .imports.gardenerServiceAccount)) ))
+      shootAdminTarget:
+        type: landscaper.gardener.cloud/kubernetes-cluster
+        config:
+          kubeconfig: (( shootAdminKubeconfig ))
+  ```
+  It constructs two export values: `shootAdminKubeconfig` returns the kubeconfig as string, and `shootAdminTarget` 
+  returns the kubeconfig wrapped in a Target.
+
+- **`getShootAdminKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+  works like `getShootAdminKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
+  ```yaml
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    ...
+  expirationTimestamp: 1695369282 # seconds from epoch
+  expirationTimestampReadable: "2023-09-22 09:54:42+02:00" # RFC3339
+  ```
+
+- **`getServiceAccountKubeconfig(serviceAccountName, serviceAccountNamespace string, expirationSeconds int, target Target): string`**
+  returns a kubeconfig for a cluster. The kubeconfig will contain a token obtained by a 
+  [token request](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) 
+  for the specified ServiceAccount. The kubeconfig is returned as base64 encoded string.
+
+  Arguments:
+  - `serviceAccountName` the name of the ServiceAccount
+  - `serviceAccountNamespace` the namespace of the ServiceAccount
+  - `expirationSeconds` the number of seconds after which the kubeconfig expires
+  - `target` a Target that contains a kubeconfig for the cluster
+
+  Example:
+  ```yaml
+  export-execution.yaml: |
+    exports:
+      serviceAccountKubeconfig: (( base64(getServiceAccountKubeconfig(.imports.serviceAccountName, .imports.serviceAccountNamespace, 7776000, .imports.cluster) ))
+      serviceAccountTarget:
+        type: landscaper.gardener.cloud/kubernetes-cluster
+        config:
+          kubeconfig: (( serviceAccountKubeconfig ))
+  ```
+
+- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): string`**  
+  works like `getServiceAccountKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
+  ```yaml
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    ...
+  expirationTimestamp: 1695369282 # seconds from epoch
+  expirationTimestampReadable: "2023-09-22 09:54:42+02:00" # RFC3339
+  ```
 
 ##### State
 

--- a/docs/usage/Templating.md
+++ b/docs/usage/Templating.md
@@ -223,7 +223,7 @@ The following additional functions are available:
   You can find the full example
   [here](https://github.com/gardener/landscaper-examples/tree/master/manifest-deployer/service-account-kubeconfig).
 
-- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): object`**
+- **`getServiceAccountKubeconfigWithExpirationTimestamp(serviceAccountName, serviceAccountNamespace string, expirationSeconds int, target Target): object`**
   works like `getServiceAccountKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
   ```yaml
   kubeconfig: |
@@ -353,7 +353,7 @@ or
           kubeconfig: (( serviceAccountKubeconfig ))
   ```
 
-- **`getServiceAccountKubeconfigWithExpirationTimestamp(shootName, shootNamespace string, expirationSeconds int, target Target): object`**
+- **`getServiceAccountKubeconfigWithExpirationTimestamp(serviceAccountName, serviceAccountNamespace string, expirationSeconds int, target Target): object`**
   works like `getServiceAccountKubeconfig`, but instead of only returning the kubeconfig as string, it returns a struct containing the kubeconfig as well as the expiration timestamp of the token used in it. The returned struct looks like this:
   ```yaml
   kubeconfig: |

--- a/pkg/landscaper/controllers/targetsync/targetsync_controller.go
+++ b/pkg/landscaper/controllers/targetsync/targetsync_controller.go
@@ -373,7 +373,7 @@ func (c *TargetSyncController) handleShoot(ctx context.Context, targetSync *lsv1
 		return nil
 	}
 
-	kubeconfig, err := shootClient.GetShootAdminKubeconfig(ctx, shoot.GetName(), shoot.GetNamespace(), kubeconfigExpirationSeconds)
+	kubeconfig, _, err := shootClient.GetShootAdminKubeconfig(ctx, shoot.GetName(), shoot.GetNamespace(), kubeconfigExpirationSeconds)
 	if err != nil {
 		msg := "targetsync for shoot failed to get admin kubeconfig"
 		logger.Error(err, msg)

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -61,7 +61,7 @@ func (o *ExecutionOperation) RenderDeployItemTemplates(ctx context.Context, inst
 		Inst:       inst.GetInstallation(),
 	}
 	targetResolver := secretresolver.New(o.Client())
-	tmpl := template.New(gotemplate.New(templateStateHandler, targetResolver), spiff.New(templateStateHandler))
+	tmpl := template.New(gotemplate.New(templateStateHandler, targetResolver), spiff.New(templateStateHandler, targetResolver))
 	executions, err := tmpl.TemplateDeployExecutions(
 		template.NewDeployExecutionOptions(
 			template.NewBlueprintExecutionOptions(

--- a/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	gotmpl "text/template"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
@@ -19,6 +20,7 @@ import (
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	imagevector "github.com/gardener/image-vector/pkg"
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -70,9 +72,11 @@ func LandscaperTplFuncMap(fs vfs.FileSystem,
 		"getComponent":         getComponentGoFunc(cd, cdList),
 		"getRepositoryContext": getEffectiveRepositoryContextGoFunc,
 
-		"getShootAdminKubeconfig":     getShootAdminKubeconfigGoFunc(targetResolver),
-		"getServiceAccountKubeconfig": getServiceAccountKubeconfigGoFunc(targetResolver),
-		"getOidcKubeconfig":           getOidcKubeconfigGoFunc(targetResolver),
+		"getShootAdminKubeconfig":                            getShootAdminKubeconfigGoFunc(targetResolver),
+		"getShootAdminKubeconfigWithExpirationTimestamp":     getShootAdminKubeconfigWithExpirationTimestampGoFunc(targetResolver),
+		"getServiceAccountKubeconfig":                        getServiceAccountKubeconfigGoFunc(targetResolver),
+		"getServiceAccountKubeconfigWithExpirationTimestamp": getServiceAccountKubeconfigWithExpirationTimestampGoFunc(targetResolver),
+		"getOidcKubeconfig":                                  getOidcKubeconfigGoFunc(targetResolver),
 
 		"generateImageOverwrite": generateImageVectorGoFunc(cd, cdList),
 	}
@@ -319,116 +323,168 @@ func generateImageVectorGoFunc(cd *types.ComponentDescriptor, list *types.Compon
 
 func getShootAdminKubeconfigGoFunc(targetResolver targetresolver.TargetResolver) func(args ...interface{}) (string, error) {
 	return func(args ...interface{}) (string, error) {
-		if len(args) != 4 {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects 4 arguments: shoot name, shoot namespace, expiration seconds, and target for garden project ")
-		}
-
-		shootName, ok := args[0].(string)
-		if !ok {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a string as 1st argument, namely the shoot name")
-		}
-
-		shootNamespace, ok := args[1].(string)
-		if !ok {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a string as 2nd argument, namely the shoot namespace")
-		}
-
-		expirationSeconds, err := toInt64(args[2])
-		if err != nil {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects an integer as 3rd argument, namely the expiration seconds: %w", err)
-		}
-
-		targetObj := args[3]
-		targetBytes, err := json.Marshal(targetObj)
-		if err != nil {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a target object as 4th argument: error during marshaling: %w", err)
-		}
-
-		target := &v1alpha1.Target{}
-		err = json.Unmarshal(targetBytes, target)
-		if err != nil {
-			return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a target object as 4th argument: error during unmarshaling: %w", err)
-		}
-
-		ctx := context.Background()
-		shootClient, err := clusters.NewShootClientFromTarget(ctx, target, targetResolver)
+		res, err := getShootAdminKubeconfigGoFunc_helper(targetResolver, false, args...)
 		if err != nil {
 			return "", err
 		}
-
-		return shootClient.GetShootAdminKubeconfig(ctx, shootName, shootNamespace, expirationSeconds)
+		return res.(string), nil
 	}
+}
+
+func getShootAdminKubeconfigWithExpirationTimestampGoFunc(targetResolver targetresolver.TargetResolver) func(args ...interface{}) (map[string]interface{}, error) {
+	return func(args ...interface{}) (map[string]interface{}, error) {
+		res, err := getShootAdminKubeconfigGoFunc_helper(targetResolver, true, args...)
+		if err != nil {
+			return nil, err
+		}
+		return res.(map[string]interface{}), nil
+	}
+}
+
+func getShootAdminKubeconfigGoFunc_helper(targetResolver targetresolver.TargetResolver, includeExpirationTimestamp bool, args ...interface{}) (interface{}, error) {
+	if len(args) != 4 {
+		return "", fmt.Errorf("templating function getShootAdminKubeconfig expects 4 arguments: shoot name, shoot namespace, expiration seconds, and target for garden project ")
+	}
+
+	shootName, ok := args[0].(string)
+	if !ok {
+		return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a string as 1st argument, namely the shoot name")
+	}
+
+	shootNamespace, ok := args[1].(string)
+	if !ok {
+		return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a string as 2nd argument, namely the shoot namespace")
+	}
+
+	expirationSeconds, err := toInt64(args[2])
+	if err != nil {
+		return "", fmt.Errorf("templating function getShootAdminKubeconfig expects an integer as 3rd argument, namely the expiration seconds: %w", err)
+	}
+
+	targetObj := args[3]
+	targetBytes, err := json.Marshal(targetObj)
+	if err != nil {
+		return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a target object as 4th argument: error during marshaling: %w", err)
+	}
+
+	target := &v1alpha1.Target{}
+	err = json.Unmarshal(targetBytes, target)
+	if err != nil {
+		return "", fmt.Errorf("templating function getShootAdminKubeconfig expects a target object as 4th argument: error during unmarshaling: %w", err)
+	}
+
+	ctx := context.Background()
+	shootClient, err := clusters.NewShootClientFromTarget(ctx, target, targetResolver)
+	if err != nil {
+		return "", err
+	}
+
+	kcfg, expirationTimestamp, err := shootClient.GetShootAdminKubeconfig(ctx, shootName, shootNamespace, expirationSeconds)
+	if err != nil {
+		return "", err
+	}
+
+	if includeExpirationTimestamp {
+		return kubeconfigWithExpirationTimestamp(kcfg, expirationTimestamp), nil
+	}
+	return kcfg, nil
 }
 
 func getServiceAccountKubeconfigGoFunc(targetResolver targetresolver.TargetResolver) func(args ...interface{}) (string, error) {
 	return func(args ...interface{}) (string, error) {
-		if len(args) != 4 {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects 4 arguments: service account name, service account namespace, expiration seconds, and target")
-		}
-
-		serviceAccountName, ok := args[0].(string)
-		if !ok {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects a string as 1st argument, namely the service account name")
-		}
-
-		serviceAccountNamespace, ok := args[1].(string)
-		if !ok {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects a string as 2nd argument, namely the service account namespace")
-		}
-
-		expirationSeconds, err := toInt64(args[2])
-		if err != nil {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects an integer as 3rd argument, namely the expiration seconds: %w", err)
-		}
-
-		targetObj := args[3]
-		targetBytes, err := json.Marshal(targetObj)
-		if err != nil {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects a target object as 4th argument: error during marshaling: %w", err)
-		}
-
-		target := &v1alpha1.Target{}
-		err = json.Unmarshal(targetBytes, target)
-		if err != nil {
-			return "", fmt.Errorf("templating function getServiceAccountToken expects a target object as 4th argument: error during unmarshaling: %w", err)
-		}
-
-		ctx := context.Background()
-		tokenClient, err := clusters.NewTokenClientFromTarget(ctx, target, targetResolver)
+		res, err := getServiceAccountKubeconfigGoFunc_helper(targetResolver, false, args...)
 		if err != nil {
 			return "", err
 		}
-
-		return tokenClient.GetServiceAccountKubeconfig(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds)
+		return res.(string), nil
 	}
+}
+
+func getServiceAccountKubeconfigWithExpirationTimestampGoFunc(targetResolver targetresolver.TargetResolver) func(args ...interface{}) (map[string]interface{}, error) {
+	return func(args ...interface{}) (map[string]interface{}, error) {
+		res, err := getServiceAccountKubeconfigGoFunc_helper(targetResolver, true, args...)
+		if err != nil {
+			return nil, err
+		}
+		return res.(map[string]interface{}), nil
+	}
+}
+
+func getServiceAccountKubeconfigGoFunc_helper(targetResolver targetresolver.TargetResolver, includeExpirationTimestamp bool, args ...interface{}) (interface{}, error) {
+	if len(args) != 4 {
+		return "", fmt.Errorf("templating function getServiceAccountToken expects 4 arguments: service account name, service account namespace, expiration seconds, and target")
+	}
+
+	serviceAccountName, ok := args[0].(string)
+	if !ok {
+		return "", fmt.Errorf("templating function getServiceAccountToken expects a string as 1st argument, namely the service account name")
+	}
+
+	serviceAccountNamespace, ok := args[1].(string)
+	if !ok {
+		return "", fmt.Errorf("templating function getServiceAccountToken expects a string as 2nd argument, namely the service account namespace")
+	}
+
+	expirationSeconds, err := toInt64(args[2])
+	if err != nil {
+		return "", fmt.Errorf("templating function getServiceAccountToken expects an integer as 3rd argument, namely the expiration seconds: %w", err)
+	}
+
+	targetObj := args[3]
+	targetBytes, err := json.Marshal(targetObj)
+	if err != nil {
+		return "", fmt.Errorf("templating function getServiceAccountToken expects a target object as 4th argument: error during marshaling: %w", err)
+	}
+
+	target := &v1alpha1.Target{}
+	err = json.Unmarshal(targetBytes, target)
+	if err != nil {
+		return "", fmt.Errorf("templating function getServiceAccountToken expects a target object as 4th argument: error during unmarshaling: %w", err)
+	}
+
+	ctx := context.Background()
+	tokenClient, err := clusters.NewTokenClientFromTarget(ctx, target, targetResolver)
+	if err != nil {
+		return "", err
+	}
+
+	kcfg, expirationTimestamp, err := tokenClient.GetServiceAccountKubeconfig(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds)
+	if err != nil {
+		return "", err
+	}
+
+	if includeExpirationTimestamp {
+		return kubeconfigWithExpirationTimestamp(kcfg, expirationTimestamp), nil
+	}
+	return kcfg, nil
 }
 
 func getOidcKubeconfigGoFunc(targetResolver targetresolver.TargetResolver) func(args ...interface{}) (string, error) {
 	return func(args ...interface{}) (string, error) {
 		if len(args) != 3 {
-			return "", fmt.Errorf("templating function getOidcKubeconfigGoFunc expects 3 arguments: issuer url, client id, and target")
+			return "", fmt.Errorf("templating function getOidcKubeconfig expects 3 arguments: issuer url, client id, and target")
 		}
 
 		issuerURL, ok := args[0].(string)
 		if !ok {
-			return "", fmt.Errorf("templating function getOidcKubeconfigGoFunc expects a string as 1st argument, namely the issuer url")
+			return "", fmt.Errorf("templating function getOidcKubeconfig expects a string as 1st argument, namely the issuer url")
 		}
 
 		clientID, ok := args[1].(string)
 		if !ok {
-			return "", fmt.Errorf("templating function getOidcKubeconfigGoFunc expects a string as 2nd argument, namely the client id")
+			return "", fmt.Errorf("templating function getOidcKubeconfig expects a string as 2nd argument, namely the client id")
 		}
 
 		targetObj := args[2]
 		targetBytes, err := json.Marshal(targetObj)
 		if err != nil {
-			return "", fmt.Errorf("templating function getOidcKubeconfigGoFunc expects a target object as 3rd argument: error during marshaling: %w", err)
+			return "", fmt.Errorf("templating function getOidcKubeconfig expects a target object as 3rd argument: error during marshaling: %w", err)
 		}
 
 		target := &v1alpha1.Target{}
 		err = json.Unmarshal(targetBytes, target)
 		if err != nil {
-			return "", fmt.Errorf("templating function getOidcKubeconfigGoFunc expects a target object as 3rd argument: error during unmarshaling: %w", err)
+			return "", fmt.Errorf("templating function getOidcKubeconfig expects a target object as 3rd argument: error during unmarshaling: %w", err)
 		}
 
 		ctx := context.Background()
@@ -454,5 +510,13 @@ func toInt64(value interface{}) (int64, error) {
 		return int64(n), nil
 	default:
 		return 0, fmt.Errorf("unsupported type %T", value)
+	}
+}
+
+func kubeconfigWithExpirationTimestamp(kcfg string, expirationTimestamp metav1.Time) map[string]interface{} {
+	return map[string]interface{}{
+		"kubeconfig":                  kcfg,
+		"expirationTimestamp":         expirationTimestamp.Unix(),
+		"expirationTimestampReadable": expirationTimestamp.Format(time.RFC3339),
 	}
 }

--- a/pkg/landscaper/installations/executions/template/spiff/funcs.go
+++ b/pkg/landscaper/installations/executions/template/spiff/funcs.go
@@ -8,20 +8,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	imagevector "github.com/gardener/image-vector/pkg"
 	"github.com/mandelsoft/spiff/dynaml"
 	"github.com/mandelsoft/spiff/spiffing"
 	spiffyaml "github.com/mandelsoft/spiff/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/components/model"
 	"github.com/gardener/landscaper/pkg/components/model/types"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
+	"github.com/gardener/landscaper/pkg/utils/clusters"
+	"github.com/gardener/landscaper/pkg/utils/targetresolver"
 )
 
-func LandscaperSpiffFuncs(functions spiffing.Functions, componentVersion model.ComponentVersion, componentVersions *model.ComponentVersionList) error {
+func LandscaperSpiffFuncs(functions spiffing.Functions, componentVersion model.ComponentVersion, componentVersions *model.ComponentVersionList, targetResolver targetresolver.TargetResolver) error {
 	cd, err := model.GetComponentDescriptor(componentVersion)
 	if err != nil {
 		return fmt.Errorf("unable to get component descriptor to register spiff functions: %w", err)
@@ -38,6 +43,11 @@ func LandscaperSpiffFuncs(functions spiffing.Functions, componentVersion model.C
 	functions.RegisterFunction("parseOCIRef", parseOCIReference)
 	functions.RegisterFunction("ociRefRepo", getOCIReferenceRepository)
 	functions.RegisterFunction("ociRefVersion", getOCIReferenceVersion)
+	functions.RegisterFunction("getShootAdminKubeconfig", getShootAdminKubeconfigSpiffFunc(targetResolver, false))
+	functions.RegisterFunction("getShootAdminKubeconfigWithExpirationTimestamp", getShootAdminKubeconfigSpiffFunc(targetResolver, true))
+	functions.RegisterFunction("getServiceAccountKubeconfig", getServiceAccountKubeconfigSpiffFunc(targetResolver, false))
+	functions.RegisterFunction("getServiceAccountKubeconfigWithExpirationTimestamp", getServiceAccountKubeconfigSpiffFunc(targetResolver, true))
+	functions.RegisterFunction("getOidcKubeconfig", getOidcKubeconfigSpiffFunc(targetResolver))
 
 	return nil
 }
@@ -246,6 +256,195 @@ func getOCIReferenceVersion(arguments []interface{}, binding dynaml.Binding) (in
 	}
 	ref := arguments[0].(string)
 	data, err := yaml.Marshal(template.ParseOCIReference(ref)[1])
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	node, err := spiffyaml.Parse("", data)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	result, err := binding.Flow(node, false)
+	if err != nil {
+		return info.Error(err.Error())
+	}
+
+	return result.Value(), info, true
+}
+
+func getShootAdminKubeconfigSpiffFunc(targetResolver targetresolver.TargetResolver, includeExpirationTimestamp bool) dynaml.Function {
+	return func(args []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+		info := dynaml.DefaultInfo()
+		if len(args) != 4 {
+			return info.Error("templating function getShootAdminKubeconfig expects 4 arguments: shoot name, shoot namespace, expiration seconds, and target for garden project ")
+		}
+
+		shootName, ok := args[0].(string)
+		if !ok {
+			return info.Error("templating function getShootAdminKubeconfig expects a string as 1st argument, namely the shoot name")
+		}
+
+		shootNamespace, ok := args[1].(string)
+		if !ok {
+			return info.Error("templating function getShootAdminKubeconfig expects a string as 2nd argument, namely the shoot namespace")
+		}
+
+		expirationSeconds, err := toInt64(args[2])
+		if err != nil {
+			return info.Error("templating function getShootAdminKubeconfig expects an integer as 3rd argument, namely the expiration seconds: %w", err)
+		}
+
+		targetObj := args[3]
+		targetBytes, err := spiffyaml.Marshal(spiffyaml.NewNode(targetObj, ""))
+		if err != nil {
+			return info.Error("templating function getShootAdminKubeconfig expects a target object as 4th argument: error during marshaling: %w", err)
+		}
+
+		target := &lsv1alpha1.Target{}
+		err = yaml.Unmarshal(targetBytes, target)
+		if err != nil {
+			return info.Error("templating function getShootAdminKubeconfig expects a target object as 4th argument: error during unmarshaling: %w", err)
+		}
+
+		ctx := context.Background()
+		shootClient, err := clusters.NewShootClientFromTarget(ctx, target, targetResolver)
+		if err != nil {
+			return info.Error(err)
+		}
+
+		kcfg, expirationTimestamp, err := shootClient.GetShootAdminKubeconfig(ctx, shootName, shootNamespace, expirationSeconds)
+		if err != nil {
+			return info.Error(err)
+		}
+
+		if includeExpirationTimestamp {
+			return kubeconfigWithExpirationTimestamp(kcfg, expirationTimestamp, info, binding)
+		}
+		return kcfg, info, true
+	}
+}
+
+func getServiceAccountKubeconfigSpiffFunc(targetResolver targetresolver.TargetResolver, includeExpirationTimestamp bool) dynaml.Function {
+	return func(args []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+		info := dynaml.DefaultInfo()
+		if len(args) != 4 {
+			return info.Error("templating function getServiceAccountToken expects 4 arguments: service account name, service account namespace, expiration seconds, and target")
+		}
+
+		serviceAccountName, ok := args[0].(string)
+		if !ok {
+			return info.Error("templating function getServiceAccountToken expects a string as 1st argument, namely the service account name")
+		}
+
+		serviceAccountNamespace, ok := args[1].(string)
+		if !ok {
+			return info.Error("templating function getServiceAccountToken expects a string as 2nd argument, namely the service account namespace")
+		}
+
+		expirationSeconds, err := toInt64(args[2])
+		if err != nil {
+			return info.Error("templating function getServiceAccountToken expects an integer as 3rd argument, namely the expiration seconds: %w", err)
+		}
+
+		targetObj := args[3]
+		targetBytes, err := spiffyaml.Marshal(spiffyaml.NewNode(targetObj, ""))
+		if err != nil {
+			return info.Error("templating function getServiceAccountToken expects a target object as 4th argument: error during marshaling: %w", err)
+		}
+
+		target := &lsv1alpha1.Target{}
+		err = yaml.Unmarshal(targetBytes, target)
+		if err != nil {
+			return info.Error("templating function getServiceAccountToken expects a target object as 4th argument: error during unmarshaling: %w", err)
+		}
+
+		ctx := context.Background()
+		tokenClient, err := clusters.NewTokenClientFromTarget(ctx, target, targetResolver)
+		if err != nil {
+			return info.Error(err)
+		}
+
+		kcfg, expirationTimestamp, err := tokenClient.GetServiceAccountKubeconfig(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds)
+		if err != nil {
+			return info.Error(err)
+		}
+
+		if includeExpirationTimestamp {
+			return kubeconfigWithExpirationTimestamp(kcfg, expirationTimestamp, info, binding)
+		}
+		return kcfg, info, true
+	}
+}
+
+func getOidcKubeconfigSpiffFunc(targetResolver targetresolver.TargetResolver) dynaml.Function {
+	return func(args []interface{}, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+		info := dynaml.DefaultInfo()
+		if len(args) != 3 {
+			return info.Error("templating function getOidcKubeconfig expects 3 arguments: issuer url, client id, and target")
+		}
+
+		issuerURL, ok := args[0].(string)
+		if !ok {
+			return info.Error("templating function getOidcKubeconfig expects a string as 1st argument, namely the issuer url")
+		}
+
+		clientID, ok := args[1].(string)
+		if !ok {
+			return info.Error("templating function getOidcKubeconfig expects a string as 2nd argument, namely the client id")
+		}
+
+		targetObj := args[2]
+		targetBytes, err := spiffyaml.Marshal(spiffyaml.NewNode(targetObj, ""))
+		if err != nil {
+			return info.Error("templating function getOidcKubeconfig expects a target object as 3rd argument: error during marshaling: %w", err)
+		}
+
+		target := &lsv1alpha1.Target{}
+		err = yaml.Unmarshal(targetBytes, target)
+		if err != nil {
+			return info.Error("templating function getOidcKubeconfig expects a target object as 3rd argument: error during unmarshaling: %w", err)
+		}
+
+		ctx := context.Background()
+		kcfg, err := clusters.BuildOIDCKubeconfig(ctx, issuerURL, clientID, target, targetResolver)
+		if err != nil {
+			return info.Error(err)
+		}
+
+		return kcfg, info, true
+	}
+}
+
+func toInt64(value interface{}) (int64, error) {
+	switch n := value.(type) {
+	case int64:
+		return n, nil
+	case int32:
+		return int64(n), nil
+	case int16:
+		return int64(n), nil
+	case int8:
+		return int64(n), nil
+	case int:
+		return int64(n), nil
+	case float64:
+		return int64(n), nil
+	case float32:
+		return int64(n), nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T", value)
+	}
+}
+
+func kubeconfigWithExpirationTimestamp(kcfg string, expirationTimestamp metav1.Time, info dynaml.EvaluationInfo, binding dynaml.Binding) (interface{}, dynaml.EvaluationInfo, bool) {
+	rawData := map[string]interface{}{
+		"kubeconfig":                  kcfg,
+		"expirationTimestamp":         expirationTimestamp.Unix(),
+		"expirationTimestampReadable": expirationTimestamp.Format(time.RFC3339),
+	}
+
+	data, err := yaml.Marshal(rawData)
 	if err != nil {
 		return info.Error(err.Error())
 	}

--- a/pkg/landscaper/installations/executions/template/spiff/spifftemplate.go
+++ b/pkg/landscaper/installations/executions/template/spiff/spifftemplate.go
@@ -17,19 +17,22 @@ import (
 	"github.com/gardener/landscaper/pkg/components/model"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
+	"github.com/gardener/landscaper/pkg/utils/targetresolver"
 )
 
 // Templater describes the spiff template implementation for execution templater.
 type Templater struct {
 	state          template.GenericStateHandler
 	inputFormatter *template.TemplateInputFormatter
+	targetResolver targetresolver.TargetResolver
 }
 
 // New creates a new spiff execution templater.
-func New(state template.GenericStateHandler) *Templater {
+func New(state template.GenericStateHandler, targetResolver targetresolver.TargetResolver) *Templater {
 	return &Templater{
 		state:          state,
 		inputFormatter: template.NewTemplateInputFormatter(false, "imports", "values", "state"),
+		targetResolver: targetResolver,
 	}
 }
 
@@ -61,7 +64,7 @@ func (t *Templater) TemplateSubinstallationExecutions(tmplExec lsv1alpha1.Templa
 	}
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, cd, cdList); err != nil {
+	if err = LandscaperSpiffFuncs(functions, cd, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 
@@ -106,7 +109,7 @@ func (t *Templater) TemplateImportExecutions(tmplExec lsv1alpha1.TemplateExecuto
 	defer ctx.Done()
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, descriptor, cdList); err != nil {
+	if err = LandscaperSpiffFuncs(functions, descriptor, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 
@@ -152,7 +155,7 @@ func (t *Templater) TemplateDeployExecutions(tmplExec lsv1alpha1.TemplateExecuto
 	}
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, descriptor, cdList); err != nil {
+	if err = LandscaperSpiffFuncs(functions, descriptor, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 
@@ -201,7 +204,7 @@ func (t *Templater) TemplateExportExecutions(tmplExec lsv1alpha1.TemplateExecuto
 	}
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, descriptor, cdList); err != nil {
+	if err = LandscaperSpiffFuncs(functions, descriptor, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 

--- a/pkg/landscaper/installations/executions/template/template_test.go
+++ b/pkg/landscaper/installations/executions/template/template_test.go
@@ -78,7 +78,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.SubinstallationExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateSubinstallationExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil, nil)))
@@ -98,7 +98,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.SubinstallationExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateSubinstallationExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil,
@@ -121,7 +121,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateDeployExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil, nil)))
@@ -141,7 +141,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateDeployExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil,
@@ -162,7 +162,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			memFs := memoryfs.New()
 			err = vfs.WriteFile(memFs, "VERSION", []byte("0.0.0"), os.ModePerm)
@@ -186,7 +186,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			imageAccess, err := componentresolvers.NewOCIRegistryAccess("quay.io/example/myimage:1.0.0")
 			Expect(err).ToNot(HaveOccurred())
@@ -238,7 +238,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			imageAccess, err := componentresolvers.NewOCIRegistryAccess("quay.io/example/myimage:1.0.0")
 			Expect(err).ToNot(HaveOccurred())
@@ -311,7 +311,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			_, err = op.TemplateDeployExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil,
@@ -327,7 +327,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			_, err = op.TemplateDeployExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil,
@@ -354,7 +354,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			componentDef := lsv1alpha1.ComponentDescriptorDefinition{}
 			componentDef.Reference = &lsv1alpha1.ComponentDescriptorReference{}
@@ -402,7 +402,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			cdRaw, err := os.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
@@ -448,7 +448,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateDeployExecutions(template.NewDeployExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil,
@@ -477,7 +477,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.ExportExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateExportExecutions(template.NewExportExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil, nil), nil))
@@ -493,7 +493,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.ExportExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			res, err := op.TemplateExportExecutions(template.NewExportExecutionOptions(
 				template.NewBlueprintExecutionOptions(nil, &blueprints.Blueprint{Info: blue, Fs: nil}, nil, nil, nil),
@@ -510,7 +510,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 
 			blue := &lsv1alpha1.Blueprint{}
 			blue.ExportExecutions = exec
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			memFs := memoryfs.New()
 			err = vfs.WriteFile(memFs, "VERSION", []byte("0.0.0"), os.ModePerm)
@@ -539,7 +539,7 @@ func runTestSuiteGoTemplate(testdataDir, sharedTestdataDir string) {
 			blue := &lsv1alpha1.Blueprint{}
 			blue.DeployExecutions = exec
 
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			cdRaw, err := os.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())
@@ -723,7 +723,7 @@ func runTestSuiteSpiff(testdataDir, sharedTestdataDir string) {
 					Type: "object",
 				},
 			}
-			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler))
+			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			cdRaw, err := os.ReadFile(filepath.Join(sharedTestdataDir, "component-descriptor-12.yaml"))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -83,7 +83,7 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 
 	tmpl := template.New(
 		gotemplate.New(stateHdlr, targetResolver),
-		spiff.New(stateHdlr))
+		spiff.New(stateHdlr, targetResolver))
 	exports, err := tmpl.TemplateExportExecutions(
 		template.NewExportExecutionOptions(
 			template.NewBlueprintExecutionOptions(

--- a/pkg/landscaper/installations/imports/constructor.go
+++ b/pkg/landscaper/installations/imports/constructor.go
@@ -294,7 +294,7 @@ func (c *Constructor) RenderImportExecutions() error {
 	targetResolver := secretresolver.New(c.Operation.Client())
 	tmpl := template.New(
 		gotemplate.New(templateStateHandler, targetResolver),
-		spiff.New(templateStateHandler))
+		spiff.New(templateStateHandler, targetResolver))
 	errors, bindings, err := tmpl.TemplateImportExecutions(
 		template.NewBlueprintExecutionOptions(
 			c.Operation.Context().External.InjectComponentDescriptorRef(c.Operation.Inst.GetInstallation()),

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -195,7 +195,7 @@ func (o *Operation) getInstallationTemplates() ([]*lsv1alpha1.InstallationTempla
 			Inst:       o.Inst.GetInstallation(),
 		}
 		targetResolver := secretresolver.New(o.Client())
-		tmpl := template.New(gotemplate.New(templateStateHandler, targetResolver), spiff.New(templateStateHandler))
+		tmpl := template.New(gotemplate.New(templateStateHandler, targetResolver), spiff.New(templateStateHandler, targetResolver))
 		templatedTmpls, err := tmpl.TemplateSubinstallationExecutions(template.NewDeployExecutionOptions(
 			template.NewBlueprintExecutionOptions(
 				o.Context().External.InjectComponentDescriptorRef(o.Inst.GetInstallation().DeepCopy()),

--- a/pkg/utils/clusters/shoot_client.go
+++ b/pkg/utils/clusters/shoot_client.go
@@ -91,7 +91,7 @@ func (c *ShootClient) ExistsShoot(ctx context.Context, shootNamespace, shootName
 }
 
 // GetShootAdminKubeconfig returns a short-lived admin kubeconfig for the specified shoot as base64 encoded string.
-func (c *ShootClient) GetShootAdminKubeconfig(ctx context.Context, shootName, shootNamespace string, kubeconfigExpirationSeconds int64) (string, error) {
+func (c *ShootClient) GetShootAdminKubeconfig(ctx context.Context, shootName, shootNamespace string, kubeconfigExpirationSeconds int64) (string, metav1.Time, error) {
 
 	adminKubeconfigRequest := unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -107,18 +107,29 @@ func (c *ShootClient) GetShootAdminKubeconfig(ctx context.Context, shootName, sh
 		},
 	}
 
+	var expirationTimestamp metav1.Time
 	namespacedShootClient := c.unstructuredClient.Namespace(shootNamespace)
 	result, err := namespacedShootClient.Create(ctx, &adminKubeconfigRequest, metav1.CreateOptions{}, subresourceAdminKubeconfig)
 	if err != nil {
-		return "", fmt.Errorf("shoot client: admin kubeconfig request failed: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("shoot client: admin kubeconfig request failed: %w", err)
 	}
 
 	shootKubeconfigBase64, found, err := unstructured.NestedString(result.Object, "status", "kubeconfig")
 	if err != nil {
-		return "", fmt.Errorf("shoot client: could not get kubeconfig from result: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("shoot client: could not get kubeconfig from result: %w", err)
 	} else if !found {
-		return "", fmt.Errorf("shoot client: could not find kubeconfig in result")
+		return "", expirationTimestamp, fmt.Errorf("shoot client: could not find kubeconfig in result")
+	}
+	rawExpirationTimestamp, found, err := unstructured.NestedString(result.Object, "status", "expirationTimestamp")
+	if err != nil {
+		return "", expirationTimestamp, fmt.Errorf("shoot client: could not get expiration timestamp from result: %w", err)
+	} else if !found {
+		return "", expirationTimestamp, fmt.Errorf("shoot client: could not find expiration timestamp in result")
+	}
+	err = expirationTimestamp.UnmarshalJSON([]byte(fmt.Sprintf("\"%s\"", rawExpirationTimestamp)))
+	if err != nil {
+		return "", expirationTimestamp, fmt.Errorf("error converting raw expiration timestamp '%s' to metav1.Time: %w", rawExpirationTimestamp, err)
 	}
 
-	return shootKubeconfigBase64, nil
+	return shootKubeconfigBase64, expirationTimestamp, nil
 }

--- a/pkg/utils/clusters/token_client.go
+++ b/pkg/utils/clusters/token_client.go
@@ -64,7 +64,7 @@ func NewTokenClientFromTarget(ctx context.Context, target *v1alpha1.Target, targ
 }
 
 func (c *TokenClient) GetServiceAccountToken(ctx context.Context, serviceAccountName, serviceAccountNamespace string,
-	expirationSeconds int64) (string, error) {
+	expirationSeconds int64) (string, metav1.Time, error) {
 
 	tokenRequest := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
@@ -72,31 +72,32 @@ func (c *TokenClient) GetServiceAccountToken(ctx context.Context, serviceAccount
 		},
 	}
 
+	var expirationTimestamp metav1.Time
 	serviceAccountClient := c.clientset.CoreV1().ServiceAccounts(serviceAccountNamespace)
 	tokenRequest, err := serviceAccountClient.CreateToken(ctx, serviceAccountName, tokenRequest, metav1.CreateOptions{})
 	if err != nil {
-		return "", fmt.Errorf("token client: token request failed: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("token client: token request failed: %w", err)
 	}
 
-	return tokenRequest.Status.Token, nil
+	return tokenRequest.Status.Token, tokenRequest.Status.ExpirationTimestamp, nil
 }
 
 func (c *TokenClient) GetServiceAccountKubeconfig(ctx context.Context, serviceAccountName, serviceAccountNamespace string,
-	expirationSeconds int64) (string, error) {
+	expirationSeconds int64) (string, metav1.Time, error) {
 
-	token, err := c.GetServiceAccountToken(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds)
+	token, expirationTimestamp, err := c.GetServiceAccountToken(ctx, serviceAccountName, serviceAccountNamespace, expirationSeconds)
 	if err != nil {
-		return "", err
+		return "", expirationTimestamp, err
 	}
 
 	config, err := clientcmd.Load(c.kubeconfig)
 	if err != nil {
-		return "", fmt.Errorf("token client: failed to load config: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("token client: failed to load config: %w", err)
 	}
 
 	context, ok := config.Contexts[config.CurrentContext]
 	if !ok || context == nil {
-		return "", fmt.Errorf("token client: current context not found: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("token client: current context not found: %w", err)
 	}
 
 	context.AuthInfo = serviceAccountName
@@ -112,7 +113,7 @@ func (c *TokenClient) GetServiceAccountKubeconfig(ctx context.Context, serviceAc
 
 	cluster, ok := config.Clusters[context.Cluster]
 	if !ok || context == nil {
-		return "", fmt.Errorf("token client: current cluster not found: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("token client: current cluster not found: %w", err)
 	}
 
 	config.Clusters = map[string]*api.Cluster{
@@ -121,10 +122,10 @@ func (c *TokenClient) GetServiceAccountKubeconfig(ctx context.Context, serviceAc
 
 	serviceAccountKubeconfig, err := clientcmd.Write(*config)
 	if err != nil {
-		return "", fmt.Errorf("token client: failed to write config: %w", err)
+		return "", expirationTimestamp, fmt.Errorf("token client: failed to write config: %w", err)
 	}
 
 	serviceAccountKubeconfig64 := base64.StdEncoding.EncodeToString(serviceAccountKubeconfig)
 
-	return serviceAccountKubeconfig64, nil
+	return serviceAccountKubeconfig64, expirationTimestamp, nil
 }

--- a/pkg/utils/landscaper/blueprint.go
+++ b/pkg/utils/landscaper/blueprint.go
@@ -128,7 +128,7 @@ func (r *BlueprintRenderer) RenderImportExecutions(input *ResolvedInstallation, 
 	formatter := template.NewTemplateInputFormatter(true)
 	tmpl := template.New(
 		gotemplate.New(templateStateHandler, nil).WithInputFormatter(formatter),
-		spiff.New(templateStateHandler).WithInputFormatter(formatter))
+		spiff.New(templateStateHandler, nil).WithInputFormatter(formatter))
 	errorList, bindings, err := tmpl.TemplateImportExecutions(
 		template.NewBlueprintExecutionOptions(
 			input.Installation,
@@ -174,7 +174,7 @@ func (r *BlueprintRenderer) RenderExportExecutions(input *ResolvedInstallation, 
 	formatter := template.NewTemplateInputFormatter(true)
 	tmpl := template.New(
 		gotemplate.New(templateStateHandler, nil).WithInputFormatter(formatter),
-		spiff.New(templateStateHandler).WithInputFormatter(formatter))
+		spiff.New(templateStateHandler, nil).WithInputFormatter(formatter))
 	exports, err := tmpl.TemplateExportExecutions(
 		template.NewExportExecutionOptions(
 			template.NewBlueprintExecutionOptions(
@@ -200,7 +200,7 @@ func (r *BlueprintRenderer) renderDeployItems(input *ResolvedInstallation, impor
 	formatter := template.NewTemplateInputFormatter(true)
 	tmpl := template.New(
 		gotemplate.New(templateStateHandler, nil).WithInputFormatter(formatter),
-		spiff.New(templateStateHandler).WithInputFormatter(formatter))
+		spiff.New(templateStateHandler, nil).WithInputFormatter(formatter))
 	executions, err := tmpl.TemplateDeployExecutions(
 		template.NewDeployExecutionOptions(
 			template.NewBlueprintExecutionOptions(
@@ -333,7 +333,7 @@ func (r *BlueprintRenderer) renderSubInstallations(input *ResolvedInstallation, 
 	formatter := template.NewTemplateInputFormatter(true)
 	tmpl := template.New(
 		gotemplate.New(templateStateHandler, nil).WithInputFormatter(formatter),
-		spiff.New(templateStateHandler).WithInputFormatter(formatter))
+		spiff.New(templateStateHandler, nil).WithInputFormatter(formatter))
 	subInstallationTemplates, err := tmpl.TemplateSubinstallationExecutions(
 		template.NewDeployExecutionOptions(
 			template.NewBlueprintExecutionOptions(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority 3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Besides the `getShootAdminKubeconfig` and `getServiceAccountKubeconfig` functions available when templating with `GoTemplate`, there are now additionally `getShootAdminKubeconfigWithExpirationTimestamp` and `getServiceAccountKubeconfigWithExpirationTimestamp` functions which work like their siblings, but return an object containing the kubeconfig as well as the token's expiration timestamp instead of returning the kubeconfig directly. All of the mentioned functions are now also available when using `Spiff` as templating engine.
```
