### PR TITLE
fix deployer

### DIFF
--- a/pkg/deployer/container/container.go
+++ b/pkg/deployer/container/container.go
@@ -72,24 +72,27 @@ func New(lsClient,
 	lsCtx *lsv1alpha1.Context,
 	sharedCache cache.Cache,
 	rt *lsv1alpha1.ResolvedTarget) (*Container, error) {
+
+	currOp := "InitContainerOperation"
+
 	providerConfig := &containerv1alpha1.ProviderConfiguration{}
 	decoder := api.NewDecoder(Scheme)
 	if _, _, err := decoder.Decode(item.Spec.Configuration.Raw, nil, providerConfig); err != nil {
 		return nil, lserrors.NewWrappedError(err,
-			"Init", "DecodeProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
+			currOp, "DecodeProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
 	applyDefaults(&config, providerConfig)
 
 	if err := container1alpha1validation.ValidateProviderConfiguration(providerConfig); err != nil {
 		return nil, lserrors.NewWrappedError(err,
-			"Init", "ValidateProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
+			currOp, "ValidateProviderConfiguration", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
 	status, err := DecodeProviderStatus(item.Status.ProviderStatus)
 	if err != nil {
 		return nil, lserrors.NewWrappedError(err,
-			"Init", "DecodeProviderStatus", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
+			currOp, "DecodeProviderStatus", err.Error(), lsv1alpha1.ErrorConfigurationProblem)
 	}
 
 	return &Container{

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -78,6 +78,7 @@ func New(helmconfig helmv1alpha1.Configuration,
 	sharedCache cache.Cache) (*Helm, error) {
 
 	currOp := "InitHelmOperation"
+
 	config := &helmv1alpha1.ProviderConfiguration{}
 	helmdecoder := api.NewDecoder(HelmScheme)
 	if _, _, err := helmdecoder.Decode(item.Spec.Configuration.Raw, nil, config); err != nil {

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -352,6 +352,11 @@ func (c *controller) reconcile(ctx context.Context, deployItem *lsv1alpha1.Deplo
 		return lsErr
 	}
 
+	if deployItem.Spec.Configuration == nil || len(deployItem.Spec.Configuration.Raw) == 0 {
+		return lserrors.NewError(operation, "ProviderConfigurationMissing", "provider configuration missing",
+			lsv1alpha1.ErrorConfigurationProblem)
+	}
+
 	err := c.deployer.Reconcile(ctx, lsCtx, deployItem, rt)
 	return lserrors.BuildLsErrorOrNil(err, operation, "Reconcile")
 }

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -72,8 +72,10 @@ func New(lsKubeClient client.Client,
 	item *lsv1alpha1.DeployItem,
 	rt *lsv1alpha1.ResolvedTarget) (*Manifest, error) {
 
-	config := &manifestv1alpha2.ProviderConfiguration{}
 	currOp := "InitManifestOperation"
+
+	config := &manifestv1alpha2.ProviderConfiguration{}
+
 	manifestDecoder := api.NewDecoder(Scheme)
 	if _, _, err := manifestDecoder.Decode(item.Spec.Configuration.Raw, nil, config); err != nil {
 		return nil, lserrors.NewWrappedError(err,

--- a/pkg/deployer/manifest/test/testdata/08-di-no-config.yaml
+++ b/pkg/deployer/manifest/test/testdata/08-di-no-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: my-manifests
+spec:
+  type: landscaper.gardener.cloud/kubernetes-manifest
+
+  target: # has to be of type landscaper.gardener.cloud/kubernetes-cluster
+    name: my-cluster
+    namespace: test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind bug
/priority 3

**What this PR does / why we need it**:

Fix for deployer restart if provider config is missing in deploy item.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
- Fix for deployer restart if provider config is missing in deploy item.
```
