### PR TITLE
Fix pipeline

### DIFF
--- a/.ci/int-test
+++ b/.ci/int-test
@@ -16,6 +16,9 @@ set -o pipefail
 PR_ID=$1
 export PR_ID
 
+USE_OCM_LIB=$2
+export USE_OCM_LIB
+
 SOURCE_PATH="$(dirname $0)/.."
 cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"

--- a/.ci/int-test
+++ b/.ci/int-test
@@ -25,6 +25,7 @@ SOURCE_PATH="$(pwd)"
 export SOURCE_PATH
 
 echo "Starting Landscaper integration tests in $SOURCE_PATH"
+echo " with use_ocm_lib $USE_OCM_LIB"
 
 # install bash for the get version command
 if ! which bash 1>/dev/null; then

--- a/.ci/int-test-helper/create-shoot-cluster
+++ b/.ci/int-test-helper/create-shoot-cluster
@@ -22,6 +22,7 @@ cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"
 
 echo "Run create Gardener shoot cluster in ${SOURCE_PATH}"
+echo " with use-ocm-lib ${USE_OCM_LIB}"
 
 go run -mod=vendor ./hack/testcluster shootcluster create \
     --kubeconfig=$GARDENER_KUBECONFIG_PATH \
@@ -30,5 +31,5 @@ go run -mod=vendor ./hack/testcluster shootcluster create \
     --max-num-cluster=$MAX_NUM_CLUSTERS \
     --num-clusters-start-delete-oldest=$NUM_CLUSTERS_START_DELETE_OLDEST \
     --duration-for-cluster-deletion=$DURATION_FOR_CLUSTER_DELETION \
-    --pr-id=$PR_ID
+    --pr-id=$PR_ID \
     --use-ocm-lib=$USE_OCM_LIB

--- a/.ci/int-test-helper/create-shoot-cluster
+++ b/.ci/int-test-helper/create-shoot-cluster
@@ -15,6 +15,7 @@ MAX_NUM_CLUSTERS=$4
 NUM_CLUSTERS_START_DELETE_OLDEST=$5
 DURATION_FOR_CLUSTER_DELETION=$6
 PR_ID=$7
+USE_OCM_LIB=$8
 
 SOURCE_PATH="$(dirname $0)/../.."
 cd "${SOURCE_PATH}"
@@ -30,3 +31,4 @@ go run -mod=vendor ./hack/testcluster shootcluster create \
     --num-clusters-start-delete-oldest=$NUM_CLUSTERS_START_DELETE_OLDEST \
     --duration-for-cluster-deletion=$DURATION_FOR_CLUSTER_DELETION \
     --pr-id=$PR_ID
+    --use-ocm-lib=$USE_OCM_LIB

--- a/.ci/int-test-helper/install-landscaper
+++ b/.ci/int-test-helper/install-landscaper
@@ -11,6 +11,7 @@ set -o pipefail
 KUBECONFIG_PATH=$1
 VERSION=$2
 TMP=$3
+USE_OCM_LIB=$4
 
 SOURCE_PATH="$(dirname $0)/../.."
 cd "${SOURCE_PATH}"
@@ -45,6 +46,7 @@ landscaper:
     deployItemTimeouts:
       pickup: 30s
       abort: 30s
+    useOCMLib: $USE_OCM_LIB
 " > $TMP/values.yaml
 
 touch $TMP/registry-values.yaml

--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -9,6 +9,8 @@
 # is integrated in the test cluster name indicating that the tests were triggered by a head update commit or a new release.
 # The cluster name has the format it-pr1-<4-digits>.
 
+USE_OCM_LIB="true"
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -24,5 +26,5 @@ cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"
 export SOURCE_PATH
 
-./.ci/int-test "1" | tee $FULL_INTEGRATION_TEST_PATH/ttt.log
+./.ci/int-test "1" $USE_OCM_LIB | tee $FULL_INTEGRATION_TEST_PATH/ttt.log
 

--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -9,7 +9,7 @@
 # is integrated in the test cluster name indicating that the tests were triggered by a head update commit or a new release.
 # The cluster name has the format it-pr1-<4-digits>.
 
