### PR TITLE
Obsolete field for registry pull secrets in installations

### DIFF
--- a/apis/core/types_deployitem.go
+++ b/apis/core/types_deployitem.go
@@ -55,12 +55,6 @@ type DeployItemSpec struct {
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 	// Timeout specifies how long the deployer may take to apply the deploy item.
 	// When the time is exceeded, the deploy item fails.
 	// Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout).

--- a/apis/core/types_execution.go
+++ b/apis/core/types_execution.go
@@ -63,13 +63,6 @@ type ExecutionSpec struct {
 
 	// DeployItemsCompressed as zipped byte array
 	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
-
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/apis/core/types_installation.go
+++ b/apis/core/types_installation.go
@@ -54,13 +54,6 @@ type InstallationSpec struct {
 	// Blueprint is the resolved reference to the definition.
 	Blueprint BlueprintDefinition `json:"blueprint"`
 
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
-
 	// Imports define the imported data objects and targets.
 	// +optional
 	Imports InstallationImports `json:"imports,omitempty"`

--- a/apis/core/v1alpha1/conversion.go
+++ b/apis/core/v1alpha1/conversion.go
@@ -44,7 +44,6 @@ func Convert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out
 	if err := Convert_v1alpha1_DeployItemTemplateList_To_core_DeployItemTemplateList((*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems)), (*core.DeployItemTemplateList)(unsafe.Pointer(&out.DeployItems)), s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
@@ -53,7 +52,6 @@ func Convert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec
 	if err := Convert_core_DeployItemTemplateList_To_v1alpha1_DeployItemTemplateList((*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems)), (*DeployItemTemplateList)(unsafe.Pointer(&out.DeployItems)), s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 

--- a/apis/core/v1alpha1/types_deployitem.go
+++ b/apis/core/v1alpha1/types_deployitem.go
@@ -149,12 +149,6 @@ type DeployItemSpec struct {
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 	// Timeout specifies how long the deployer may take to apply the deploy item.
 	// When the time is exceeded, the deploy item fails.
 	// Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout).

--- a/apis/core/v1alpha1/types_execution.go
+++ b/apis/core/v1alpha1/types_execution.go
@@ -164,13 +164,6 @@ type ExecutionSpec struct {
 
 	// DeployItemsCompressed as zipped byte array
 	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
-
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/apis/core/v1alpha1/types_installation.go
+++ b/apis/core/v1alpha1/types_installation.go
@@ -183,13 +183,6 @@ type InstallationSpec struct {
 	// Blueprint is the resolved reference to the definition.
 	Blueprint BlueprintDefinition `json:"blueprint"`
 
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
-
 	// Imports define the imported data objects and targets.
 	// +optional
 	Imports InstallationImports `json:"imports,omitempty"`

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2543,7 +2543,6 @@ func autoConvert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *Installa
 	if err := Convert_v1alpha1_BlueprintDefinition_To_core_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	if err := Convert_v1alpha1_InstallationImports_To_core_InstallationImports(&in.Imports, &out.Imports, s); err != nil {
 		return err
 	}
@@ -2567,7 +2566,6 @@ func autoConvert_core_InstallationSpec_To_v1alpha1_InstallationSpec(in *core.Ins
 	if err := Convert_core_BlueprintDefinition_To_v1alpha1_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	if err := Convert_core_InstallationImports_To_v1alpha1_InstallationImports(&in.Imports, &out.Imports, s); err != nil {
 		return err
 	}

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1712,7 +1712,6 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
 	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	out.OnDelete = (*core.OnDeleteConfig)(unsafe.Pointer(in.OnDelete))
@@ -1729,7 +1728,6 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
 	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	out.OnDelete = (*OnDeleteConfig)(unsafe.Pointer(in.OnDelete))

--- a/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2219,7 +2219,6 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
@@ -2227,7 +2226,6 @@ func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.Execution
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1663,11 +1663,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Blueprint.DeepCopyInto(&out.Blueprint)
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	in.Imports.DeepCopyInto(&out.Imports)
 	if in.ImportDataMappings != nil {
 		in, out := &in.ImportDataMappings, &out.ImportDataMappings

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -747,11 +747,6 @@ func (in *DeployItemSpec) DeepCopyInto(out *DeployItemSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1284,11 +1284,6 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/apis/core/validation/installation.go
+++ b/apis/core/validation/installation.go
@@ -55,9 +55,6 @@ func ValidateInstallationSpec(spec *core.InstallationSpec, fldPath *field.Path) 
 	allErrs = append(allErrs, ValidateInstallationBlueprint(spec.Blueprint, fldPath.Child("blueprint"))...)
 	allErrs = append(allErrs, ValidateInstallationComponentDescriptor(spec.ComponentDescriptor, fldPath.Child("componentDescriptor"))...)
 
-	// check RegistryPullSecrets
-	allErrs = append(allErrs, ValidateObjectReferenceList(spec.RegistryPullSecrets, fldPath.Child("registryPullSecrets"))...)
-
 	return allErrs
 }
 

--- a/apis/core/zz_generated.deepcopy.go
+++ b/apis/core/zz_generated.deepcopy.go
@@ -1663,11 +1663,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Blueprint.DeepCopyInto(&out.Blueprint)
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	in.Imports.DeepCopyInto(&out.Imports)
 	if in.ImportDataMappings != nil {
 		in, out := &in.ImportDataMappings, &out.ImportDataMappings

--- a/apis/core/zz_generated.deepcopy.go
+++ b/apis/core/zz_generated.deepcopy.go
@@ -747,11 +747,6 @@ func (in *DeployItemSpec) DeepCopyInto(out *DeployItemSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/apis/core/zz_generated.deepcopy.go
+++ b/apis/core/zz_generated.deepcopy.go
@@ -1284,11 +1284,6 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -5205,25 +5205,11 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 							Format:      "byte",
 						},
 					},
-					"registryPullSecrets": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.DeployItemTemplate", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.DeployItemTemplate"},
 	}
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -5839,20 +5839,6 @@ func schema_landscaper_apis_core_v1alpha1_InstallationSpec(ref common.ReferenceC
 							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.BlueprintDefinition"),
 						},
 					},
-					"registryPullSecrets": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
-									},
-								},
-							},
-						},
-					},
 					"imports": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Imports define the imported data objects and targets.",
