### PR TITLE
Automatic reconcile

### DIFF
--- a/apis/core/v1alpha1/constants.go
+++ b/apis/core/v1alpha1/constants.go
@@ -38,6 +38,9 @@ const (
 	// ReconcileReasonAnnotation can be used to specify a reason for a reconcile operation, for example a retry.
 	ReconcileReasonAnnotation = LandscaperDomain + "/reconcile-reason"
 
+	// ReconcileIfChangedAnnotation can be used to automatically trigger a reconcile operation if the spec has changed
+	ReconcileIfChangedAnnotation = LandscaperDomain + "/reconcile-if-changed"
+
 	// ReconcileTimestampAnnotation is used to recognize timeouts in deployitems
 	ReconcileTimestampAnnotation = LandscaperDomain + "/reconcile-time"
 

--- a/apis/core/v1alpha1/helper/helpers.go
+++ b/apis/core/v1alpha1/helper/helpers.go
@@ -221,6 +221,11 @@ func RemoveVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObject
 	return objects
 }
 
+func HasReconcileIfChangedAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.ReconcileIfChangedAnnotation]
+	return ok && v == "true"
+}
+
 // HasIgnoreAnnotation returns true only if the given object
 // has the 'landscaper.gardener.cloud/ignore' annotation
 // and its value is 'true'.

