### PR TITLE
move logic which TargetResolver to use into library

### DIFF
--- a/apis/core/v1alpha1/types_target.go
+++ b/apis/core/v1alpha1/types_target.go
@@ -125,3 +125,15 @@ type ResolvedTarget struct {
 	// Otherwise, the inline configuration of the target is put here.
 	Content string `json:"content"`
 }
+
+// NewResolvedTarget is a constructor for ResolvedTarget.
+// It puts the target's inline configuration into the Content field, if the target doesn't contain a secret reference.
+func NewResolvedTarget(target *Target) *ResolvedTarget {
+	res := &ResolvedTarget{
+		Target: target,
+	}
+	if target.Spec.SecretRef == nil && target.Spec.Configuration != nil {
+		res.Content = string(target.Spec.Configuration.RawMessage)
+	}
+	return res
+}

--- a/controller-utils/pkg/landscaper/targetresolver/generic/genericresolver.go
+++ b/controller-utils/pkg/landscaper/targetresolver/generic/genericresolver.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package generic
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+)
+
+// GenericResolver is a generic targetresolver that checks which actual resolver is required and then uses it to resolve the Target.
+type GenericResolver struct {
+	Client client.Client
+}
+
+// New creates a new GenericResolver.
+// This constructor's argument list is the union of all actual targetresolver's arguments.
+// The given arguments may be nil, if it is known that the specific resolver which requires the argument will not be needed,
+// but this will cause errors if done wrong (which tries to instantiate an actual resolver with nil arguments).
+func New(c client.Client) *GenericResolver {
+	return &GenericResolver{
+		Client: c,
+	}
+}
+
+func (gr GenericResolver) Resolve(ctx context.Context, target *lsv1alpha1.Target) (*lsv1alpha1.ResolvedTarget, error) {
+	var rt *lsv1alpha1.ResolvedTarget
+	var err error
+	if target.Spec.SecretRef != nil {
+		if gr.Client == nil {
+			return nil, fmt.Errorf("target contains a secret reference, but secretresolver cannot be constructed because given client is nil")
+		}
+		sr := secret.New(gr.Client)
+		rt, err = sr.Resolve(ctx, target)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving secret reference (%s/%s#%s) for Target '%s/%s': %w", target.Namespace, target.Spec.SecretRef.Name, target.Spec.SecretRef.Key, target.Namespace, target.Name, err)
+		}
+	} else {
+		rt = lsv1alpha1.NewResolvedTarget(target)
+	}
+	return rt, nil
+}

--- a/controller-utils/pkg/landscaper/targetresolver/secret/secretrefresolver.go
+++ b/controller-utils/pkg/landscaper/targetresolver/secret/secretrefresolver.go
@@ -14,10 +14,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
 	lscutils "github.com/gardener/landscaper/controller-utils/pkg/landscaper"
