### PR TITLE
fix credential propagation for oci helm resource

### DIFF
--- a/pkg/components/cnudie/factory.go
+++ b/pkg/components/cnudie/factory.go
@@ -125,6 +125,7 @@ func (*Factory) NewHelmRepoResource(ctx context.Context,
 
 // NewHelmOCIResource returns a helm chart resource that is stored in an OCI registry.
 func (*Factory) NewHelmOCIResource(ctx context.Context,
+	fs vfs.FileSystem,
 	ociImageRef string,
 	registryPullSecrets []corev1.Secret,
 	ociConfig *config.OCIConfiguration,

--- a/pkg/components/model/factory.go
+++ b/pkg/components/model/factory.go
@@ -72,6 +72,7 @@ type Factory interface {
 
 	// NewHelmOCIResource returns a helm chart resource that is stored in an OCI registry.
 	NewHelmOCIResource(ctx context.Context,
+		fs vfs.FileSystem,
 		ociImageRef string,
 		registryPullSecrets []corev1.Secret,
 		ociConfig *config.OCIConfiguration,

--- a/pkg/components/ocmlib/factory.go
+++ b/pkg/components/ocmlib/factory.go
@@ -253,7 +253,7 @@ func (f *Factory) NewHelmOCIResource(ctx context.Context, ociImageRef string, re
 		if !ok {
 			continue
 		}
-		credspec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes)
+		credspec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes, true)
 		_, err := provider.ocictx.CredentialsContext().RepositoryForSpec(credspec)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot create credentials from secret")

--- a/pkg/components/ocmlib/factory.go
+++ b/pkg/components/ocmlib/factory.go
@@ -63,11 +63,6 @@ func (*Factory) NewRegistryAccess(ctx context.Context,
 	registryAccess.octx = ocm.New(datacontext.MODE_EXTENDED)
 	registryAccess.session = ocm.NewSession(datacontext.NewSession())
 
-	ociConfigFiles := make([]string, 0)
-	if ociRegistryConfig != nil {
-		ociConfigFiles = ociRegistryConfig.ConfigFiles
-	}
-
 	var localfs vfs.FileSystem
 	if localRegistryConfig != nil {
 		var err error
@@ -120,41 +115,16 @@ func (*Factory) NewRegistryAccess(ctx context.Context,
 
 	}
 
-	for _, path := range ociConfigFiles {
-		dockerConfigBytes, err := vfs.ReadFile(fs, path)
-		if err != nil {
-			return nil, err
-		}
-		spec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes, true)
-		_, err = registryAccess.octx.CredentialsContext().RepositoryForSpec(spec)
-		if err != nil {
+	if ociRegistryConfig != nil {
+		// set credentials from pull secrets
+		if err := addConfigFileCredsToCredContext(fs, ociRegistryConfig.ConfigFiles, registryAccess.octx); err != nil {
 			return nil, err
 		}
 	}
 
 	// set credentials from pull secrets
-	for _, secret := range secrets {
-		dockerConfigBytes, ok := secret.Data[corev1.DockerConfigJsonKey]
-		if ok {
-			spec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes, true)
-			_, err := registryAccess.octx.CredentialsContext().RepositoryForSpec(spec)
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot create credentials from secret")
-			}
-		}
-		ocmConfigBytes, ok := secret.Data[".ocmcredentialconfig"]
-		if ok {
-			cfg, err := registryAccess.octx.ConfigContext().GetConfigForData(ocmConfigBytes, runtime.DefaultYAMLEncoding)
-			if err != nil {
-				return nil, err
-			}
-			if cfg.GetKind() == credconfig.ConfigType {
-				err := registryAccess.octx.ConfigContext().ApplyConfig(cfg, fmt.Sprintf("landscaper secret: %s/%s", secret.Namespace, secret.Name))
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
+	if err := addSecretCredsToCredContext(secrets, registryAccess.octx); err != nil {
+		return nil, err
 	}
 
 	return registryAccess, nil
@@ -216,7 +186,16 @@ func (c *CredentialSource) Credentials(ctx credentials.Context, _ ...credentials
 	return credentials.NewCredentials(props), nil
 }
 
-func (f *Factory) NewHelmOCIResource(ctx context.Context, ociImageRef string, registryPullSecrets []corev1.Secret, ociConfig *config.OCIConfiguration, sharedCache cache.Cache) (model.TypedResourceProvider, error) {
+func (f *Factory) NewHelmOCIResource(ctx context.Context,
+	fs vfs.FileSystem, ociImageRef string,
+	registryPullSecrets []corev1.Secret,
+	ociConfig *config.OCIConfiguration,
+	sharedCache cache.Cache) (model.TypedResourceProvider, error) {
+
+	if fs == nil {
+		fs = osfs.New()
+	}
+
 	refspec, err := oci.ParseRef(ociImageRef)
 	if err != nil {
 		return nil, err
@@ -229,36 +208,65 @@ func (f *Factory) NewHelmOCIResource(ctx context.Context, ociImageRef string, re
 		repourl: fmt.Sprintf("oci://%s", refspec.Host),
 	}
 
-	ociConfigFiles := make([]string, 0)
 	if ociConfig != nil {
-		ociConfigFiles = ociConfig.ConfigFiles
-	}
-
-	// set available default credentials from dockerconfig files
-	var credspec *dockerconfig.RepositorySpec
-	for _, path := range ociConfigFiles {
-		credspec = dockerconfig.NewRepositorySpec(path, true)
-		_, err := provider.ocictx.CredentialsContext().RepositoryForSpec(credspec)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot access %v", path)
+		// set credentials from config files
+		if err = addConfigFileCredsToCredContext(fs, ociConfig.ConfigFiles, provider.ocictx); err != nil {
+			return nil, err
 		}
 	}
 
 	// set credentials from pull secrets
-	for _, secret := range registryPullSecrets {
-		if secret.Type != corev1.SecretTypeDockerConfigJson {
-			continue
-		}
-		dockerConfigBytes, ok := secret.Data[corev1.DockerConfigJsonKey]
-		if !ok {
-			continue
-		}
-		credspec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes, true)
-		_, err := provider.ocictx.CredentialsContext().RepositoryForSpec(credspec)
-		if err != nil {
-			return nil, errors.Wrapf(err, "cannot create credentials from secret")
-		}
+	if err = addSecretCredsToCredContext(registryPullSecrets, provider.ocictx); err != nil {
+		return nil, err
 	}
 
 	return provider, nil
+}
+
+func addConfigFileCredsToCredContext(fs vfs.FileSystem, filePaths []string, provider credentials.ContextProvider) error {
+	credctx := provider.CredentialsContext()
+
+	// set available default credentials from dockerconfig files
+	for _, path := range filePaths {
+		dockerConfigBytes, err := vfs.ReadFile(fs, path)
+		if err != nil {
+			return err
+		}
+		spec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes, true)
+		_, err = credctx.RepositoryForSpec(spec)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addSecretCredsToCredContext(secrets []corev1.Secret, provider credentials.ContextProvider) error {
+	credctx := provider.CredentialsContext()
+	cfgctx := credctx.ConfigContext()
+
+	for _, secret := range secrets {
+		dockerConfigBytes, ok := secret.Data[corev1.DockerConfigJsonKey]
+		if ok {
+			spec := dockerconfig.NewRepositorySpecForConfig(dockerConfigBytes, true)
+			_, err := credctx.RepositoryForSpec(spec)
+			if err != nil {
+				return errors.Wrapf(err, "cannot create credentials from secret")
+			}
+		}
+		ocmConfigBytes, ok := secret.Data[".ocmcredentialconfig"]
+		if ok {
+			cfg, err := cfgctx.GetConfigForData(ocmConfigBytes, runtime.DefaultYAMLEncoding)
+			if err != nil {
+				return err
+			}
+			if cfg.GetKind() == credconfig.ConfigType {
+				err := cfgctx.ApplyConfig(cfg, fmt.Sprintf("landscaper secret: %s/%s", secret.Namespace, secret.Name))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/components/ocmlib/registryaccess.go
+++ b/pkg/components/ocmlib/registryaccess.go
@@ -102,10 +102,6 @@ func (r *RegistryAccess) GetComponentVersion(ctx context.Context, cdRef *lsv1alp
 	return r.NewComponentVersion(cv)
 }
 
-func (r *RegistryAccess) OCMContext() ocm.Context {
-	return r.octx
-}
-
 func (r *RegistryAccess) Close() error {
 	err := r.session.Close()
 	if err != nil {

--- a/pkg/components/ocmlib/suite_test.go
+++ b/pkg/components/ocmlib/suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package ocmlib_test
+package ocmlib
 
 import (
 	"testing"

--- a/pkg/deployer/helm/chartresolver/chart.go
+++ b/pkg/deployer/helm/chartresolver/chart.go
@@ -93,7 +93,7 @@ func getChartFromOCIRef(ctx context.Context,
 	ociConfig *config.OCIConfiguration,
 	sharedCache cache.Cache) (*chart.Chart, error) {
 
-	resource, err := registries.GetFactory(contextObj.UseOCM).NewHelmOCIResource(ctx, ociImageRef, registryPullSecrets, ociConfig, sharedCache)
+	resource, err := registries.GetFactory(contextObj.UseOCM).NewHelmOCIResource(ctx, nil, ociImageRef, registryPullSecrets, ociConfig, sharedCache)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 1

**What this PR does / why we need it**:
For helm oci resources, secrets were not propagated into the ocm lib, which led to authentication failure. 

This PR fixes this bug by aligning the credential handling implementation for `HelmOCIResource` (the objects with which the deployer fetch helm charts) and the credential handling implementation of the main `RegistryAccess`. Therefore, it introduces two auxiliary functions `addConfigFileCredsToCredContext` and `addSecretCredsToCredContext` that are used in both implementations. Furthermore, it adds tests to cover this bug.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
