### PR TITLE
USE_OCM_LIB parameter for local int tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: setup-testenv
 
 .PHONY: integration-test
 integration-test:
-	@$(REPO_ROOT)/.ci/local-integration-test $(KUBECONFIG_PATH) $(EFFECTIVE_VERSION)
+	@$(REPO_ROOT)/.ci/local-integration-test $(KUBECONFIG_PATH) $(EFFECTIVE_VERSION) $(USE_OCM_LIB)
 
 .PHONY: integration-test-pure
 integration-test-pure:
@@ -67,7 +67,7 @@ integration-test-pure:
 
 .PHONY: integration-test-with-cluster-creation
 integration-test-with-cluster-creation:
-	@$(REPO_ROOT)/.ci/local-integration-test-with-cluster-creation $(KUBECONFIG_PATH) garden-laas $(EFFECTIVE_VERSION) 0
+	@$(REPO_ROOT)/.ci/local-integration-test-with-cluster-creation $(KUBECONFIG_PATH) garden-laas $(EFFECTIVE_VERSION) 0 $(USE_OCM_LIB)
 
 .PHONY: verify
 verify: check

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -3,8 +3,13 @@
 This document describes how tests in the Landscaper project can be executed, how they can be written and how the execution in the pipelines work.
 
 **Index:**
-- [Unit tests](#unit-tests)
-- [Integration tests](#integration-tests)
+- [Testing](#testing)
+		- [Unit Tests](#unit-tests)
+			- [execute](#execute)
+			- [write tests](#write-tests)
+		- [Integration tests](#integration-tests)
+			- [execution](#execution)
+			- [write tests](#write-tests-1)
 
 ### Unit Tests
 
@@ -72,7 +77,7 @@ The TestMachinery itself works with
 The integration tests can also be executed locally by providing a kubernetes cluster. Then just run the tests with:
 
 ```
-make integration-test KUBECONFIG_PATH=<path to cluster kubeconfig file>
+make integration-test KUBECONFIG_PATH=<path to cluster kubeconfig file> USE_OCM_LIB=false
 ```
 
 The tests set up a local OCI registry, install/upgrade the landscaper and executes the integration tests.
@@ -80,7 +85,7 @@ The tests set up a local OCI registry, install/upgrade the landscaper and execut
 It is also possible to execute the tests with Gardner shoot cluster creation and deletion with:
 
 ```
-make integration-test-with-cluster-creation KUBECONFIG_PATH=<path to Gardener kubeconfig for project laas on the Canary landscape>
+make integration-test-with-cluster-creation KUBECONFIG_PATH=<path to Gardener kubeconfig for project laas on the Canary landscape> USE_OCM_LIB=false
 ```
 
 #### write tests


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority 1

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Introduces USE_OCM_LIB parameter for running local integration tests
```