--- a/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/controller-utils/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -38,6 +38,9 @@ const (
 	// ReconcileReasonAnnotation can be used to specify a reason for a reconcile operation, for example a retry.
 	ReconcileReasonAnnotation = LandscaperDomain + "/reconcile-reason"
 
+	// ReconcileIfChangedAnnotation can be used to automatically trigger a reconcile operation if the spec has changed
+	ReconcileIfChangedAnnotation = LandscaperDomain + "/reconcile-if-changed"
+
 	// ReconcileTimestampAnnotation is used to recognize timeouts in deployitems
 	ReconcileTimestampAnnotation = LandscaperDomain + "/reconcile-time"
 

--- a/docs/guided-tour/hello-world/README.md
+++ b/docs/guided-tour/hello-world/README.md
@@ -106,9 +106,15 @@ Note that deleting an `Installation` like this will also delete the deployed Hel
 ## Automatic Reconcile
 
 Above we wrote that Landscaper only starts working on an Installation if it has the annotation
-`landscaper.gardener.cloud/operation: reconcile`. There is also the possibility to let Landscaper add this
-annotation automatically such that you get an automatic reconciliation of an Installation. For more details
-see [here](../../usage/Installations.md#automatic-reconciliationprocessing-of-installations).
+`landscaper.gardener.cloud/operation: reconcile`. 
+
+There is also the possibility to let Landscaper add this annotation automatically such that you get an automatic 
+reconciliation of an Installation. For more details see 
+[here](../../usage/Installations.md#automatic-reconciliationprocessing-of-installations).
+
+With the annotation `landscaper.gardener.cloud/reconcile-if-changed: true`, Installations are automatically processed
+only if their `spec` was changed and a new `generation` created. For more details see
+[here](../../usage/Installations.md#automatic-reconciliationprocessing-of-installations-if-spec-was-changed).
 
 ## References
 

--- a/docs/usage/Installations.md
+++ b/docs/usage/Installations.md
@@ -920,3 +920,16 @@ the spec, the labels or annotations of an installations. If you want to start th
 annotation. With this strategy, it is possible to make different changes before starting the processing. If you
 do not want this behaviour, you could just always add the reconcile annotation together with any changes of the 
 installation. 
+
+## Automatic Reconciliation/Processing of Installations if Spec was changed
+
+As already described before, the Landscaper only processes an installation if the annotation 
+`landscaper.gardener.cloud/operation: reconcile` is set. If you add the annotation 
+`landscaper.gardener.cloud/reconcile-if-changed: true` to the Installation, the Landscaper automatically adds the reconcile 
+annotation to the Installation when the `spec` of the Installation was changed and therefore the `generation` differs 
+from the `observedGeneration` in the status.
+
+The motivation for this annotation is that in a system setup where e.g. Flux is watching and synchronizing Installations 
+from a git repository, the `reconcile` annotation which is removed when processing an Installation, would be added again 
+by flux and this results in endless reconcile iterations. The `reconcile-if-changed` annotation is not removed by 
+Landscaper preventing frequent reconciliations but relevant modifications of an Installation are still processed.

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -181,6 +181,16 @@ func (c *Controller) handleAutomaticReconcile(ctx context.Context, inst *lsv1alp
 
 	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "handleAutomaticReconcile")
 
+	if installations.IsRootInstallation(inst) &&
+		metav1.HasAnnotation(inst.ObjectMeta, lsv1alpha1.ReconcileIfChangedAnnotation) &&
+		!lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) &&
+		inst.Status.JobID == inst.Status.JobIDFinished &&
+		inst.GetGeneration() != inst.Status.ObservedGeneration {
+		if err := c.addReconcileAnnotation(ctx, inst); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	retryHelper := newRetryHelper(c.Client(), c.clock)
 
 	if err := retryHelper.preProcessRetry(ctx, inst); err != nil {
@@ -418,4 +428,17 @@ func (c *Controller) setInstallationPhaseAndUpdate(ctx context.Context, inst *ls
 	}
 
 	return lsError
+}
+
+func (c *Controller) addReconcileAnnotation(ctx context.Context, inst *lsv1alpha1.Installation) error {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
+
+	lsv1alpha1helper.SetOperation(&inst.ObjectMeta, lsv1alpha1.ReconcileOperation)
+
+	if err := c.Writer().UpdateInstallation(ctx, read_write_layer.W000078, inst); err != nil {
+		logger.Error(err, "failed to trigger automatic reconcile operation of installation")
+		return err
+	}
+
+	return nil
 }

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -182,7 +182,7 @@ func (c *Controller) handleAutomaticReconcile(ctx context.Context, inst *lsv1alp
 	logger, _ := logging.FromContextOrNew(ctx, nil, lc.KeyMethod, "handleAutomaticReconcile")
 
 	if installations.IsRootInstallation(inst) &&
-		metav1.HasAnnotation(inst.ObjectMeta, lsv1alpha1.ReconcileIfChangedAnnotation) &&
+		lsv1alpha1helper.HasReconcileIfChangedAnnotation(inst.ObjectMeta) &&
 		!lsv1alpha1helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation) &&
 		inst.Status.JobID == inst.Status.JobIDFinished &&
 		inst.GetGeneration() != inst.Status.ObservedGeneration {

--- a/pkg/landscaper/controllers/installations/controller_test.go
+++ b/pkg/landscaper/controllers/installations/controller_test.go
@@ -82,9 +82,9 @@ var _ = Describe("Installation Controller", func() {
 		})
 
 		It("should reconcile an installation with reconcile-if-changed annotation", func() {
-			// We consider an Installation in a finished state.
-			// The Installation has no reconcile annotation. Therefore, a reconciliation should have no effect.
-			// After the reconciliation, the jobID and jobIDFinished should be the same as before.
+			// We consider an Installation with a reconcile-if-changed annotation and an observed generation
+			// different from the observation. Though the Installation has no reconcile annotation, it must be
+			// processed.
 			ctx := context.Background()
 
 			var err error

--- a/pkg/landscaper/controllers/installations/testdata/state/test10/00-root.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test10/00-root.yaml
@@ -7,6 +7,9 @@ kind: Installation
 metadata:
   name: root
   namespace: {{ .Namespace }}
+  generation: 2
+  annotations:
+      landscaper.gardener.cloud/reconcile-if-changed: "true"
   finalizers:
   - finalizer.landscaper.gardener.cloud
 spec:
@@ -27,3 +30,4 @@ status:
   phase: Succeeded
   jobID: job1
   jobIDFinished: job1
+  generation: 3

--- a/pkg/landscaper/controllers/installations/testdata/state/test10/00-root.yaml
+++ b/pkg/landscaper/controllers/installations/testdata/state/test10/00-root.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Installation
+metadata:
+  name: root
+  namespace: {{ .Namespace }}
+  finalizers:
+  - finalizer.landscaper.gardener.cloud
+spec:
+
+  componentDescriptor:
+    ref:
+      repositoryContext:
+        type: local
+        baseUrl: "../testdata/registry"
+      version: 1.0.0
+      componentName: example.com/root
+
+  blueprint:
+    ref:
+      resourceName: root-no-imports
+
+status:
+  phase: Succeeded
+  jobID: job1
+  jobIDFinished: job1

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/constants.go
@@ -38,6 +38,9 @@ const (
 	// ReconcileReasonAnnotation can be used to specify a reason for a reconcile operation, for example a retry.
 	ReconcileReasonAnnotation = LandscaperDomain + "/reconcile-reason"
 
+	// ReconcileIfChangedAnnotation can be used to automatically trigger a reconcile operation if the spec has changed
+	ReconcileIfChangedAnnotation = LandscaperDomain + "/reconcile-if-changed"
+
 	// ReconcileTimestampAnnotation is used to recognize timeouts in deployitems
 	ReconcileTimestampAnnotation = LandscaperDomain + "/reconcile-time"
 

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -221,6 +221,11 @@ func RemoveVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObject
 	return objects
 }
 
+func HasReconcileIfChangedAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.ReconcileIfChangedAnnotation]
+	return ok && v == "true"
+}
+
 // HasIgnoreAnnotation returns true only if the given object
 // has the 'landscaper.gardener.cloud/ignore' annotation
 // and its value is 'true'.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Add the reconcile-if-changed annotation to a root installations results in automatic reconcile operations if the spec of the installation is changed. This is required to support the use case where e.g. flux is watching installations in a git repo. Adding the reconcile annotation to these installations would result in a situation where flux is adding again this annotation when if was removed by the landscaper after every reconsiliation. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- automatic reconcile if installation spec changed
```
