### PR TITLE
Integration test: use target selectors in blueprints test 

### DIFF
--- a/hack/int-test-helper/install-landscaper
+++ b/hack/int-test-helper/install-landscaper
@@ -37,12 +37,24 @@ landscaper:
         container:
           deployer:
             verbosityLevel: debug
+            targetSelector:
+            - annotations:
+              - key: landscaper.gardener.cloud/environment
+                operator: !
         helm:
           deployer:
             verbosityLevel: debug
+            targetSelector:
+            - annotations:
+              - key: landscaper.gardener.cloud/environment
+                operator: !
         manifest:
           deployer:
             verbosityLevel: debug
+            targetSelector:
+            - annotations:
+              - key: landscaper.gardener.cloud/environment
+                operator: !
     deployItemTimeouts:
       pickup: 30s
       abort: 30s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority 3

**What this PR does / why we need it**:

This pull request affects only the integration tests. 
It is a continuation of [Integration tests: make retrying client context aware #881](https://github.com/gardener/landscaper/pull/881) to fix the blueprints test.

##### (C) Deployer responsibility

During the blueprints tests, there are two competing deployers. We define target selectors to separate their responsibilities.

##### (D) Test all four deployers

Due to a copy-paste error, the manifest deployer was skipped and instead the mock deployer was tested twice. This has been fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
