### PR TITLE
create new ocm context per reconciliation

### DIFF
--- a/pkg/components/ocmlib/factory.go
+++ b/pkg/components/ocmlib/factory.go
@@ -202,7 +202,7 @@ func (f *Factory) NewHelmOCIResource(ctx context.Context,
 	}
 
 	provider := &HelmChartProvider{
-		ocictx:  oci.DefaultContext(),
+		ocictx:  oci.New(datacontext.MODE_EXTENDED),
 		ref:     refspec.Repository,
 		version: refspec.Version(),
 		repourl: fmt.Sprintf("oci://%s", refspec.Host),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 1

**What this PR does / why we need it**:
The `NewHelmOCIResource` method used an oci default context provided by the ocm library through `oci.DefaultContext()`. Since this context is implemented as a global variable, changes the context are stored over multiple reconciliation loops. Since we read e.g. credentials to oci or helm repositories and put them into the context object during a reconciliation, we added the same credentials to the context multiple times (thus, e.g. after a resource was reconciled 6 times, the context contained 6 instances of the same credential). 

This changes the behaviour to create a new context each time the method is called. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
NONE
```
