### PR TITLE
Bugfixes

### DIFF
--- a/pkg/landscaper/installations/executions/template/inputformatter.go
+++ b/pkg/landscaper/installations/executions/template/inputformatter.go
@@ -104,7 +104,10 @@ func removeValue(val interface{}, depth uint) interface{} {
 			m[k] = removeValue(v, depth+1)
 		}
 	} else {
-		val = fmt.Sprintf("[...] (%s)", reflect.TypeOf(val).String())
+		if val != nil {
+			val = reflect.TypeOf(val).String()
+		}
+		val = fmt.Sprintf("[...] (%s)", val)
 	}
 
 	return val

--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -50,9 +50,9 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 	var (
 		fldPath         = field.NewPath(fmt.Sprintf("(inst: %s)", c.Inst.GetInstallation().Name)).Child("internalExports")
 		internalExports = map[string]interface{}{
-			"deployitems": struct{}{},
-			"dataobjects": struct{}{},
-			"targets":     struct{}{},
+			"deployitems": map[string]interface{}{},
+			"dataobjects": map[string]interface{}{},
+			"targets":     map[string]interface{}{},
 		}
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Fixes two small bugs:
1. The input formatter, which is used to build error messages for errors during templating called `reflect.TypeOf(val).String()`, which caused the landscaper to crash if `val` was `nil`.
2. The default value for deployitem/dataobject/target imports was an empty struct. While this probably doesn't matter when using `GoTemplate` (because it is text-based), this caused problems for `Spiff` templates without any DeployItems, because the default value was not overwritten and Spiff can't handle the empty struct when building the YAML tree. Changing the default from an empty struct to an empty map solved the problem and is also 'more correct', since all three keys hold objects (json-wise), which are represented as maps in Go. I assume that this issue went unnoticed due to Spiff being rarely used.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a nil pointer exception that could occur during construction of the error message for a failed templating execution.
```
```bugfix user
Fixed a bug which could occur when rendering exports with `Spiff` while not having any DeployItems.
```
