### PR TITLE
add log statements for cluster creation (run-int-tests)

### DIFF
--- a/hack/testcluster/pkg/shootcluster_manager.go
+++ b/hack/testcluster/pkg/shootcluster_manager.go
@@ -372,6 +372,7 @@ func (o *ShootClusterManager) waitUntilShootClusterIsReady(ctx context.Context, 
 		shoot, getError := gardenClient.Get(ctx, clusterName, metav1.GetOptions{})
 		if getError != nil {
 			if errors.IsNotFound(getError) {
+				o.log.Logfln("is not found")
 				return false, nil
 			}
 
@@ -398,6 +399,7 @@ func (o *ShootClusterManager) waitUntilShootClusterIsReady(ctx context.Context, 
 		if !ok {
 			return false, fmt.Errorf("failed to get cluster status: unexpected type")
 		}
+		o.log.Logfln("conditions: ", conditions)
 
 		checkList := map[string]bool{
 			"APIServerAvailable":      false,
@@ -406,6 +408,7 @@ func (o *ShootClusterManager) waitUntilShootClusterIsReady(ctx context.Context, 
 			"SystemComponentsHealthy": false,
 		}
 
+		o.log.Logfln("checklist: ", checkList)
 		for _, condition := range conditions {
 			conditionMap, ok := condition.(map[string]interface{})
 			if !ok {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/priority 3

**What this PR does / why we need it**:
Alternative PR for Stabilize-Integration-Tests PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
