### PR TITLE
document ocm feature switch for guided tour

### DIFF
--- a/docs/guided-tour/README.md
+++ b/docs/guided-tour/README.md
@@ -25,7 +25,11 @@ In this tour, you will learn about the different Landscaper features by simple e
 
 > **_NOTE:_** **The Landscaper now also supports [OCM (Open Component Model)](https://ocm.software/) Component
 > Descriptors [Version 3](https://ocm.software/docs/component-descriptors/version-3/), additionally to [Version
-> 2](https://ocm.software/docs/component-descriptors/version-2/).**
+> 2](https://ocm.software/docs/component-descriptors/version-2/).  
+> Since we try our best to avoid disruptions, this functionality is currently behind a feature switch. For detailed 
+> information on how to enable this for your own landscaper instance, set the corresponding flag in the configuration to
+> `true`, as shown [here](https://github.com/gardener/landscaper/blob/master/docs/installation/install-landscaper-controller.md#configuration-through-valuesyaml).
+> If you just want to follow along the tour, you should have the switch enabled!**
 
 ## A Hello World Example
 

--- a/docs/guided-tour/blueprints/external-blueprint/README.md
+++ b/docs/guided-tour/blueprints/external-blueprint/README.md
@@ -27,6 +27,9 @@ in this script: [commands/push-blueprint.sh](./commands/push-blueprint.sh).
 
 ## Components and Component Descriptors
 
+> **_NOTE:_** **To follow along the following section, be sure to set the `useOCM: true` feature switch in the 
+> values.yaml, as shown [here](https://github.com/gardener/landscaper/blob/master/docs/installation/install-landscaper-controller.md#configuration-through-valuesyaml).**
+
 An Installation may reference its blueprints via so-called
 [component-descriptors](../../../concepts/Glossary.md#_component-descriptor_).  A component descriptor describes a
 component, or rather, a specific component version. In general, a component version is a container for all required

--- a/docs/installation/install-landscaper-controller.md
+++ b/docs/installation/install-landscaper-controller.md
@@ -75,7 +75,12 @@ landscaper:
           }
       metrics:
         port: 8080  
-    
+        
+      # tell the landscaper to use the new ocm tooling to process components     
+      # if you use the ocm-cli to create components you likely want this to be set to true
+      # if you use the deprecated component-cli to create components you likely want this to be set to false
+      useOCM: true # current default: false    
+      
       # deploy with integrated deployers for quick start
       deployers: 
       - container


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind technical-debt
/priority 2

**What this PR does / why we need it**:
Since we want to deprecate the component-cli/component-spec based implementations within the landscaper, we adjusted the Guided Tour to be based on the ocm tooling such as the ocm-cli. The thereby created components are always compatible with the component-cli implementation.
Therefore, it should be mentioned prominently in the beginning of the Guided Tour, that the feature switch should be set to true.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