-	. "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 )
-
-var _ TargetResolver = SecretRefResolver{}
 
 type SecretRefResolver struct {
 	Client client.Client
@@ -30,7 +27,7 @@ func New(c client.Client) *SecretRefResolver {
 }
 
 func (srr SecretRefResolver) Resolve(ctx context.Context, target *lsv1alpha1.Target) (*lsv1alpha1.ResolvedTarget, error) {
-	rt := NewResolvedTarget(target)
+	rt := lsv1alpha1.NewResolvedTarget(target)
 
 	if target.Spec.SecretRef != nil {
 		sr := &lsv1alpha1.SecretReference{

--- a/controller-utils/pkg/landscaper/targetresolver/targetresolver.go
+++ b/controller-utils/pkg/landscaper/targetresolver/targetresolver.go
@@ -7,7 +7,10 @@ package targetresolver
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
 )
 
 type TargetResolver interface {
@@ -15,14 +18,11 @@ type TargetResolver interface {
 	Resolve(context.Context, *lsv1alpha1.Target) (*lsv1alpha1.ResolvedTarget, error)
 }
 
-// NewResolvedTarget is a constructor for ResolvedTarget.
-// It puts the target's inline configuration into the Content field, if the target doesn't contain a secret reference.
-func NewResolvedTarget(target *lsv1alpha1.Target) *lsv1alpha1.ResolvedTarget {
-	res := &lsv1alpha1.ResolvedTarget{
-		Target: target,
-	}
-	if target.Spec.SecretRef == nil && target.Spec.Configuration != nil {
-		res.Content = string(target.Spec.Configuration.RawMessage)
-	}
-	return res
+// Resolve is a generic resolve function for targets.
+// It checks which target resolver to use, instantiates it and uses it to resolve the target.
+// It therefore requires all arguments that are required for any of the contained targetresolvers.
+// These arguments are only used if the corresponding resolver is actually used, so they can be nil for resolvers that are known to not be required.
+// Internally, a GenericResolver is used (which uses the actual resolvers).
+func Resolve(ctx context.Context, target *lsv1alpha1.Target, c client.Client) (*lsv1alpha1.ResolvedTarget, error) {
+	return genericresolver.New(c).Resolve(ctx, target)
 }

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
@@ -125,3 +125,15 @@ type ResolvedTarget struct {
 	// Otherwise, the inline configuration of the target is put here.
 	Content string `json:"content"`
 }
+
+// NewResolvedTarget is a constructor for ResolvedTarget.
+// It puts the target's inline configuration into the Content field, if the target doesn't contain a secret reference.
+func NewResolvedTarget(target *Target) *ResolvedTarget {
+	res := &ResolvedTarget{
+		Target: target,
+	}
+	if target.Spec.SecretRef == nil && target.Spec.Configuration != nil {
+		res.Content = string(target.Spec.Configuration.RawMessage)
+	}
+	return res
+}

--- a/pkg/deployer/manifest/export_test.go
+++ b/pkg/deployer/manifest/export_test.go
@@ -19,7 +19,6 @@ import (
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/deployer/manifest"
 	"github.com/gardener/landscaper/test/utils"
@@ -97,7 +96,7 @@ var _ = Describe("Export", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, item)).To(Succeed())
 
-		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, targetresolver.NewResolvedTarget(target))
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, lsv1alpha1.NewResolvedTarget(target))
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(m.Reconcile(ctx)).To(Succeed())
@@ -173,7 +172,7 @@ var _ = Describe("Export", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, item)).To(Succeed())
 
-		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, targetresolver.NewResolvedTarget(target))
+		m, err := manifest.New(testenv.Client, testenv.Client, &manifestv1alpha2.Configuration{}, item, lsv1alpha1.NewResolvedTarget(target))
 		Expect(err).ToNot(HaveOccurred())
 
 		go func() {

--- a/pkg/deployer/manifest/misc_test.go
+++ b/pkg/deployer/manifest/misc_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
 	"github.com/gardener/landscaper/apis/deployer/utils/readinesschecks"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	secretresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/deployer/manifest"
 	"github.com/gardener/landscaper/test/utils"
@@ -74,7 +74,7 @@ var _ = Describe("", func() {
 		rawCM, err := kutil.ConvertToRawExtension(cm, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -123,7 +123,7 @@ var _ = Describe("", func() {
 		rawCM, err := kutil.ConvertToRawExtension(cm, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -188,7 +188,7 @@ var _ = Describe("", func() {
 		rawCM, err := kutil.ConvertToRawExtension(cm, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -249,7 +249,7 @@ var _ = Describe("", func() {
 		rawCM, err := kutil.ConvertToRawExtension(cm, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -306,7 +306,7 @@ var _ = Describe("", func() {
 		rawCM, err := kutil.ConvertToRawExtension(cm, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -368,7 +368,7 @@ var _ = Describe("", func() {
 		requirementValueMarshaled, err := json.Marshal(requirementValue)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -479,7 +479,7 @@ var _ = Describe("", func() {
 		rawCMList, err := kutil.ConvertToRawExtension(cmList, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -543,7 +543,7 @@ var _ = Describe("", func() {
 		rawCMList, err := kutil.ConvertToRawExtension(cmList, scheme.Scheme)
 		Expect(err).ToNot(HaveOccurred())
 
-		sr := secretresolver.New(state.Client)
+		sr := genericresolver.New(state.Client)
 		rt, err := sr.Resolve(ctx, target)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/deployer/manifest/policy_test.go
+++ b/pkg/deployer/manifest/policy_test.go
@@ -18,7 +18,6 @@ import (
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/deployer/manifest"
 	"github.com/gardener/landscaper/test/utils"
@@ -86,7 +85,7 @@ var _ = Describe("Policy", func() {
 		rawTarget, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, rawTarget)).To(Succeed())
-		target = targetresolver.NewResolvedTarget(rawTarget)
+		target = lsv1alpha1.NewResolvedTarget(rawTarget)
 
 		configMap = &corev1.ConfigMap{}
 		configMap.Name = "my-cm"

--- a/pkg/deployer/manifest/readiness_check_test.go
+++ b/pkg/deployer/manifest/readiness_check_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
 	"github.com/gardener/landscaper/apis/deployer/utils/readinesschecks"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/deployer/manifest"
 	"github.com/gardener/landscaper/test/utils"
@@ -46,7 +45,7 @@ var _ = Describe("ReadinessCheck", func() {
 		rawTarget, err := utils.CreateKubernetesTarget(state.Namespace, "my-target", testenv.Env.Config)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(state.Create(ctx, rawTarget)).To(Succeed())
-		target = targetresolver.NewResolvedTarget(rawTarget)
+		target = lsv1alpha1.NewResolvedTarget(rawTarget)
 	})
 
 	AfterEach(func() {

--- a/pkg/landscaper/installations/executions/operation.go
+++ b/pkg/landscaper/installations/executions/operation.go
@@ -19,7 +19,7 @@ import (
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	"github.com/gardener/landscaper/apis/core/validation"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
-	secretresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
 	"github.com/gardener/landscaper/pkg/api"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
@@ -60,7 +60,7 @@ func (o *ExecutionOperation) RenderDeployItemTemplates(ctx context.Context, inst
 		KubeClient: o.Client(),
 		Inst:       inst.GetInstallation(),
 	}
-	targetResolver := secretresolver.New(o.Client())
+	targetResolver := genericresolver.New(o.Client())
 	tmpl := template.New(gotemplate.New(templateStateHandler, targetResolver), spiff.New(templateStateHandler, targetResolver))
 	executions, err := tmpl.TemplateDeployExecutions(
 		template.NewDeployExecutionOptions(

--- a/pkg/landscaper/installations/executions/template/spiff/spifftemplate.go
+++ b/pkg/landscaper/installations/executions/template/spiff/spifftemplate.go
@@ -14,10 +14,10 @@ import (
 	"sigs.k8s.io/yaml"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 	"github.com/gardener/landscaper/pkg/components/model"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
-	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 )
 
 // Templater describes the spiff template implementation for execution templater.

--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -18,7 +18,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	secretresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
@@ -79,7 +79,7 @@ func (c *Constructor) Construct(ctx context.Context) ([]*dataobjects.DataObject,
 		KubeClient: c.Client(),
 		Inst:       c.Inst.GetInstallation(),
 	}
-	targetResolver := secretresolver.New(c.Client())
+	targetResolver := genericresolver.New(c.Client())
 
 	tmpl := template.New(
 		gotemplate.New(stateHdlr, targetResolver),

--- a/pkg/landscaper/installations/imports/constructor.go
+++ b/pkg/landscaper/installations/imports/constructor.go
@@ -16,7 +16,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-	secretresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects"
 	"github.com/gardener/landscaper/pkg/landscaper/dataobjects/jsonpath"
 	"github.com/gardener/landscaper/pkg/landscaper/installations"
@@ -301,7 +301,7 @@ func (c *Constructor) RenderImportExecutions() error {
 		KubeClient: c.Operation.Client(),
 		Inst:       c.Operation.Inst.GetInstallation(),
 	}
-	targetResolver := secretresolver.New(c.Operation.Client())
+	targetResolver := genericresolver.New(c.Operation.Client())
 	tmpl := template.New(
 		gotemplate.New(templateStateHandler, targetResolver),
 		spiff.New(templateStateHandler, targetResolver))

--- a/pkg/landscaper/installations/subinstallations/subinstallations.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations.go
@@ -18,7 +18,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsv1alpha1helper "github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	"github.com/gardener/landscaper/apis/core/validation"
-	secretresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	lc "github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template"
@@ -194,7 +194,7 @@ func (o *Operation) getInstallationTemplates() ([]*lsv1alpha1.InstallationTempla
 			KubeClient: o.Client(),
 			Inst:       o.Inst.GetInstallation(),
 		}
-		targetResolver := secretresolver.New(o.Client())
+		targetResolver := genericresolver.New(o.Client())
 		tmpl := template.New(gotemplate.New(templateStateHandler, targetResolver), spiff.New(templateStateHandler, targetResolver))
 		templatedTmpls, err := tmpl.TemplateSubinstallationExecutions(template.NewDeployExecutionOptions(
 			template.NewBlueprintExecutionOptions(

--- a/pkg/utils/uncached_client.go
+++ b/pkg/utils/uncached_client.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"k8s.io/client-go/kubernetes"
 	"reflect"
 	"strconv"
+
+	"k8s.io/client-go/kubernetes"
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -11,11 +11,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	utils3 "github.com/gardener/landscaper/pkg/utils"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	utils3 "github.com/gardener/landscaper/pkg/utils"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/gardener/component-cli/ociclient"

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	utils2 "github.com/gardener/landscaper/pkg/utils"
 	"html/template"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
+
+	utils2 "github.com/gardener/landscaper/pkg/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/types_target.go
@@ -125,3 +125,15 @@ type ResolvedTarget struct {
 	// Otherwise, the inline configuration of the target is put here.
 	Content string `json:"content"`
 }
+
+// NewResolvedTarget is a constructor for ResolvedTarget.
+// It puts the target's inline configuration into the Content field, if the target doesn't contain a secret reference.
+func NewResolvedTarget(target *Target) *ResolvedTarget {
+	res := &ResolvedTarget{
+		Target: target,
+	}
+	if target.Spec.SecretRef == nil && target.Spec.Configuration != nil {
+		res.Content = string(target.Spec.Configuration.RawMessage)
+	}
+	return res
+}

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic/genericresolver.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic/genericresolver.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package generic
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret"
+)
+
+// GenericResolver is a generic targetresolver that checks which actual resolver is required and then uses it to resolve the Target.
+type GenericResolver struct {
+	Client client.Client
+}
+
+// New creates a new GenericResolver.
+// This constructor's argument list is the union of all actual targetresolver's arguments.
+// The given arguments may be nil, if it is known that the specific resolver which requires the argument will not be needed,
+// but this will cause errors if done wrong (which tries to instantiate an actual resolver with nil arguments).
+func New(c client.Client) *GenericResolver {
+	return &GenericResolver{
+		Client: c,
+	}
+}
+
+func (gr GenericResolver) Resolve(ctx context.Context, target *lsv1alpha1.Target) (*lsv1alpha1.ResolvedTarget, error) {
+	var rt *lsv1alpha1.ResolvedTarget
+	var err error
+	if target.Spec.SecretRef != nil {
+		if gr.Client == nil {
+			return nil, fmt.Errorf("target contains a secret reference, but secretresolver cannot be constructed because given client is nil")
+		}
+		sr := secret.New(gr.Client)
+		rt, err = sr.Resolve(ctx, target)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving secret reference (%s/%s#%s) for Target '%s/%s': %w", target.Namespace, target.Spec.SecretRef.Name, target.Spec.SecretRef.Key, target.Namespace, target.Name, err)
+		}
+	} else {
+		rt = lsv1alpha1.NewResolvedTarget(target)
+	}
+	return rt, nil
+}

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret/secretrefresolver.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret/secretrefresolver.go
@@ -14,10 +14,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
 	lscutils "github.com/gardener/landscaper/controller-utils/pkg/landscaper"
-	. "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 )
-
-var _ TargetResolver = SecretRefResolver{}
 
 type SecretRefResolver struct {
 	Client client.Client
@@ -30,7 +27,7 @@ func New(c client.Client) *SecretRefResolver {
 }
 
 func (srr SecretRefResolver) Resolve(ctx context.Context, target *lsv1alpha1.Target) (*lsv1alpha1.ResolvedTarget, error) {
-	rt := NewResolvedTarget(target)
+	rt := lsv1alpha1.NewResolvedTarget(target)
 
 	if target.Spec.SecretRef != nil {
 		sr := &lsv1alpha1.SecretReference{

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/targetresolver.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/targetresolver.go
@@ -8,6 +8,8 @@ import (
 	"context"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	genericresolver "github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type TargetResolver interface {
@@ -15,14 +17,11 @@ type TargetResolver interface {
 	Resolve(context.Context, *lsv1alpha1.Target) (*lsv1alpha1.ResolvedTarget, error)
 }
 
-// NewResolvedTarget is a constructor for ResolvedTarget.
-// It puts the target's inline configuration into the Content field, if the target doesn't contain a secret reference.
-func NewResolvedTarget(target *lsv1alpha1.Target) *lsv1alpha1.ResolvedTarget {
-	res := &lsv1alpha1.ResolvedTarget{
-		Target: target,
-	}
-	if target.Spec.SecretRef == nil && target.Spec.Configuration != nil {
-		res.Content = string(target.Spec.Configuration.RawMessage)
-	}
-	return res
+// Resolve is a generic resolve function for targets.
+// It checks which target resolver to use, instantiates it and uses it to resolve the target.
+// It therefore requires all arguments that are required for any of the contained targetresolvers.
+// These arguments are only used if the corresponding resolver is actually used, so they can be nil for resolvers that are known to not be required.
+// Internally, a GenericResolver is used (which uses the actual resolvers).
+func Resolve(ctx context.Context, target *lsv1alpha1.Target, c client.Client) (*lsv1alpha1.ResolvedTarget, error) {
+	return genericresolver.New(c).Resolve(ctx, target)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -592,6 +592,7 @@ github.com/gardener/landscaper/controller-utils/pkg/kubernetes
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes/mock
 github.com/gardener/landscaper/controller-utils/pkg/landscaper
 github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver
+github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/generic
 github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver/secret
 github.com/gardener/landscaper/controller-utils/pkg/logging
 github.com/gardener/landscaper/controller-utils/pkg/logging/constants


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Before this change, we had one `TargetResolver` implementation, which can resolve secret references and should be used if there is a secret reference within the Target. The problem with this approach is that someone from the outside who wants to work with Targets (e.g. when using the results (=exports) of an Installation programmatically) would need to know which TargetResolver implementations exist and when to use which one. The only way to figure this out is by checking usages of the TargetResolver within the Landscaper code.
Since it should be as easy as possible to build upon the exports of an Installation, this logic was moved into the `targetresolver` package:
1. There is now a `GenericResolver`. It implements the `TargetResolver` interface, but doesn't resolve anything by its own, instead it checks which other implementation to use and calls that one.
2. The `targetresolver` package now has a `Resolve` function that can resolve any Target. It does so by constructing a GenericResolver internally.

While this makes using TargetResolvers significantly easier, there is a disadvantage: Both methods require all arguments that any `TargetResolver` implementation takes. Currently, there is only one implementation and that only requires a `client.Client` to access the cluster, but if we add another implementation, e.g. for resolving references to a secret vault, both - the GenericResolver as well as the Resolve function - need to be given the client as well as the vault configuration. They could still be instantiated with a nil vault configuration, but then trying to resolve a secret that references a vault would cause an error. This also means that each new `TargetResolver` implementation causes a breaking change (for developers) and requires each call to GenericResolver or the Resolve function to be modified.

However, there are two reasons why this is probably not as bad as it sounds:
1. We used the TargetResolver for quite some time now and did not require any other implementation. It is unlikely that new implementations will be created often in the future.
2. Whenever a Target is resolved, we usually want it to be resolvable by all supported implementations - I can't imagine a place in the code where it would be fine to be able to resolve just some of the allowed Targets and not all of them (except for tests). This means that wherever Targets are resolved, we would require all arguments for all implementations anyway, so having them all gathered in a single function call is not really a drawback.



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The `NewResolvedTarget` constructor has moved from the `targetresolver` package to the `v1alpha1` api package. This has been done to avoid import cycles in the refactored `targetresolver` package, but it also makes sense, as the `ResolvedTarget` type is also declared there.
```
```feature developer
New options for resolving a `Target` have been added to the `targetresolver` package:
1. The package itself now contains a `Resolve` function.
2. There is a new `generic` sub-package containing the `GenericResolver` implementation of the `TargetResolver` interface.
Both of these have the advantage that they contain the logic when to use which TargetResolver implementation (although there currently is only one, but they will be expanded when new implementations are added). It is strongly recommended to use one of these methods instead of using the SecretRefResolver explicitly.
```