-USE_OCM_LIB="true"
+USE_OCM_LIB=$1
 
 set -o errexit
 set -o nounset

--- a/.ci/integration-test-new
+++ b/.ci/integration-test-new
@@ -8,6 +8,8 @@
 # In that case, the integration tests are executed by calling ./.ci/int-test. The parameter $PR_ID is integrated in the
 # test cluster name. The cluster name has the format it-pr$PR_ID-<4-digits>.
 
+USE_OCM_LIB=$1
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -32,7 +34,7 @@ echo "git comment: " $GIT_COMMENT
 
 if git show -s --format=%s | grep run-int-tests; then
     echo "integration tests should be started"
-    ./.ci/int-test $PR_ID
+    ./.ci/int-test $PR_ID $USE_OCM_LIB
 else
     echo "integration tests are skipped"
 fi

--- a/.ci/local-integration-test
+++ b/.ci/local-integration-test
@@ -26,6 +26,8 @@ set -o pipefail
 
 KUBECONFIG_PATH=$1
 VERSION=$2
+USE_OCM_LIB=$3
+
 SOURCE_PATH="$(dirname $0)/.."
 cd "${SOURCE_PATH}"
 SOURCE_PATH="$(pwd)"
@@ -42,5 +44,5 @@ echo "Config directory: ${TMP}"
 
 ./.ci/int-test-helper/install-missing-software
 ./.ci/int-test-helper/create-registry $KUBECONFIG_PATH $TMP
-./.ci/int-test-helper/install-landscaper $KUBECONFIG_PATH ${VERSION} $TMP
+./.ci/int-test-helper/install-landscaper $KUBECONFIG_PATH ${VERSION} $TMP $USE_OCM_LIB
 ./.ci/int-test-helper/run-tests $KUBECONFIG_PATH $TMP/docker.config ${VERSION}

--- a/.ci/local-integration-test-with-cluster-creation
+++ b/.ci/local-integration-test-with-cluster-creation
@@ -49,6 +49,7 @@ GARDENER_KUBECONFIG_PATH=$1
 NAMESPACE=$2
 VERSION=$3
 PR_ID=$4
+USE_OCM_LIB=$5
 
 MAX_NUM_CLUSTERS=20
 NUM_CLUSTERS_START_DELETE_OLDEST=15
@@ -76,11 +77,12 @@ echo "Config directory: ${TMP}"
   $MAX_NUM_CLUSTERS \
   $NUM_CLUSTERS_START_DELETE_OLDEST \
   $DURATION_FOR_CLUSTER_DELETION \
-  $PR_ID
+  $PR_ID \
+  $USE_OCM_LIB
 
 KUBECONFIG_PATH=$TMP/kubeconfig.yaml
 echo "Test cluster kubeconfig path: ${KUBECONFIG_PATH}"
 
-./.ci/local-integration-test $KUBECONFIG_PATH $VERSION
+./.ci/local-integration-test $KUBECONFIG_PATH $VERSION $USE_OCM_LIB
 
 ./.ci/int-test-helper/delete-shoot-cluster $GARDENER_KUBECONFIG_PATH $NAMESPACE $TMP

--- a/.ci/local-integration-test-with-cluster-creation
+++ b/.ci/local-integration-test-with-cluster-creation
@@ -64,6 +64,7 @@ echo "Source path: ${SOURCE_PATH}"
 echo "Gardener kubeconfig path: ${GARDENER_KUBECONFIG_PATH}"
 echo "Shoot cluster namespace: ${NAMESPACE}"
 echo "Landscaper version: ${VERSION}"
+echo "Use OCM Lib ${USE_OCM_LIB}"
 
 TMP="${SOURCE_PATH}/tmp-int-test-cluster"
 rm -f -r $TMP

--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -22,6 +22,7 @@ from subprocess import run
 version = os.environ["VERSION"]
 source_path = os.environ["SOURCE_PATH"]
 pr_id = os.environ["PR_ID"]
+use_ocm_lib = os.environ["USE_OCM_LIB"]
 
 factory = ctx().cfg_factory()
 print("Starting integration tests with version " + version + " in sourcepath " + source_path)
