### PR TITLE
Templating with v3alpha1

### DIFF
--- a/docs/guided-tour/templating/components/README.md
+++ b/docs/guided-tour/templating/components/README.md
@@ -56,7 +56,7 @@ provide access to the involved component descriptors:
   To give an example, a list with the names of the involved components can be obtained as follows:
   ```yaml
   componentNames:
-  {{ range $index, $comp := .components }}
+  {{ range $index, $comp := .components.components }}
     - {{ $comp.component.name }}  
   {{ end }}
   ```

--- a/docs/usage/Templating.md
+++ b/docs/usage/Templating.md
@@ -265,7 +265,7 @@ The execution type to use for spiff templates is `Spiff`. The template can be pr
     deployItems:
     - name: my-first-deploy-item
       type: landscaper.gardener.cloud/mock
-      config: (( .imports.config ))
+      config: (( imports.config ))
 ```
 or
 ```yaml
@@ -275,7 +275,7 @@ or
     deployItems:
     - name: my-first-deploy-item
       type: landscaper.gardener.cloud/mock
-      config: (( .imports.config ))
+      config: (( imports.config ))
 ```
 
 ##### Additional Functions

--- a/pkg/components/cnudie/componentversion.go
+++ b/pkg/components/cnudie/componentversion.go
@@ -34,6 +34,10 @@ func newComponentVersion(registryAccess *RegistryAccess, cd *types.ComponentDesc
 	}
 }
 
+func (c *ComponentVersion) GetSchemaVersion() string {
+	return c.componentDescriptor.Metadata.Version
+}
+
 func (c *ComponentVersion) GetName() string {
 	return c.componentDescriptor.GetName()
 }

--- a/pkg/components/model/componentversion.go
+++ b/pkg/components/model/componentversion.go
@@ -12,6 +12,8 @@ import (
 )
 
 type ComponentVersion interface {
+	// GetSchemaVersion return the used ocm schema version.
+	GetSchemaVersion() string
 
 	// GetName returns the name of the component version.
 	GetName() string

--- a/pkg/components/ocmlib/componentversion.go
+++ b/pkg/components/ocmlib/componentversion.go
@@ -24,6 +24,12 @@ type ComponentVersion struct {
 	componentDescriptorV2  cdv2.ComponentDescriptor
 }
 
+var _ model.ComponentVersion = &ComponentVersion{}
+
+func (c *ComponentVersion) GetSchemaVersion() string {
+	return c.componentVersionAccess.GetDescriptor().SchemaVersion()
+}
+
 func (c *ComponentVersion) GetName() string {
 	return c.componentVersionAccess.GetName()
 }

--- a/pkg/components/testutils/componentversion.go
+++ b/pkg/components/testutils/componentversion.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 	"io"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
@@ -52,6 +53,10 @@ func newTestComponentVersionWithRegistryAccess(cd *types.ComponentDescriptor, bl
 		componentDescriptor: cd,
 		blobResolver:        blobResolver,
 	}
+}
+
+func (c *TestComponentVersion) GetSchemaVersion() string {
+	return v2.SchemaVersion
 }
 
 func (c *TestComponentVersion) GetName() string {

--- a/pkg/components/testutils/componentversion.go
+++ b/pkg/components/testutils/componentversion.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 	"io"
+
+	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 

--- a/pkg/landscaper/installations/executions/template/common/utils.go
+++ b/pkg/landscaper/installations/executions/template/common/utils.go
@@ -26,16 +26,15 @@ const (
 // This can be defined as a OCM_SCHEMA_VERSION blueprint annotation. If the blueprint does not have a respective
 // annotation, the schema version is defaulted to the schema version of the provided component version.
 func DetermineOCMSchemaVersion(blueprint *blueprints.Blueprint, componentVersion model.ComponentVersion) string {
-	var ocmSchemaVersion string
-	var ok bool
+	ocmSchemaVersion := ""
 
 	if blueprint != nil && blueprint.Info != nil && blueprint.Info.Annotations != nil {
-		ocmSchemaVersion, ok = blueprint.Info.Annotations[OCM_SCHEMA_VERSION]
+		schemaVersion, ok := blueprint.Info.Annotations[OCM_SCHEMA_VERSION]
 		if ok {
-			return ocmSchemaVersion
+			ocmSchemaVersion = schemaVersion
 		}
 	}
-	if componentVersion != nil {
+	if ocmSchemaVersion == "" && componentVersion != nil {
 		ocmSchemaVersion = componentVersion.GetSchemaVersion()
 	}
 

--- a/pkg/landscaper/installations/executions/template/common/utils.go
+++ b/pkg/landscaper/installations/executions/template/common/utils.go
@@ -3,15 +3,17 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/codec"
-	"github.com/gardener/landscaper/pkg/components/model"
-	"github.com/gardener/landscaper/pkg/components/model/types"
-	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
 	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 	"github.com/open-component-model/ocm/pkg/runtime"
+
+	"github.com/gardener/landscaper/pkg/components/model"
+	"github.com/gardener/landscaper/pkg/components/model/types"
+	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 )
 
 const (
@@ -27,7 +29,7 @@ func DetermineOCMSchemaVersion(blueprint *blueprints.Blueprint, componentVersion
 	var ocmSchemaVersion string
 	var ok bool
 
-	if blueprint != nil {
+	if blueprint != nil && blueprint.Info != nil && blueprint.Info.Annotations != nil {
 		ocmSchemaVersion, ok = blueprint.Info.Annotations[OCM_SCHEMA_VERSION]
 		if ok {
 			return ocmSchemaVersion

--- a/pkg/landscaper/installations/executions/template/common/utils.go
+++ b/pkg/landscaper/installations/executions/template/common/utils.go
@@ -1,0 +1,141 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/gardener/component-spec/bindings-go/codec"
+	"github.com/gardener/landscaper/pkg/components/model"
+	"github.com/gardener/landscaper/pkg/components/model/types"
+	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
+	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
+	"github.com/open-component-model/ocm/pkg/runtime"
+)
+
+const OCMSchemaVersion = "OCMSchemaVersion"
+
+// DetermineOCMSchemaVersion analyzes the schema version against which should be templated.
+// This can be defined as a OCMSchemaVersion blueprint annotation. If the blueprint does not have a respective
+// annotation, the schema version is defaulted to the schema version of the provided component version.
+func DetermineOCMSchemaVersion(blueprint *blueprints.Blueprint, componentVersion model.ComponentVersion) string {
+	var ocmSchemaVersion string
+	var ok bool
+
+	if blueprint != nil {
+		ocmSchemaVersion, ok = blueprint.Info.Annotations[OCMSchemaVersion]
+		if ok {
+			return ocmSchemaVersion
+		}
+	}
+	if componentVersion != nil {
+		ocmSchemaVersion = componentVersion.GetSchemaVersion()
+	}
+
+	return ocmSchemaVersion
+}
+
+func GetSchemaVersionFromCdMap(cdMap map[string]interface{}) (string, error) {
+	var compdescSchemaVersion string
+	apiVersion, ok := cdMap["apiVersion"]
+	if ok {
+		apiVersionCasted, ok := apiVersion.(string)
+		if ok {
+			compdescSchemaVersion = apiVersionCasted
+			return compdescSchemaVersion, nil
+		}
+	}
+
+	meta, ok := cdMap["meta"]
+	if ok {
+		metaCasted, ok := meta.(map[string]interface{})
+		if ok {
+			schemaVersion, ok := metaCasted["schemaVersion"]
+			if ok {
+				schemaVersionCasted, ok := schemaVersion.(string)
+				if ok {
+					compdescSchemaVersion = schemaVersionCasted
+					return compdescSchemaVersion, nil
+				}
+			} else {
+				configuredSchemaVersion, ok := metaCasted["configuredSchemaVersion"]
+				if ok {
+					configuredSchemaVersionCasted, ok := configuredSchemaVersion.(string)
+					if ok {
+						compdescSchemaVersion = configuredSchemaVersionCasted
+						return compdescSchemaVersion, nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("Unable to determine component descriptor schema version.")
+}
+
+func ConvertCdMapToCompDescV2(inCdMap map[string]interface{}) (*types.ComponentDescriptor, error) {
+	descriptor := types.ComponentDescriptor{}
+
+	ocmSchemaVersion, err := GetSchemaVersionFromCdMap(inCdMap)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(inCdMap)
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("invalid component descriptor: %s", err.Error()))
+	}
+
+	switch ocmSchemaVersion {
+	case v3alpha1.GroupVersion:
+		internalCd, err := compdesc.Decode(data)
+		if err != nil {
+			return nil, err
+		}
+		outCdData, err := compdesc.Encode(internalCd, compdesc.SchemaVersion(v2.SchemaVersion))
+		if err != nil {
+			return nil, err
+		}
+		err = runtime.DefaultYAMLEncoding.Unmarshal(outCdData, &descriptor)
+		if err != nil {
+			return nil, err
+		}
+	case v2.SchemaVersion:
+		if err := codec.Decode(data, &descriptor); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown schema version")
+	}
+
+	return &descriptor, nil
+}
+
+func ConvertCompDescV2ToCdMap(cd cdv2.ComponentDescriptor, ocmSchemaVersion string) (map[string]interface{}, error) {
+	data, err := json.Marshal(cd)
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("invalid component descriptor: %s", err.Error()))
+	}
+	switch ocmSchemaVersion {
+	case v3alpha1.GroupVersion:
+		internalCd, err := compdesc.Decode(data)
+		if err != nil {
+			return nil, err
+		}
+		data, err = compdesc.Encode(internalCd, compdesc.SchemaVersion(v2.SchemaVersion))
+		if err != nil {
+			return nil, err
+		}
+	case v2.SchemaVersion:
+	default:
+		return nil, fmt.Errorf("unknown schema version")
+	}
+
+	cdMap := map[string]interface{}{}
+	err = runtime.DefaultYAMLEncoding.Unmarshal(data, &cdMap)
+	if err != nil {
+		return nil, err
+	}
+	return cdMap, nil
+}

--- a/pkg/landscaper/installations/executions/template/common/utils.go
+++ b/pkg/landscaper/installations/executions/template/common/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	OCM_SCHEMA_VERSION      = "OCM_SCHEMA_VERSION"
+	OCM_SCHEMA_VERSION      = "ocmSchemaVersion"
 	SCHEMA_VERSION_V2       = cdv2.SchemaVersion
 	SCHEMA_VERSION_V3ALPHA1 = v3alpha1.GroupVersion
 )

--- a/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
@@ -10,12 +10,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
-	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 	"os"
 	"strings"
 	gotmpl "text/template"
 	"time"
+
+	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 

--- a/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
@@ -172,7 +172,6 @@ func getResourcesGoFunc(cd *types.ComponentDescriptor) func(...interface{}) []ma
 		if cd == nil {
 			panic("Unable to search for a resource as no ComponentDescriptor is defined.")
 		}
-
 		resources, err := lstmpl.ResolveResources(cd, args)
 		if err != nil {
 			panic(err)
@@ -196,7 +195,6 @@ func getResourceGoFunc(cd *types.ComponentDescriptor) func(args ...interface{}) 
 		if cd == nil {
 			panic("Unable to search for a resource as no ComponentDescriptor is defined.")
 		}
-
 		resources, err := lstmpl.ResolveResources(cd, args)
 		if err != nil {
 			panic(err)
@@ -225,7 +223,7 @@ func getEffectiveRepositoryContextGoFunc(arg interface{}) map[string]interface{}
 	if !ok {
 		panic("invalid component descriptor")
 	}
-	cd, err := common.ConvertCdMapToCompDescV2(cdMap)
+	cd, err := common.ConvertMapCdToCompDescV2(cdMap)
 	if err != nil {
 		return nil
 	}

--- a/pkg/landscaper/installations/executions/template/gotemplate/gotemplate.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/gotemplate.go
@@ -59,7 +59,7 @@ func NewTemplateExecution(blueprint *blueprints.Blueprint,
 	cdList *model.ComponentVersionList,
 	targetResolver targetresolver.TargetResolver) (*TemplateExecution, error) {
 
-	funcs, err := LandscaperTplFuncMap(blueprint.Fs, cd, cdList, targetResolver)
+	funcs, err := LandscaperTplFuncMap(blueprint, cd, cdList, targetResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/landscaper/installations/executions/template/helper.go
+++ b/pkg/landscaper/installations/executions/template/helper.go
@@ -7,8 +7,9 @@ package template
 import (
 	"errors"
 	"fmt"
-	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 	"strings"
+
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 
 	"github.com/gardener/component-cli/ociclient/oci"
 	"github.com/gardener/component-spec/bindings-go/utils/selector"

--- a/pkg/landscaper/installations/executions/template/helper.go
+++ b/pkg/landscaper/installations/executions/template/helper.go
@@ -5,13 +5,12 @@
 package template
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 	"strings"
 
 	"github.com/gardener/component-cli/ociclient/oci"
-	"github.com/gardener/component-spec/bindings-go/codec"
 	"github.com/gardener/component-spec/bindings-go/utils/selector"
 
 	"github.com/gardener/landscaper/pkg/components/model/types"
@@ -31,13 +30,13 @@ func ResolveResources(defaultCD *types.ComponentDescriptor, args []interface{}) 
 	// if the first argument is map we use it as the component descriptor
 	// otherwise the default one is used
 	desc := defaultCD
+
+	// if the first input argument is a component descriptor in schema version v3alpha1, convert it to
+	// schema version v2 for internal processing
+	var err error
 	if cdMap, ok := args[0].(map[string]interface{}); ok {
-		data, err := json.Marshal(cdMap)
+		desc, err = common.ConvertCdMapToCompDescV2(cdMap)
 		if err != nil {
-			return nil, fmt.Errorf(fmt.Sprintf("invalid component descriptor: %s", err.Error()))
-		}
-		desc = &types.ComponentDescriptor{}
-		if err := codec.Decode(data, desc); err != nil {
 			return nil, err
 		}
 		// resize the arguments to remove the component descriptor and keep the arguments
@@ -76,20 +75,20 @@ func ResolveResources(defaultCD *types.ComponentDescriptor, args []interface{}) 
 // The arguments are expected to be a set of key value pairs that describe the identity of the resource.
 // e.g. []interface{}{"name", "my-component"}.
 // Optionally the first argument can be a component descriptor provided as map[string]interface{}
-func ResolveComponents(defaultCD *types.ComponentDescriptor, list *types.ComponentDescriptorList, args []interface{}) ([]types.ComponentDescriptor, error) {
+func ResolveComponents(defaultCD *types.ComponentDescriptor, list *types.ComponentDescriptorList, ocmSchemaVersion string, args []interface{}) ([]map[string]interface{}, error) {
 	if len(args) < 2 {
 		panic("at least 2 arguments are expected")
 	}
 	// if the first argument is map we use it as the component descriptor
 	// otherwise the default one is used
 	desc := defaultCD
+
+	// if the first input argument is a component descriptor in schema version v3alpha1, convert it to
+	// schema version v2 for internal processing
+	var err error
 	if cdMap, ok := args[0].(map[string]interface{}); ok {
-		data, err := json.Marshal(cdMap)
+		desc, err = common.ConvertCdMapToCompDescV2(cdMap)
 		if err != nil {
-			return nil, fmt.Errorf(fmt.Sprintf("invalid component descriptor: %s", err.Error()))
-		}
-		desc = &types.ComponentDescriptor{}
-		if err := codec.Decode(data, desc); err != nil {
 			return nil, err
 		}
 		// resize the arguments to remove the component descriptor and keep the arguments
@@ -128,7 +127,16 @@ func ResolveComponents(defaultCD *types.ComponentDescriptor, list *types.Compone
 		components[i] = cd
 	}
 
-	return components, nil
+	descriptors := make([]map[string]interface{}, len(components))
+	for i, descriptor := range components {
+		desc, err := common.ConvertCompDescV2ToCdMap(descriptor, ocmSchemaVersion)
+		if err != nil {
+			return nil, err
+		}
+		descriptors[i] = desc
+	}
+
+	return descriptors, nil
 }
 
 // ParseOCIReference parses a oci reference string into its repository and version.

--- a/pkg/landscaper/installations/executions/template/helper.go
+++ b/pkg/landscaper/installations/executions/template/helper.go
@@ -35,7 +35,7 @@ func ResolveResources(defaultCD *types.ComponentDescriptor, args []interface{}) 
 	// schema version v2 for internal processing
 	var err error
 	if cdMap, ok := args[0].(map[string]interface{}); ok {
-		desc, err = common.ConvertCdMapToCompDescV2(cdMap)
+		desc, err = common.ConvertMapCdToCompDescV2(cdMap)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func ResolveComponents(defaultCD *types.ComponentDescriptor, list *types.Compone
 	// schema version v2 for internal processing
 	var err error
 	if cdMap, ok := args[0].(map[string]interface{}); ok {
-		desc, err = common.ConvertCdMapToCompDescV2(cdMap)
+		desc, err = common.ConvertMapCdToCompDescV2(cdMap)
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +129,7 @@ func ResolveComponents(defaultCD *types.ComponentDescriptor, list *types.Compone
 
 	descriptors := make([]map[string]interface{}, len(components))
 	for i, descriptor := range components {
-		desc, err := common.ConvertCompDescV2ToCdMap(descriptor, ocmSchemaVersion)
+		desc, err := common.ConvertCompDescV2ToMapCd(descriptor, ocmSchemaVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/landscaper/installations/executions/template/options.go
+++ b/pkg/landscaper/installations/executions/template/options.go
@@ -6,6 +6,7 @@ package template
 
 import (
 	"fmt"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/pkg/components/model"
@@ -35,19 +36,13 @@ func NewBlueprintExecutionOptions(installation *lsv1alpha1.Installation, bluepri
 }
 
 func (o *BlueprintExecutionOptions) Values() (map[string]interface{}, error) {
-	compdescVersion := ""
-	if o.ComponentVersion != nil {
-		compdescVersion = o.Blueprint.Info.Annotations["OCMSchemaVersion"]
-		if compdescVersion == "" {
-			compdescVersion = o.ComponentVersion.GetComponentDescriptor().Metadata.Version
-		}
-	}
+	ocmSchemaVersion := common.DetermineOCMSchemaVersion(o.Blueprint, o.ComponentVersion)
 	// marshal and unmarshal resolved component descriptor
-	component, err := serializeComponentDescriptor(o.ComponentVersion, compdescVersion)
+	component, err := serializeComponentDescriptor(o.ComponentVersion, ocmSchemaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("error during serializing of the resolved components: %w", err)
 	}
-	components, err := serializeComponentDescriptorList(o.ComponentVersions)
+	components, err := serializeComponentDescriptorList(o.ComponentVersions, ocmSchemaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("error during serializing of the component descriptor: %w", err)
 	}

--- a/pkg/landscaper/installations/executions/template/options.go
+++ b/pkg/landscaper/installations/executions/template/options.go
@@ -35,8 +35,15 @@ func NewBlueprintExecutionOptions(installation *lsv1alpha1.Installation, bluepri
 }
 
 func (o *BlueprintExecutionOptions) Values() (map[string]interface{}, error) {
+	compdescVersion := ""
+	if o.ComponentVersion != nil {
+		compdescVersion = o.Blueprint.Info.Annotations["OCMSchemaVersion"]
+		if compdescVersion == "" {
+			compdescVersion = o.ComponentVersion.GetComponentDescriptor().Metadata.Version
+		}
+	}
 	// marshal and unmarshal resolved component descriptor
-	component, err := serializeComponentDescriptor(o.ComponentVersion)
+	component, err := serializeComponentDescriptor(o.ComponentVersion, compdescVersion)
 	if err != nil {
 		return nil, fmt.Errorf("error during serializing of the resolved components: %w", err)
 	}

--- a/pkg/landscaper/installations/executions/template/options.go
+++ b/pkg/landscaper/installations/executions/template/options.go
@@ -6,6 +6,7 @@ package template
 
 import (
 	"fmt"
+
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"

--- a/pkg/landscaper/installations/executions/template/spiff/funcs.go
+++ b/pkg/landscaper/installations/executions/template/spiff/funcs.go
@@ -67,12 +67,12 @@ func spiffResolveResources(cd *types.ComponentDescriptor) func(arguments []inter
 		compdescSchemaVersion := ""
 		inCdMap, ok := arguments[0].(map[string]interface{})
 		if ok {
-			compdescSchemaVersion, err = common.GetSchemaVersionFromCdMap(inCdMap)
+			compdescSchemaVersion, err = common.GetSchemaVersionFromMapCd(inCdMap)
 			if err != nil {
 				panic(err)
 			}
 			if compdescSchemaVersion == v3alpha1.GroupVersion {
-				arguments[0], err = common.ConvertCdMapToCompDescV2(inCdMap)
+				arguments[0], err = common.ConvertMapCdToCompDescV2(inCdMap)
 				if err != nil {
 					panic("Unable to convert component descriptor to internal schema version")
 				}

--- a/pkg/landscaper/installations/executions/template/spiff/funcs.go
+++ b/pkg/landscaper/installations/executions/template/spiff/funcs.go
@@ -8,10 +8,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
+
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
-	"time"
 
 	"github.com/gardener/component-spec/bindings-go/ctf"
 	imagevector "github.com/gardener/image-vector/pkg"

--- a/pkg/landscaper/installations/executions/template/spiff/spifftemplate.go
+++ b/pkg/landscaper/installations/executions/template/spiff/spifftemplate.go
@@ -64,7 +64,7 @@ func (t *Templater) TemplateSubinstallationExecutions(tmplExec lsv1alpha1.Templa
 	}
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, cd, cdList, t.targetResolver); err != nil {
+	if err = LandscaperSpiffFuncs(blueprint, functions, cd, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +109,7 @@ func (t *Templater) TemplateImportExecutions(tmplExec lsv1alpha1.TemplateExecuto
 	defer ctx.Done()
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, descriptor, cdList, t.targetResolver); err != nil {
+	if err = LandscaperSpiffFuncs(blueprint, functions, descriptor, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 
@@ -155,7 +155,7 @@ func (t *Templater) TemplateDeployExecutions(tmplExec lsv1alpha1.TemplateExecuto
 	}
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, descriptor, cdList, t.targetResolver); err != nil {
+	if err = LandscaperSpiffFuncs(blueprint, functions, descriptor, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 
@@ -204,7 +204,7 @@ func (t *Templater) TemplateExportExecutions(tmplExec lsv1alpha1.TemplateExecuto
 	}
 
 	functions := spiffing.NewFunctions()
-	if err = LandscaperSpiffFuncs(functions, descriptor, cdList, t.targetResolver); err != nil {
+	if err = LandscaperSpiffFuncs(blueprint, functions, descriptor, cdList, t.targetResolver); err != nil {
 		return nil, err
 	}
 

--- a/pkg/landscaper/installations/executions/template/template.go
+++ b/pkg/landscaper/installations/executions/template/template.go
@@ -335,7 +335,7 @@ func serializeComponentDescriptorList(componentVersionList *model.ComponentVersi
 
 	switch ocmSchemaVersion {
 	case common.SCHEMA_VERSION_V3ALPHA1:
-		val := make([]map[string]interface{}, len(cds.Components))
+		val := make([]interface{}, len(cds.Components))
 		for i, cd := range cds.Components {
 			data, err := codec.Encode(&cd)
 			if err != nil {

--- a/pkg/landscaper/installations/executions/template/template.go
+++ b/pkg/landscaper/installations/executions/template/template.go
@@ -7,11 +7,16 @@ package template
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gardener/component-spec/bindings-go/codec"
-	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	ocmruntime "github.com/open-component-model/ocm/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
+
+	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
+	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 
 	"github.com/gardener/landscaper/apis/core"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -19,8 +24,6 @@ import (
 	"github.com/gardener/landscaper/pkg/components/model"
 	"github.com/gardener/landscaper/pkg/landscaper/blueprints"
 	"github.com/gardener/landscaper/pkg/utils"
-	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
-	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 )
 
 // Templater implements all available template executors.

--- a/pkg/landscaper/installations/executions/template/template.go
+++ b/pkg/landscaper/installations/executions/template/template.go
@@ -8,9 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gardener/component-spec/bindings-go/codec"
+	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
-	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 	ocmruntime "github.com/open-component-model/ocm/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -301,7 +300,7 @@ func serializeComponentDescriptor(componentVersion model.ComponentVersion, ocmSc
 	}
 
 	switch ocmSchemaVersion {
-	case v3alpha1.GroupVersion:
+	case common.SCHEMA_VERSION_V3ALPHA1:
 		ocmCd, err := compdesc.Decode(data)
 		if err != nil {
 			return nil, err
@@ -310,7 +309,7 @@ func serializeComponentDescriptor(componentVersion model.ComponentVersion, ocmSc
 		if err != nil {
 			return nil, err
 		}
-	case v2.SchemaVersion:
+	case common.SCHEMA_VERSION_V2:
 	default:
 		return nil, fmt.Errorf("unknown schema version")
 	}

--- a/pkg/landscaper/installations/executions/template/template_test.go
+++ b/pkg/landscaper/installations/executions/template/template_test.go
@@ -195,6 +195,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			op := template.New(gotemplate.New(stateHandler, nil), spiff.New(stateHandler, nil))
 
 			imageAccess1, err := componentresolvers.NewOCIRegistryAccess("quay.io/example/myimage:1.0.0")
+			Expect(err).ToNot(HaveOccurred())
 			imageAccess2, err := componentresolvers.NewOCIRegistryAccess("quay.io/example/yourimage:1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 			cd := &types.ComponentDescriptor{

--- a/pkg/landscaper/installations/executions/template/template_test.go
+++ b/pkg/landscaper/installations/executions/template/template_test.go
@@ -7,11 +7,12 @@ package template_test
 import (
 	"context"
 	"encoding/json"
-	apiconfig "github.com/gardener/landscaper/apis/config"
-	"github.com/gardener/landscaper/pkg/components/registries"
 	"os"
 	"path/filepath"
 	"testing"
+
+	apiconfig "github.com/gardener/landscaper/apis/config"
+	"github.com/gardener/landscaper/pkg/components/registries"
 
 	"github.com/gardener/landscaper/pkg/landscaper/installations/executions/template/common"
 
@@ -323,11 +324,11 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			registry, err := registries.GetFactory(useOCM).NewRegistryAccess(ctx, nil, nil, nil, &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-" + schemaVersionSuffix, "1.0.0"})
+			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-" + schemaVersionSuffix, Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
-			componentVersionRef1, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-" + schemaVersionSuffix + "-ref1", "1.0.0"})
+			componentVersionRef1, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-" + schemaVersionSuffix + "-ref1", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
-			componentVersionRef2, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-" + schemaVersionSuffix + "-ref2", "1.0.0"})
+			componentVersionRef2, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-" + schemaVersionSuffix + "-ref2", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersionList := &model.ComponentVersionList{
@@ -386,11 +387,11 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil, &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-v2-mixed", "1.0.0"})
+			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v2-mixed", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
-			componentVersionRef1, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-v2-ref1", "1.0.0"})
+			componentVersionRef1, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v2-ref1", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
-			componentVersionRef2, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-v3alpha1-ref2", "1.0.0"})
+			componentVersionRef2, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v3alpha1-ref2", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersionList := &model.ComponentVersionList{
@@ -442,11 +443,11 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil, &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-v3alpha1-mixed", "1.0.0"})
+			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v3alpha1-mixed", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
-			componentVersionRef1, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-v2-ref1", "1.0.0"})
+			componentVersionRef1, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v2-ref1", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
-			componentVersionRef2, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{repositoryContext, "example.com/landscaper-component-v3alpha1-ref2", "1.0.0"})
+			componentVersionRef2, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v3alpha1-ref2", Version: "1.0.0"})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersionList := &model.ComponentVersionList{

--- a/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-04.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-04.yaml
@@ -13,3 +13,8 @@
         kind: Configuration
         {{- $res := getResource .cd "name" "mycustomimage" }}
         image: {{ $res.access.imageReference }}
+        images:
+        {{- $resources := getResources .cd "class" "image" }}
+        {{- range $_, $resource := $resources }}
+        - image: {{ $resource.access.imageReference }}
+        {{- end }}

--- a/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-30.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-30.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: GoTemplate
+  template: |
+    deployItems:
+    - name: schema-version-specific
+      type: landscaper.gardener.cloud/mock
+      config:
+        name: {{ .cd.component.name }}
+        names:
+        {{- range $_, $cd := .components.components }}
+          - name: {{ $cd.component.name }}
+        {{- end }}

--- a/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-31.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/gotemplate/template-31.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: GoTemplate
+  template: |
+    deployItems:
+    - name: schema-version-specific
+      type: landscaper.gardener.cloud/mock
+      config:
+        name: {{ .cd.metadata.name }}
+        names:
+        {{- range $_, $cd := .components }}
+          - name: {{ $cd.metadata.name }}
+        {{- end }}

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2-mixed.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2-mixed.yaml
@@ -1,0 +1,24 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/landscaper-component-v2-mixed
+  version: 1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "/"
+
+  sources: []
+
+  resources: []
+
+  componentReferences:
+    - name: ref1
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v2-ref1
+    - name: ref2
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v3alpha1-ref2

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2-ref1.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2-ref1.yaml
@@ -1,0 +1,18 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/landscaper-component-v2-ref1
+  version: 1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "/"
+
+  sources: []
+
+  resources: []
+
+  componentReferences: []

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2-ref2.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2-ref2.yaml
@@ -1,0 +1,18 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/landscaper-component-v2-ref2
+  version: 1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "/"
+
+  sources: []
+
+  resources: []
+
+  componentReferences: []

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v2.yaml
@@ -1,0 +1,24 @@
+meta:
+  schemaVersion: v2
+
+component:
+  name: example.com/landscaper-component-v2
+  version: 1.0.0
+
+  provider: internal
+
+  repositoryContexts:
+    - type: ociRegistry
+      baseUrl: "/"
+
+  sources: []
+
+  resources: []
+
+  componentReferences:
+    - name: ref1
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v2-ref1
+    - name: ref2
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v2-ref2

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3-mixed.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3-mixed.yaml
@@ -1,0 +1,18 @@
+apiVersion: ocm.software/v3alpha1
+kind: ComponentVersion
+metadata:
+  name: example.com/landscaper-component-v3alpha1-mixed
+  provider:
+    name: internal
+  version: 1.0.0
+repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "/"
+spec:
+  references:
+    - name: ref1
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v2-ref1
+    - name: ref2
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v3alpha1-ref2

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3-ref1.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3-ref1.yaml
@@ -1,0 +1,11 @@
+apiVersion: ocm.software/v3alpha1
+kind: ComponentVersion
+metadata:
+  name: example.com/landscaper-component-v3alpha1-ref1
+  provider:
+    name: internal
+  version: 1.0.0
+repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "/"
+spec: {}

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3-ref2.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3-ref2.yaml
@@ -1,0 +1,11 @@
+apiVersion: ocm.software/v3alpha1
+kind: ComponentVersion
+metadata:
+  name: example.com/landscaper-component-v3alpha1-ref2
+  provider:
+    name: internal
+  version: 1.0.0
+repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "/"
+spec: {}

--- a/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/shared_data/localocmrepository/component-descriptor-v3.yaml
@@ -1,0 +1,18 @@
+apiVersion: ocm.software/v3alpha1
+kind: ComponentVersion
+metadata:
+  name: example.com/landscaper-component-v3alpha1
+  provider:
+    name: internal
+  version: 1.0.0
+repositoryContexts:
+  - type: ociRegistry
+    baseUrl: "/"
+spec:
+  references:
+    - name: ref1
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v3alpha1-ref1
+    - name: ref2
+      version: 1.0.0
+      componentName: example.com/landscaper-component-v3alpha1-ref2

--- a/pkg/landscaper/installations/executions/template/testdata/spifftemplate/text/template-30.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/spifftemplate/text/template-30.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: Spiff
+  template:
+    deployItems:
+      - name: test
+        type: landscaper.gardener.cloud/mock
+        config:
+          name: (( cd.component.name ))
+          names: (( map[components.components|c|->{"name"=c.component.name}] ))

--- a/pkg/landscaper/installations/executions/template/testdata/spifftemplate/text/template-31.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/spifftemplate/text/template-31.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: Spiff
+  template:
+    deployItems:
+      - name: test
+        type: landscaper.gardener.cloud/mock
+        config:
+          name: (( cd.metadata.name ))
+          names: (( map[components|c|->{"name"=c.metadata.name}] ))

--- a/pkg/landscaper/installations/executions/template/testdata/spifftemplate/yaml/template-30.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/spifftemplate/yaml/template-30.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: Spiff
+  template:
+    deployItems:
+      - name: test
+        type: landscaper.gardener.cloud/mock
+        config:
+          name: (( cd.component.name ))
+          names: (( map[components.components|c|->{"name"=c.component.name}] ))

--- a/pkg/landscaper/installations/executions/template/testdata/spifftemplate/yaml/template-31.yaml
+++ b/pkg/landscaper/installations/executions/template/testdata/spifftemplate/yaml/template-31.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- name: one
+  type: Spiff
+  template:
+    deployItems:
+      - name: test
+        type: landscaper.gardener.cloud/mock
+        config:
+          name: (( cd.metadata.name ))
+          names: (( map[components|c|->{"name"=c.metadata.name}] ))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority 1

**What this PR does / why we need it**:
This PR enables to template against component descriptors of schema version v3alpha1 in blueprints.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We discussed that the templating should always be done against the schema version of the component descriptor that is provided in the installation which is usually also the component descriptor containing the blueprint.
With this implementation, this is the default. But as the creator of the blueprint is not necessarily the creator of the installation or the component descriptor provided in the installation, I also implemented the option to specify the schema version to template against in the blueprint itself as an annotation. 

Should we keep this or should I get rid of this?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature
templating against ocm component descriptors
```
