### PR TITLE
implement defaults for optional imports

### DIFF
--- a/pkg/landscaper/installations/error.go
+++ b/pkg/landscaper/installations/error.go
@@ -16,6 +16,7 @@ type ErrorReason string
 const (
 	ImportNotFound         ErrorReason = "ImportNotFound"
 	ImportNotSatisfied     ErrorReason = "ImportNotSatisfied"
+	InvalidDefaultValue    ErrorReason = "InvalidDefaultValue"
 	NotCompletedDependents ErrorReason = "NotCompletedDependents"
 	SchemaValidationFailed ErrorReason = "SchemaValidationFailed"
 )

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -146,6 +146,26 @@ var _ = Describe("Constructor", func() {
 		Expect(inInstRoot.GetImports()).To(Equal(expectedConfig))
 	})
 
+	It("should use defaults defined in blueprint for missing optional imports", func() {
+		ctx := context.Background()
+		inInstRoot, err := installations.CreateInternalInstallation(ctx, op.ComponentsRegistry(), fakeInstallations["test13/root"])
+		Expect(err).ToNot(HaveOccurred())
+		op.Inst = inInstRoot
+		Expect(op.ResolveComponentDescriptors(ctx)).To(Succeed())
+
+		expectedConfig := map[string]interface{}{
+			"defaulted": map[string]interface{}{
+				"foo": "bar",
+			},
+		}
+
+		Expect(op.SetInstallationContext(ctx)).To(Succeed())
+		c := imports.NewConstructor(op)
+		Expect(c.Construct(ctx, nil)).To(Succeed())
+		Expect(inInstRoot.GetImports()).ToNot(BeNil())
+		Expect(inInstRoot.GetImports()).To(Equal(expectedConfig))
+	})
+
 	Context("schema validation", func() {
 		It("should forbid when the import of a component does not satisfy the schema", func() {
 			ctx := context.Background()

--- a/pkg/landscaper/installations/imports/testdata/state/test13/00-root.yaml
+++ b/pkg/landscaper/installations/imports/testdata/state/test13/00-root.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root
+  namespace: test13
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: root-5

--- a/pkg/landscaper/installations/testdata/registry/blobs/root-5/blueprint.yaml
+++ b/pkg/landscaper/installations/testdata/registry/blobs/root-5/blueprint.yaml
@@ -10,11 +10,14 @@ annotations:
   local/version: 1.0.0
 
 imports:
-- name: cd-from-registry
-  type: componentDescriptor
-- name: cd-from-configmap
-  type: componentDescriptor
-- name: cd-from-secret
-  type: componentDescriptor
-- name: cdlist
-  type: componentDescriptorList
+- name: defaulted
+  type: data
+  schema:
+    type: object
+    properties:
+      foo:
+        type: string
+  required: false
+  default:
+    value:
+      foo: bar


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority 3

**What this PR does / why we need it**:
According to our documentation, optional data imports can be given a default value which will be used if the import is not satisfied otherwise. This PR makes it actually work.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Default values defined in blueprints for optional data imports are now added to the imports as expected.
```