@@ -5906,7 +5892,7 @@ func schema_landscaper_apis_core_v1alpha1_InstallationSpec(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.AnyJSON", "github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcile", "github.com/gardener/landscaper/apis/core/v1alpha1.BlueprintDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.ComponentDescriptorDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationExports", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationImports", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.AnyJSON", "github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcile", "github.com/gardener/landscaper/apis/core/v1alpha1.BlueprintDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.ComponentDescriptorDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationExports", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationImports"},
 	}
 }
 

--- a/apis/openapi/openapi_generated.go
+++ b/apis/openapi/openapi_generated.go
@@ -4307,20 +4307,6 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
-					"registryPullSecrets": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
-									},
-								},
-							},
-						},
-					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timeout specifies how long the deployer may take to apply the deploy item. When the time is exceeded, the deploy item fails. Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout). Defaults to ten minutes if not specified.",

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -55,12 +55,6 @@ type DeployItemSpec struct {
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 	// Timeout specifies how long the deployer may take to apply the deploy item.
 	// When the time is exceeded, the deploy item fails.
 	// Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout).

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -63,13 +63,6 @@ type ExecutionSpec struct {
 
 	// DeployItemsCompressed as zipped byte array
 	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
-
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -54,13 +54,6 @@ type InstallationSpec struct {
 	// Blueprint is the resolved reference to the definition.
 	Blueprint BlueprintDefinition `json:"blueprint"`
 
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
-
 	// Imports define the imported data objects and targets.
 	// +optional
 	Imports InstallationImports `json:"imports,omitempty"`

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/conversion.go
@@ -44,7 +44,6 @@ func Convert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out
 	if err := Convert_v1alpha1_DeployItemTemplateList_To_core_DeployItemTemplateList((*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems)), (*core.DeployItemTemplateList)(unsafe.Pointer(&out.DeployItems)), s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
@@ -53,7 +52,6 @@ func Convert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec
 	if err := Convert_core_DeployItemTemplateList_To_v1alpha1_DeployItemTemplateList((*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems)), (*DeployItemTemplateList)(unsafe.Pointer(&out.DeployItems)), s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -149,12 +149,6 @@ type DeployItemSpec struct {
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 	// Timeout specifies how long the deployer may take to apply the deploy item.
 	// When the time is exceeded, the deploy item fails.
 	// Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout).

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -164,13 +164,6 @@ type ExecutionSpec struct {
 
 	// DeployItemsCompressed as zipped byte array
 	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
-
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -183,13 +183,6 @@ type InstallationSpec struct {
 	// Blueprint is the resolved reference to the definition.
 	Blueprint BlueprintDefinition `json:"blueprint"`
 
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
-
 	// Imports define the imported data objects and targets.
 	// +optional
 	Imports InstallationImports `json:"imports,omitempty"`

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2543,7 +2543,6 @@ func autoConvert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *Installa
 	if err := Convert_v1alpha1_BlueprintDefinition_To_core_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	if err := Convert_v1alpha1_InstallationImports_To_core_InstallationImports(&in.Imports, &out.Imports, s); err != nil {
 		return err
 	}
@@ -2567,7 +2566,6 @@ func autoConvert_core_InstallationSpec_To_v1alpha1_InstallationSpec(in *core.Ins
 	if err := Convert_core_BlueprintDefinition_To_v1alpha1_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	if err := Convert_core_InstallationImports_To_v1alpha1_InstallationImports(&in.Imports, &out.Imports, s); err != nil {
 		return err
 	}

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1712,7 +1712,6 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
 	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	out.OnDelete = (*core.OnDeleteConfig)(unsafe.Pointer(in.OnDelete))
@@ -1729,7 +1728,6 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
 	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	out.OnDelete = (*OnDeleteConfig)(unsafe.Pointer(in.OnDelete))

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2219,7 +2219,6 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
@@ -2227,7 +2226,6 @@ func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.Execution
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1663,11 +1663,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Blueprint.DeepCopyInto(&out.Blueprint)
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	in.Imports.DeepCopyInto(&out.Imports)
 	if in.ImportDataMappings != nil {
 		in, out := &in.ImportDataMappings, &out.ImportDataMappings

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -747,11 +747,6 @@ func (in *DeployItemSpec) DeepCopyInto(out *DeployItemSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1284,11 +1284,6 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1663,11 +1663,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Blueprint.DeepCopyInto(&out.Blueprint)
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	in.Imports.DeepCopyInto(&out.Imports)
 	if in.ImportDataMappings != nil {
 		in, out := &in.ImportDataMappings, &out.ImportDataMappings

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -747,11 +747,6 @@ func (in *DeployItemSpec) DeepCopyInto(out *DeployItemSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1284,11 +1284,6 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -951,23 +951,6 @@ DeployItemTemplateList
 <p>DeployItemsCompressed as zipped byte array</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>registryPullSecrets</code></br>
-<em>
-<a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
-[]ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RegistryPullSecrets defines a list of registry credentials that are used to
-pull blueprints, component descriptors and jsonschemas from the respective registry.
-For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
-Note that the type information is used to determine the secret key and the type of the secret.</p>
-</td>
-</tr>
 </table>
 </td>
 </tr>
@@ -3731,23 +3714,6 @@ DeployItemTemplateList
 <p>DeployItemsCompressed as zipped byte array</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>registryPullSecrets</code></br>
-<em>
-<a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
-[]ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RegistryPullSecrets defines a list of registry credentials that are used to
-pull blueprints, component descriptors and jsonschemas from the respective registry.
-For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
-Note that the type information is used to determine the secret key and the type of the secret.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="landscaper.gardener.cloud/v1alpha1.ExecutionStatus">ExecutionStatus
@@ -5024,7 +4990,6 @@ ObjectReference
 <a href="#landscaper.gardener.cloud/v1alpha1.DeployItemSpec">DeployItemSpec</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.DeployItemStatus">DeployItemStatus</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.DeployItemTemplate">DeployItemTemplate</a>, 
-<a href="#landscaper.gardener.cloud/v1alpha1.ExecutionSpec">ExecutionSpec</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.ExecutionStatus">ExecutionStatus</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.ImportStatus">ImportStatus</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.InstallationStatus">InstallationStatus</a>, 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1086,23 +1086,6 @@ BlueprintDefinition
 </tr>
 <tr>
 <td>
-<code>registryPullSecrets</code></br>
-<em>
-<a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
-[]ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RegistryPullSecrets defines a list of registry credentials that are used to
-pull blueprints, component descriptors and jsonschemas from the respective registry.
-For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
-Note that the type information is used to determine the secret key and the type of the secret.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>imports</code></br>
 <em>
 <a href="#landscaper.gardener.cloud/v1alpha1.InstallationImports">
@@ -4527,23 +4510,6 @@ BlueprintDefinition
 </tr>
 <tr>
 <td>
-<code>registryPullSecrets</code></br>
-<em>
-<a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
-[]ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RegistryPullSecrets defines a list of registry credentials that are used to
-pull blueprints, component descriptors and jsonschemas from the respective registry.
-For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
-Note that the type information is used to determine the secret key and the type of the secret.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>imports</code></br>
 <em>
 <a href="#landscaper.gardener.cloud/v1alpha1.InstallationImports">
@@ -5061,7 +5027,6 @@ ObjectReference
 <a href="#landscaper.gardener.cloud/v1alpha1.ExecutionSpec">ExecutionSpec</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.ExecutionStatus">ExecutionStatus</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.ImportStatus">ImportStatus</a>, 
-<a href="#landscaper.gardener.cloud/v1alpha1.InstallationSpec">InstallationSpec</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.InstallationStatus">InstallationStatus</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.NamedObjectReference">NamedObjectReference</a>, 
 <a href="#landscaper.gardener.cloud/v1alpha1.SecretReference">SecretReference</a>, 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -563,23 +563,6 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </tr>
 <tr>
 <td>
-<code>registryPullSecrets</code></br>
-<em>
-<a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
-[]ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RegistryPullSecrets defines a list of registry credentials that are used to
-pull blueprints, component descriptors and jsonschemas from the respective registry.
-For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
-Note that the type information is used to determine the secret key and the type of the secret.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>timeout</code></br>
 <em>
 <a href="#landscaper.gardener.cloud/v1alpha1.Duration">
@@ -2773,23 +2756,6 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </td>
 <td>
 <p>Configuration contains the deployer type specific configuration.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>registryPullSecrets</code></br>
-<em>
-<a href="#landscaper.gardener.cloud/v1alpha1.ObjectReference">
-[]ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>RegistryPullSecrets defines a list of registry credentials that are used to
-pull blueprints, component descriptors and jsonschemas from the respective registry.
-For more info see: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/">https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</a>
-Note that the type information is used to determine the secret key and the type of the secret.</p>
 </td>
 </tr>
 <tr>

--- a/docs/proposals/feature-coverage.md
+++ b/docs/proposals/feature-coverage.md
@@ -137,8 +137,7 @@ The blueprint of an installation can be given:
 Subinstallations, deploy executions, export executions can be defined in separate files or in the blueprint.yaml
 
 Pulling a blueprint, component descriptor or jsonschema using a registry pull secret
-- from field `registryPullSecrets` of the installation spec
-- from field `registryPullSecrets` of the `Context` referenced in the `Installation`
+from field `registryPullSecrets` of the `Context` referenced in the `Installation`
 
 
 

--- a/examples/30-Example-Installation.yaml
+++ b/examples/30-Example-Installation.yaml
@@ -18,11 +18,6 @@ spec:
       componentName: github.com/gardener/virtual-cluster
       version: v1.7.2
 
-#  # additional pull secrets to access component descriptors and blueprints
-#  # is deprecated and should be defined in the context instead.
-#  registryPullSecrets: # additional pull secrets to access component descriptors and blueprints
-#  - name: my-pullsecret
-
   blueprint: # will be read from the component descriptor
     ref:
       resourceName: my-installation-blueprint

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -527,24 +527,6 @@ func (c *Container) parseAndSyncSecrets(ctx context.Context, defaultLabels map[s
 		}
 	}
 
-	for _, secretRef := range c.DeployItem.Spec.RegistryPullSecrets {
-		secret := &corev1.Secret{}
-
-		err := c.lsClient.Get(ctx, secretRef.NamespacedName(), secret)
-		if err != nil {
-			log.Debug("Unable to get auth config from secret, skipping", lc.KeyResource, secretRef.NamespacedName().String(), lc.KeyError, err.Error())
-		}
-		authConfig, err := dockerconfig.LoadFromReader(bytes.NewBuffer(secret.Data[corev1.DockerConfigJsonKey]))
-		if err != nil {
-			log.Debug("Invalid auth config in secret, skipping", lc.KeyResource, secretRef.NamespacedName().String(), lc.KeyError, err.Error())
-			continue
-		}
-		if err := ociKeyring.Add(authConfig.GetCredentialsStore("")); err != nil {
-			erro = fmt.Errorf("unable to add config from secret %q to credentials store: %w", secretRef.NamespacedName().String(), err)
-			return
-		}
-	}
-
 	var err error
 	imagePullSecret, err = c.syncSecrets(ctx, ImagePullSecretName(c.DeployItem.Namespace, c.DeployItem.Name), c.ProviderConfiguration.Image, ociKeyring, defaultLabels)
 	if err != nil {

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -126,7 +126,7 @@ func (h *Helm) Template(ctx context.Context) (map[string]string, map[string]stri
 	// todo: do caching of charts
 
 	// resolve all registry pull secrets
-	registryPullSecretRefs := append(lib.GetRegistryPullSecretsFromContext(h.Context), h.DeployItem.Spec.RegistryPullSecrets...)
+	registryPullSecretRefs := lib.GetRegistryPullSecretsFromContext(h.Context)
 	registryPullSecrets, err := kutil.ResolveSecrets(ctx, h.lsKubeClient, registryPullSecretRefs)
 	if err != nil {
 		return nil, nil, nil, nil, lserrors.NewWrappedError(err, currOp, "ResolveSecrets", err.Error())

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -265,7 +265,8 @@ func (c *Controller) initPrerequisites(ctx context.Context, inst *lsv1alpha1.Ins
 		return nil, lserrors.NewWrappedError(err, currOp, "CalculateContext", err.Error())
 	}
 
-	if err := c.SetupRegistries(ctx, op, append(lsCtx.External.RegistryPullSecrets(), inst.Spec.RegistryPullSecrets...), inst); err != nil {
+	if err := c.SetupRegistries(ctx, op, lsCtx.External.RegistryPullSecrets(), inst); err != nil {
+
 		return nil, lserrors.NewWrappedError(err, currOp, "SetupRegistries", err.Error())
 	}
 

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_deployitems.yaml
@@ -54,25 +54,6 @@ spec:
                       to check the Garden project with the shoot cluster resources
                     type: boolean
                 type: object
-              registryPullSecrets:
-                description: 'RegistryPullSecrets defines a list of registry credentials
-                  that are used to pull blueprints, component descriptors and jsonschemas
-                  from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-                  Note that the type information is used to determine the secret key
-                  and the type of the secret.'
-                items:
-                  description: ObjectReference is the reference to a kubernetes object.
-                  properties:
-                    name:
-                      description: Name is the name of the kubernetes object.
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of kubernetes object.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
               target:
                 description: Target specifies an optional target of the deploy item.
                   In most cases it contains the secrets to access a evironment. It

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_executions.yaml
@@ -113,25 +113,6 @@ spec:
                 description: DeployItemsCompressed as zipped byte array
                 format: byte
                 type: string
-              registryPullSecrets:
-                description: 'RegistryPullSecrets defines a list of registry credentials
-                  that are used to pull blueprints, component descriptors and jsonschemas
-                  from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-                  Note that the type information is used to determine the secret key
-                  and the type of the secret.'
-                items:
-                  description: ObjectReference is the reference to a kubernetes object.
-                  properties:
-                    name:
-                      description: Name is the name of the kubernetes object.
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of kubernetes object.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
             type: object
           status:
             description: Status contains the current status of the execution.

--- a/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
+++ b/pkg/landscaper/crdmanager/crdresources/landscaper.gardener.cloud_installations.yaml
@@ -615,25 +615,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              registryPullSecrets:
-                description: 'RegistryPullSecrets defines a list of registry credentials
-                  that are used to pull blueprints, component descriptors and jsonschemas
-                  from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-                  Note that the type information is used to determine the secret key
-                  and the type of the secret.'
-                items:
-                  description: ObjectReference is the reference to a kubernetes object.
-                  properties:
-                    name:
-                      description: Name is the name of the kubernetes object.
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of kubernetes object.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
             required:
             - blueprint
             type: object

--- a/pkg/landscaper/execution/reconcile.go
+++ b/pkg/landscaper/execution/reconcile.go
@@ -47,7 +47,6 @@ func (o *Operation) updateDeployItem(ctx context.Context, item executionItem) ls
 		item.DeployItem.GenerateName = fmt.Sprintf("%s-%s-", o.exec.Name, item.Info.Name)
 		item.DeployItem.Namespace = o.exec.Namespace
 	}
-	item.DeployItem.Spec.RegistryPullSecrets = o.exec.Spec.RegistryPullSecrets
 
 	if _, err := o.Writer().CreateOrUpdateDeployItem(ctx, read_write_layer.W000036, item.DeployItem, func() error {
 		ApplyDeployItemTemplate(item.DeployItem, item.Info)

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -157,7 +157,6 @@ func (o *ExecutionOperation) Ensure(ctx context.Context, inst *installations.Ins
 	exec := &lsv1alpha1.Execution{}
 	exec.Name = inst.GetInstallation().Name
 	exec.Namespace = inst.GetInstallation().Namespace
-	exec.Spec.RegistryPullSecrets = inst.GetInstallation().Spec.RegistryPullSecrets
 
 	versionedDeployItemTemplateList := lsv1alpha1.DeployItemTemplateList{}
 	if err := lsv1alpha1.Convert_core_DeployItemTemplateList_To_v1alpha1_DeployItemTemplateList(&execTemplates, &versionedDeployItemTemplateList, nil); err != nil {

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -287,7 +287,6 @@ func (o *Operation) createOrUpdateNewInstallation(ctx context.Context,
 		}
 		subInst.Spec = lsv1alpha1.InstallationSpec{
 			Context:             inst.Spec.Context,
-			RegistryPullSecrets: inst.Spec.RegistryPullSecrets,
 			ComponentDescriptor: subCdDef,
 			Blueprint:           *subBlueprint,
 			Imports:             subInstTmpl.Imports,

--- a/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_deployitem.go
@@ -55,12 +55,6 @@ type DeployItemSpec struct {
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 	// Timeout specifies how long the deployer may take to apply the deploy item.
 	// When the time is exceeded, the deploy item fails.
 	// Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout).

--- a/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_execution.go
@@ -63,13 +63,6 @@ type ExecutionSpec struct {
 
 	// DeployItemsCompressed as zipped byte array
 	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
-
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/types_installation.go
@@ -54,13 +54,6 @@ type InstallationSpec struct {
 	// Blueprint is the resolved reference to the definition.
 	Blueprint BlueprintDefinition `json:"blueprint"`
 
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
-
 	// Imports define the imported data objects and targets.
 	// +optional
 	Imports InstallationImports `json:"imports,omitempty"`

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/conversion.go
@@ -44,7 +44,6 @@ func Convert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec, out
 	if err := Convert_v1alpha1_DeployItemTemplateList_To_core_DeployItemTemplateList((*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems)), (*core.DeployItemTemplateList)(unsafe.Pointer(&out.DeployItems)), s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
@@ -53,7 +52,6 @@ func Convert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.ExecutionSpec
 	if err := Convert_core_DeployItemTemplateList_To_v1alpha1_DeployItemTemplateList((*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems)), (*DeployItemTemplateList)(unsafe.Pointer(&out.DeployItems)), s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_deployitem.go
@@ -149,12 +149,6 @@ type DeployItemSpec struct {
 	Context string `json:"context,omitempty"`
 	// Configuration contains the deployer type specific configuration.
 	Configuration *runtime.RawExtension `json:"config,omitempty"`
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 	// Timeout specifies how long the deployer may take to apply the deploy item.
 	// When the time is exceeded, the deploy item fails.
 	// Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout).

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_execution.go
@@ -164,13 +164,6 @@ type ExecutionSpec struct {
 
 	// DeployItemsCompressed as zipped byte array
 	DeployItemsCompressed []byte `json:"deployItemsCompressed,omitempty"`
-
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
 }
 
 // ExecutionStatus contains the current status of a execution.

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_installation.go
@@ -183,13 +183,6 @@ type InstallationSpec struct {
 	// Blueprint is the resolved reference to the definition.
 	Blueprint BlueprintDefinition `json:"blueprint"`
 
-	// RegistryPullSecrets defines a list of registry credentials that are used to
-	// pull blueprints, component descriptors and jsonschemas from the respective registry.
-	// For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-	// Note that the type information is used to determine the secret key and the type of the secret.
-	// +optional
-	RegistryPullSecrets []ObjectReference `json:"registryPullSecrets,omitempty"`
-
 	// Imports define the imported data objects and targets.
 	// +optional
 	Imports InstallationImports `json:"imports,omitempty"`

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2543,7 +2543,6 @@ func autoConvert_v1alpha1_InstallationSpec_To_core_InstallationSpec(in *Installa
 	if err := Convert_v1alpha1_BlueprintDefinition_To_core_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	if err := Convert_v1alpha1_InstallationImports_To_core_InstallationImports(&in.Imports, &out.Imports, s); err != nil {
 		return err
 	}
@@ -2567,7 +2566,6 @@ func autoConvert_core_InstallationSpec_To_v1alpha1_InstallationSpec(in *core.Ins
 	if err := Convert_core_BlueprintDefinition_To_v1alpha1_BlueprintDefinition(&in.Blueprint, &out.Blueprint, s); err != nil {
 		return err
 	}
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	if err := Convert_core_InstallationImports_To_v1alpha1_InstallationImports(&in.Imports, &out.Imports, s); err != nil {
 		return err
 	}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1712,7 +1712,6 @@ func autoConvert_v1alpha1_DeployItemSpec_To_core_DeployItemSpec(in *DeployItemSp
 	out.Target = (*core.ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*core.Duration)(unsafe.Pointer(in.Timeout))
 	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	out.OnDelete = (*core.OnDeleteConfig)(unsafe.Pointer(in.OnDelete))
@@ -1729,7 +1728,6 @@ func autoConvert_core_DeployItemSpec_To_v1alpha1_DeployItemSpec(in *core.DeployI
 	out.Target = (*ObjectReference)(unsafe.Pointer(in.Target))
 	out.Context = in.Context
 	out.Configuration = (*runtime.RawExtension)(unsafe.Pointer(in.Configuration))
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	out.Timeout = (*Duration)(unsafe.Pointer(in.Timeout))
 	out.UpdateOnChangeOnly = in.UpdateOnChangeOnly
 	out.OnDelete = (*OnDeleteConfig)(unsafe.Pointer(in.OnDelete))

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2219,7 +2219,6 @@ func autoConvert_v1alpha1_ExecutionSpec_To_core_ExecutionSpec(in *ExecutionSpec,
 	out.Context = in.Context
 	out.DeployItems = *(*core.DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
-	out.RegistryPullSecrets = *(*[]core.ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 
@@ -2227,7 +2226,6 @@ func autoConvert_core_ExecutionSpec_To_v1alpha1_ExecutionSpec(in *core.Execution
 	out.Context = in.Context
 	out.DeployItems = *(*DeployItemTemplateList)(unsafe.Pointer(&in.DeployItems))
 	out.DeployItemsCompressed = *(*[]byte)(unsafe.Pointer(&in.DeployItemsCompressed))
-	out.RegistryPullSecrets = *(*[]ObjectReference)(unsafe.Pointer(&in.RegistryPullSecrets))
 	return nil
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1663,11 +1663,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Blueprint.DeepCopyInto(&out.Blueprint)
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	in.Imports.DeepCopyInto(&out.Imports)
 	if in.ImportDataMappings != nil {
 		in, out := &in.ImportDataMappings, &out.ImportDataMappings

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -747,11 +747,6 @@ func (in *DeployItemSpec) DeepCopyInto(out *DeployItemSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1284,11 +1284,6 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/validation/installation.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/validation/installation.go
@@ -55,9 +55,6 @@ func ValidateInstallationSpec(spec *core.InstallationSpec, fldPath *field.Path) 
 	allErrs = append(allErrs, ValidateInstallationBlueprint(spec.Blueprint, fldPath.Child("blueprint"))...)
 	allErrs = append(allErrs, ValidateInstallationComponentDescriptor(spec.ComponentDescriptor, fldPath.Child("componentDescriptor"))...)
 
-	// check RegistryPullSecrets
-	allErrs = append(allErrs, ValidateObjectReferenceList(spec.RegistryPullSecrets, fldPath.Child("registryPullSecrets"))...)
-
 	return allErrs
 }
 

--- a/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1663,11 +1663,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Blueprint.DeepCopyInto(&out.Blueprint)
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	in.Imports.DeepCopyInto(&out.Imports)
 	if in.ImportDataMappings != nil {
 		in, out := &in.ImportDataMappings, &out.ImportDataMappings

--- a/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -747,11 +747,6 @@ func (in *DeployItemSpec) DeepCopyInto(out *DeployItemSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/zz_generated.deepcopy.go
@@ -1284,11 +1284,6 @@ func (in *ExecutionSpec) DeepCopyInto(out *ExecutionSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.RegistryPullSecrets != nil {
-		in, out := &in.RegistryPullSecrets, &out.RegistryPullSecrets
-		*out = make([]ObjectReference, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind task
/priority 3

**What this PR does / why we need it**:

The Installation custom resource has a field `spec.registryPullSecrets`. This field is obsolete. Instead the corresponding field in the Context custom resource should be used. Moreover, the field was not correctly propagated to sub-objects.

This pull request removes the field from the Installation, Execution, and DeployItem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
- deprecated registryPullSecrets field in Installations removed
```
