### PR TITLE
update ocm dependency to include helm downloader fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
-	github.com/open-component-model/ocm v0.4.1
+	github.com/open-component-model/ocm v0.4.3
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1309,8 +1309,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
-github.com/open-component-model/ocm v0.4.1 h1:YXzOZhRJz9M/Ku9jsPzFxcZEF8VK4aS1sRwmstbL9zA=
-github.com/open-component-model/ocm v0.4.1/go.mod h1:KsuXGr4sw1EWgPRFQ8i5Ly7kKY6fBHbsr0wgfoGDyT0=
+github.com/open-component-model/ocm v0.4.3 h1:X92u0PHBdk6nd7sT+JDFjCJwevTdnB7Dbp1IMFHF/fA=
+github.com/open-component-model/ocm v0.4.3/go.mod h1:KsuXGr4sw1EWgPRFQ8i5Ly7kKY6fBHbsr0wgfoGDyT0=
 github.com/opencontainers/distribution-spec v1.0.1 h1:hT6tF6uKZAQh+HH3BrJqn7/xHhMoDHzahIg4KxD2DqM=
 github.com/opencontainers/distribution-spec v1.0.1/go.mod h1:copR2flp+jTEvQIFMb6MIx45OkrxzqyjszPDT3hx/5Q=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/vendor/github.com/open-component-model/ocm/pkg/helm/downloader.go
+++ b/vendor/github.com/open-component-model/ocm/pkg/helm/downloader.go
@@ -17,6 +17,7 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 
 	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/repositories/directcreds"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	ocihelm "github.com/open-component-model/ocm/pkg/contexts/ocm/download/handlers/helm"
@@ -73,7 +74,12 @@ func DownloadChart(out common.Printer, ctx oci.ContextProvider, ref, version, re
 	if registry.IsOCI(repourl) {
 		fs := osfs.New()
 		chart = vfs.Join(fs, dl.root, filepath.Base(ref)+".tgz")
-		creds := directcreds.NewCredentials(dl.creds)
+
+		var creds credentials.CredentialsSource
+		if dl.creds != nil {
+			creds = directcreds.NewCredentials(dl.creds)
+		}
+
 		chart, prov, aset, err = ocihelm.Download2(out, ctx.OCIContext(), identity.OCIRepoURL(repourl, ref)+":"+version, chart, osfs.New(), true, creds)
 		if prov != "" && dl.Verify > downloader.VerifyNever && dl.Verify != downloader.VerifyLater {
 			_, err = downloader.VerifyChart(chart, dl.Keyring)
@@ -101,12 +107,12 @@ func DownloadChart(out common.Printer, ctx oci.ContextProvider, ref, version, re
 func (d *chartDownloader) complete(ctx oci.ContextProvider, ref, repourl string) error {
 	rf := repo.NewFile()
 
-	creds := d.creds
 	if d.creds == nil {
 		d.creds = identity.GetCredentials(ctx.OCIContext(), repourl, ref)
-		if d.creds == nil {
-			creds = common.Properties{}
-		}
+	}
+	creds := d.creds
+	if creds == nil {
+		creds = common.Properties{}
 	}
 
 	config := vfs.Join(d.fs, d.root, ".config")

--- a/vendor/github.com/open-component-model/ocm/pkg/helm/identity/identity.go
+++ b/vendor/github.com/open-component-model/ocm/pkg/helm/identity/identity.go
@@ -76,6 +76,10 @@ func OCIRepoURL(repourl string, chartname string) string {
 }
 
 func GetConsumerId(repourl string, chartname string) cpi.ConsumerIdentity {
+	i := strings.LastIndex(chartname, ":")
+	if i >= 0 {
+		chartname = chartname[:i]
+	}
 	if registry.IsOCI(repourl) {
 		repourl = strings.TrimSuffix(repourl, "/")
 		return ociidentity.GetConsumerId(OCIRepoURL(repourl, ""), chartname)
@@ -89,7 +93,7 @@ func GetCredentials(ctx credentials.ContextProvider, repourl string, chartname s
 	if id == nil {
 		return nil
 	}
-	creds, err := credentials.CredentialsForConsumer(ctx.CredentialsContext(), id, identityMatcher)
+	creds, err := credentials.CredentialsForConsumer(ctx.CredentialsContext(), id)
 	if creds == nil || err != nil {
 		return nil
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1125,7 +1125,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/open-component-model/ocm v0.4.1
+# github.com/open-component-model/ocm v0.4.3
 ## explicit; go 1.19
 github.com/open-component-model/ocm/pkg/cobrautils/flag
 github.com/open-component-model/ocm/pkg/cobrautils/flagsets


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area helm-deployer
/kind bug
/priority 1

**What this PR does / why we need it**:
The ocm-lib facade implementation of the helm deployer uses a `ChartDownloader` provided by the ocm library. This downloader had bugs that prevented successful authentication against helm repositories and oci registries. Therefore, the helm deployer was not able to deploy helm charts that were stored in private registries even though the correct credentials were provided. 

We fixed these bugs in the ocm-lib and therefore have to upgrade the dependency to the fixed version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
