### PR TITLE
Pipeline fix

### DIFF
--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -9,13 +9,20 @@
 # is integrated in the test cluster name indicating that the tests were triggered by a head update commit or a new release.
 # The cluster name has the format it-pr1-<4-digits>.
 
-USE_OCM_LIB=$1
+USE_OCM_LIB=${1}
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
 CURRENT_PATH="$(pwd)"
+echo $USE_OCM_LIB
+if [ $USE_OCM_LIB = true ]; then
+  INTEGRATION_TEST_PATH=$INTEGRATION_TEST_OCM_PATH
+else
+  INTEGRATION_TEST_PATH=$INTEGRATION_TEST_CNUDIE_PATH
+fi
+
 cd "${INTEGRATION_TEST_PATH}"
 FULL_INTEGRATION_TEST_PATH="$(pwd)"
 export FULL_INTEGRATION_TEST_PATH

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -77,6 +77,7 @@ landscaper:
           trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          output_dir: 'integration_test_ocm'
         integration_test_ocm:
           execute:
           - integration-test
@@ -84,6 +85,7 @@ landscaper:
           trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          output_dir: 'integration_test_ocm'
     pull-request:
       steps:
         integration_test_cnudie:
@@ -125,6 +127,7 @@ landscaper:
           trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          output_dir: 'integration_test_cnudie'
         integration_test_ocm:
           execute:
           - integration-test
@@ -132,9 +135,11 @@ landscaper:
           trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          output_dir: 'integration_test_ocm'
         update_release:
           inputs:
-            INTEGRATION_TEST_PATH: integration_test_path
+            INTEGRATION_TEST_CNUDIE_PATH: integration_test_cnudie_path
+            INTEGRATION_TEST_OCM_PATH: integration_test_ocm_path
           execute:
           - update_release.py
           trait_depends:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -77,7 +77,7 @@ landscaper:
           trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
-          output_dir: 'integration_test_ocm'
+          output_dir: 'integration_test_cnudie'
         integration_test_ocm:
           execute:
           - integration-test

--- a/.ci/update_release.py
+++ b/.ci/update_release.py
@@ -32,15 +32,25 @@ gh_release = github_repo_helper.repository.release_from_tag(version_file_content
 
 
 try:
-    os.environ['INTEGRATION_TEST_PATH']
+    os.environ['INTEGRATION_TEST_CNUDIE_PATH']
+    os.environ['INTEGRATION_TEST_OCM_PATH']
 except KeyError:
     print("No integration test output path found. Output will not be added to release")
 else:
-    integration_test_path = util.check_env('INTEGRATION_TEST_PATH')
+    integration_test_path = util.check_env('INTEGRATION_TEST_CNUDIE_PATH')
     integration_test_path = pathlib.Path(integration_test_path).resolve()
     integration_test_path = integration_test_path / "ttt.log"
     gh_release.upload_asset(
         content_type='text/plain',
-        name=f'integration-test-result-{version_file_contents}.txt',
+        name=f'integration-test-cnudie-result-{version_file_contents}.txt',
+        asset=integration_test_path.open(mode='rb'),
+    )
+
+    integration_test_path = util.check_env('INTEGRATION_TEST_OCM_PATH')
+    integration_test_path = pathlib.Path(integration_test_path).resolve()
+    integration_test_path = integration_test_path / "ttt.log"
+    gh_release.upload_asset(
+        content_type='text/plain',
+        name=f'integration-test-ocm-result-{version_file_contents}.txt',
         asset=integration_test_path.open(mode='rb'),
     )


### PR DESCRIPTION
**How to categorize this PR?**
If you set an `output_dir` in a step, the pipeline coding implicitly creates a corresponding environment variable with a `_PATH` suffix (e.g. for `output_dir: 'integration_test'` `INTEGRATION_TEST_PATH`. 
Since the `output_dir` was removed in #830 but the integration_test script tried to use this environment variable, the script and therefore, the pipeline, failed.

The integration_test script uses this path to store a file with the integration test logs. This file is then accessed by the update_release.py script to upload the logs as asset of the release. 
The integration test script has been adjusted so that they should write to different `output_dir`s and the update_release.py script adds both log outputs as assets.
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/priority 1

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