@@ -32,7 +33,7 @@ with utils.TempFileAuto(prefix="landscape_kubeconfig_") as kubeconfig_temp_file:
     kubeconfig_temp_file.write(yaml.safe_dump(landscape_kubeconfig.kubeconfig()))
     landscape_kubeconfig_path = kubeconfig_temp_file.switch()
 
-    command = [source_path + "/.ci/local-integration-test-with-cluster-creation", landscape_kubeconfig_path, "garden-laas", version, pr_id]
+    command = [source_path + "/.ci/local-integration-test-with-cluster-creation", landscape_kubeconfig_path, "garden-laas", version, pr_id, use_ocm_lib]
 
     print("Executing command")
     run = run(command)

--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -26,6 +26,7 @@ use_ocm_lib = os.environ["USE_OCM_LIB"]
 
 factory = ctx().cfg_factory()
 print("Starting integration tests with version " + version + " in sourcepath " + source_path)
+print(" with use_ocm_lib ", use_ocm_lib)
 
 landscape_kubeconfig = factory.kubernetes("landscaper-integration-test")
 

--- a/hack/testcluster/pkg/shootcluster_manager.go
+++ b/hack/testcluster/pkg/shootcluster_manager.go
@@ -546,8 +546,8 @@ func (o *ShootClusterManager) deleteOutdatedShootCluster(ctx context.Context, ga
 		clusterNamePrefix := clusterName[:len(clusterName)-4]
 		newClusterNamePrefix := newClusterName[:len(newClusterName)-4]
 
-		libID := string(clusterName[3:4])
-		newLibID := string(newClusterName[3:4])
+		libID := clusterName[3:4]
+		newLibID := newClusterName[3:4]
 
 		if hasDeletionTimestamp {
 			continue

--- a/hack/testcluster/pkg/shootcluster_manager.go
+++ b/hack/testcluster/pkg/shootcluster_manager.go
@@ -42,6 +42,9 @@ const (
 	// prPrefix is the second part of shoot clusters used for integration tests
 	prPrefix = "pr"
 
+	ocmlibIdentifier = "o"
+	cnudieIdentifier = "c"
+
 	localStartPrefix = namePrefix + prPrefix + "0-"
 	headUpdatePrefix = namePrefix + prPrefix + "1-"
 
@@ -75,10 +78,12 @@ type ShootClusterManager struct {
 	numClustersStartDeleteOldest int
 	durationForClusterDeletion   time.Duration
 	prID                         string
+	useOCMLib                    bool
 }
 
 func NewShootClusterManager(log utils.Logger, gardenClusterKubeconfigPath, namespace,
-	authDirectoryPath string, maxNumOfClusters, numClustersStartDeleteOldest int, durationForClusterDeletion, prID string) (*ShootClusterManager, error) {
+	authDirectoryPath string, maxNumOfClusters, numClustersStartDeleteOldest int, durationForClusterDeletion, prID string,
+	useOCMLib bool) (*ShootClusterManager, error) {
 
 	log.Logfln("Create cluster manager with:")
 	log.Logfln("  GardenClusterKubeconfigPath: " + gardenClusterKubeconfigPath)
@@ -88,6 +93,7 @@ func NewShootClusterManager(log utils.Logger, gardenClusterKubeconfigPath, names
 	log.Logfln("  NumClustersStartDeleteOldest: " + strconv.Itoa(numClustersStartDeleteOldest))
 	log.Logfln("  DurationForClusterDeletion: " + durationForClusterDeletion)
 	log.Logfln("  PrID: " + prID)
+	log.Logfln("  UseOCMLib: " + strconv.FormatBool(useOCMLib))
 
 	duration, err := time.ParseDuration(durationForClusterDeletion)
 	if err != nil {
@@ -103,6 +109,7 @@ func NewShootClusterManager(log utils.Logger, gardenClusterKubeconfigPath, names
 		numClustersStartDeleteOldest: numClustersStartDeleteOldest,
 		durationForClusterDeletion:   duration,
 		prID:                         prID,
+		useOCMLib:                    useOCMLib,
 	}, nil
 }
 
@@ -254,7 +261,13 @@ func (o *ShootClusterManager) checkAndDeleteExistingTestShoots(ctx context.Conte
 }
 
 func (o *ShootClusterManager) generateShootName() string {
-	return namePrefix + prPrefix + o.prID + "-" + strconv.Itoa(rng.Intn(9000)+1000)
+	var libID string
+	if o.useOCMLib {
+		libID = ocmlibIdentifier
+	} else {
+		libID = cnudieIdentifier
+	}
+	return namePrefix + libID + "-" + prPrefix + o.prID + "-" + strconv.Itoa(rng.Intn(9000)+1000)
 }
 
 func (o *ShootClusterManager) matchesNamePattern(name string) bool {
@@ -533,10 +546,13 @@ func (o *ShootClusterManager) deleteOutdatedShootCluster(ctx context.Context, ga
 		clusterNamePrefix := clusterName[:len(clusterName)-4]
 		newClusterNamePrefix := newClusterName[:len(newClusterName)-4]
 
+		libID := string(clusterName[3:4])
+		newLibID := string(newClusterName[3:4])
+
 		if hasDeletionTimestamp {
 			continue
 		} else if !strings.HasPrefix(clusterName, localStartPrefix) && !strings.HasPrefix(clusterName, headUpdatePrefix) &&
-			clusterNamePrefix == newClusterNamePrefix {
+			clusterNamePrefix == newClusterNamePrefix && libID == newLibID {
 			o.log.Logfln("test shoot cluster %s will be deleted because a new test for the same PR is triggered", clusterName)
 
 			if err = o.deleteShootCluster(ctx, gardenClientForShoots, gardenClientForSecrets, clusterName); err != nil {

--- a/hack/testcluster/shootcluster_create.go
+++ b/hack/testcluster/shootcluster_create.go
@@ -43,6 +43,7 @@ type CreateShootClusterOptions struct {
 	NumClustersStartDeleteOldest int
 	DurationForClusterDeletion   string
 	PrID                         string
+	UseOCMLib                    bool
 }
 
 // AddFlags adds flags for the options to a flagset
@@ -58,6 +59,7 @@ func (o *CreateShootClusterOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.NumClustersStartDeleteOldest, "num-clusters-start-delete-oldest", 10, "number of clusters to start deletion of the oldest")
 	fs.StringVar(&o.DurationForClusterDeletion, "duration-for-cluster-deletion", "48h", "test cluster existing longer than this will be deleted")
 	fs.StringVar(&o.PrID, "pr-id", "0", "ID number of the PR, 0 if executed locally, 1 if triggered by head update")
+	fs.BoolVar(&o.UseOCMLib, "use-ocm-lib", false, "determine whether ocm-lib or component-cli handles component descriptors")
 }
 
 func (o *CreateShootClusterOptions) Complete() error {
@@ -102,7 +104,8 @@ func (o *CreateShootClusterOptions) Run(ctx context.Context) error {
 	log := utils.NewLogger().WithTimestamp()
 
 	shootClusterManager, err := pkg.NewShootClusterManager(log, o.GardenClusterKubeconfigPath, o.Namespace,
-		o.AuthDirectoryPath, o.MaxNumOfClusters, o.NumClustersStartDeleteOldest, o.DurationForClusterDeletion, o.PrID)
+		o.AuthDirectoryPath, o.MaxNumOfClusters, o.NumClustersStartDeleteOldest, o.DurationForClusterDeletion, o.PrID,
+		o.UseOCMLib)
 
 	if err != nil {
 		return err

--- a/hack/testcluster/shootcluster_delete.go
+++ b/hack/testcluster/shootcluster_delete.go
@@ -79,7 +79,7 @@ func (o *DeleteShootClusterOptions) Run(ctx context.Context) error {
 	log := utils.NewLogger().WithTimestamp()
 
 	shootClusterManager, err := pkg.NewShootClusterManager(log, o.GardenClusterKubeconfigPath, o.Namespace, o.AuthDirectoryPath,
-		0, 0, "1h", "0")
+		0, 0, "1h", "0", false)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
The recent changes of the pipeline definition caused issues as the integration tests are started twice and thereby the later integration tests cleans up the cluster the other integration test is waiting for to be ready. 

This changes were intended to be part of the ocm-lib change but are provided separately (earlier) to restore the proper behaviour of the pipeline.
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/priority 1

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
