### PR TITLE
Fix blueprint docu

### DIFF
--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -176,15 +176,6 @@ Blueprints describe formal imports. A formal import parameter has a name and a *
   This type can be used if, instead of a single target object, an arbitrary number of targets should be imported. All targets imported as part of a targetlist import must have the same `targetType`. For more information on how to work with TargetList imports, see the documentation [here](./TargetLists.md).
 
 
-- **`componentDescriptor`**
-
-  This type refers to an import of a component descriptor.
-
-
-- **`componentDescriptorList`**
-
-  Analogous to `targetList`, this type allows importing an arbitrary number of component descriptors.
-
 The imports are described as a list of import declarations in the blueprint top-level field `imports`. An import declaration has the following fields:
 
 - **`name`** *string*
@@ -205,7 +196,7 @@ The imports are described as a list of import declarations in the blueprint top-
 
 - **`default`** *any*
 
-  If the import is not required and not provided by the installation, this default value will be used for it.
+  If the import is not required and not provided by the installation, this default value will be used for it. 
 
 
 - **`imports`** *list of import declarations*
@@ -239,8 +230,9 @@ imports:
       password:
         type: string
   default:
-    username: foo
-    password: bar
+    value: 
+      username: foo
+      password: bar
 - name: mycluster
   type: target
   targetType: kubernetes-cluster # will be defaulted to 'landscaper.gardener.cloud/kubernetes-cluster'
@@ -894,9 +886,6 @@ before putting it as regular installations into the landscaper data plane:
       target: "" # target name
     - name: ""
       targetListRef: "" # references a targetlist import of the parent
-    componentDescriptors:
-    - name: ""
-      dataRef: "" # references a component descriptor (single or list) import of the parent
   #importMappings: {}
 
   exports:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup
/priority 3

**What this PR does / why we need it**:

Fix blueprint docu.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- fix blueprint docu
```
