### PR TITLE
Logging during cleanup of integration tests

### DIFF
--- a/cmd/landscaper-controller/app/app_test.go
+++ b/cmd/landscaper-controller/app/app_test.go
@@ -10,20 +10,19 @@ import (
 	"testing"
 	"time"
 
-	lsutils "github.com/gardener/landscaper/pkg/utils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/gardener/landscaper/cmd/landscaper-controller/app"
-	deployerconfig "github.com/gardener/landscaper/pkg/deployermanagement/config"
-
 	"github.com/gardener/landscaper/apis/config"
 	lsinstall "github.com/gardener/landscaper/apis/core/install"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/cmd/landscaper-controller/app"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
+	deployerconfig "github.com/gardener/landscaper/pkg/deployermanagement/config"
+	lsutils "github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
@@ -84,7 +83,7 @@ var _ = Describe("Landscaper Controller", func() {
 			Expect(testenv.Client.List(ctx, deployerRegistrations)).To(Succeed())
 			for _, reg := range deployerRegistrations.Items {
 				d := 10 * time.Second
-				Expect(envtest.CleanupForObject(ctx, testenv.Client, &reg, d)).To(Succeed())
+				Expect(envtest.CleanupForObject(ctx, utils.NewDiscardLogger(), testenv.Client, &reg, d)).To(Succeed())
 			}
 		})
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"time"
 
-	utils3 "github.com/gardener/landscaper/pkg/utils"
-
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/gardener/component-cli/ociclient"
 	"github.com/gardener/component-cli/ociclient/cache"
@@ -37,6 +35,7 @@ import (
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	utils2 "github.com/gardener/landscaper/hack/testcluster/pkg/utils"
 	lsscheme "github.com/gardener/landscaper/pkg/api"
+	utils3 "github.com/gardener/landscaper/pkg/utils"
 	"github.com/gardener/landscaper/test/utils"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
@@ -357,7 +356,7 @@ func (f *Framework) cleanupBeforeObjectsInTestNamespace(ctx context.Context, nam
 		return err
 	}
 	for _, obj := range instList.Items {
-		if err := envtest.CleanupForObject(ctx, f.Client, &obj, time.Second); err != nil {
+		if err := envtest.CleanupForObject(ctx, f.logger, f.Client, &obj, time.Second); err != nil {
 			return err
 		}
 	}
@@ -367,7 +366,7 @@ func (f *Framework) cleanupBeforeObjectsInTestNamespace(ctx context.Context, nam
 		return err
 	}
 	for _, obj := range execList.Items {
-		if err := envtest.CleanupForObject(ctx, f.Client, &obj, time.Second); err != nil {
+		if err := envtest.CleanupForObject(ctx, f.logger, f.Client, &obj, time.Second); err != nil {
 			return err
 		}
 	}
@@ -377,7 +376,7 @@ func (f *Framework) cleanupBeforeObjectsInTestNamespace(ctx context.Context, nam
 		return err
 	}
 	for _, obj := range diList.Items {
-		if err := envtest.CleanupForObject(ctx, f.Client, &obj, time.Second); err != nil {
+		if err := envtest.CleanupForObject(ctx, f.logger, f.Client, &obj, time.Second); err != nil {
 			return err
 		}
 	}
@@ -387,7 +386,7 @@ func (f *Framework) cleanupBeforeObjectsInTestNamespace(ctx context.Context, nam
 		return err
 	}
 	for _, obj := range podList.Items {
-		if err := envtest.CleanupForObject(ctx, f.Client, &obj, time.Second); err != nil {
+		if err := envtest.CleanupForObject(ctx, f.logger, f.Client, &obj, time.Second); err != nil {
 			return err
 		}
 	}

--- a/test/integration/deployers/management/dm_tests.go
+++ b/test/integration/deployers/management/dm_tests.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,6 +21,7 @@ import (
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
 	"github.com/gardener/landscaper/pkg/agent"
 	"github.com/gardener/landscaper/pkg/api"
@@ -84,7 +83,7 @@ func DeployerManagementTests(f *framework.Framework) {
 				if previousDeployerRegistrations.Has(reg.Name) {
 					continue
 				}
-				if err := envtest.CleanupForObject(ctx, f.Client, &reg, 2*time.Minute); err != nil {
+				if err := envtest.CleanupForObject(ctx, f.Log(), f.Client, &reg, 2*time.Minute); err != nil {
 					allErrs = append(allErrs, err)
 				}
 			}
@@ -95,7 +94,7 @@ func DeployerManagementTests(f *framework.Framework) {
 				if previousEnvironments.Has(env.Name) {
 					continue
 				}
-				if err := envtest.CleanupForObject(ctx, f.Client, &env, 2*time.Minute); err != nil {
+				if err := envtest.CleanupForObject(ctx, f.Log(), f.Client, &env, 2*time.Minute); err != nil {
 					allErrs = append(allErrs, err)
 				}
 			}
@@ -160,7 +159,7 @@ func DeployerManagementTests(f *framework.Framework) {
 				// remove finalizer from testenv
 				env := &lsv1alpha1.Environment{}
 				env.Name = "testenv"
-				testutil.ExpectNoError(envtest.CleanupForObject(ctx, f.Client, env, 5*time.Second))
+				testutil.ExpectNoError(envtest.CleanupForObject(ctx, f.Log(), f.Client, env, 5*time.Second))
 			})
 
 			It("should create and delete new installations for a new environment", func() {

--- a/test/utils/envtest/retrying_client.go
+++ b/test/utils/envtest/retrying_client.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/landscaper/hack/testcluster/pkg/utils"
@@ -128,6 +127,7 @@ func retrySporadic(ctx context.Context, log utils.Logger, fn func() error) error
 			log.Logfln("retrying client: all attempts failed: %w", err)
 			return err
 		} else if !isSporadicError(err) {
+			log.Logfln("retrying client: stop retrying after non-sporadic error: %w", err)
 			return err
 		} else if ctxError := ctx.Err(); ctxError != nil {
 			log.Logfln("retrying client: stop retrying because context is closed: %w", ctxError)

--- a/test/utils/envtest/state.go
+++ b/test/utils/envtest/state.go
@@ -351,14 +351,14 @@ func (s *State) CleanupStateWithClient(ctx context.Context, c client.Client, opt
 
 	s.log.Logln("cleanup deploy items")
 	for _, obj := range s.DeployItems {
-		if err := CleanupForDeployItem(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForDeployItem(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
 
 	s.log.Logln("cleanup executions")
 	for _, obj := range s.Executions {
-		if err := CleanupForExecution(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForExecution(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
@@ -372,42 +372,42 @@ func (s *State) CleanupStateWithClient(ctx context.Context, c client.Client, opt
 
 	s.log.Logln("cleanup data objects")
 	for _, obj := range s.DataObjects {
-		if err := CleanupForObject(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
 
 	s.log.Logln("cleanup targets")
 	for _, obj := range s.Targets {
-		if err := CleanupForObject(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
 
 	s.log.Logln("cleanup target syncs")
 	for _, obj := range s.TargetSyncs {
-		if err := CleanupForObject(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
 
 	s.log.Logln("cleanup secrets")
 	for _, obj := range s.Secrets {
-		if err := CleanupForObject(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
 
 	s.log.Logln("cleanup config maps")
 	for _, obj := range s.ConfigMaps {
-		if err := CleanupForObject(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
 
 	s.log.Logln("cleanup generic")
 	for _, obj := range s.Generic {
-		if err := CleanupForObject(ctx, c, obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, obj, *timeout); err != nil {
 			return err
 		}
 	}
@@ -419,7 +419,7 @@ func (s *State) CleanupStateWithClient(ctx context.Context, c client.Client, opt
 		return fmt.Errorf("unable to list pods in %q: %w", s.Namespace, err)
 	}
 	for _, obj := range pods.Items {
-		if err := CleanupForObject(ctx, c, &obj, *timeout); err != nil {
+		if err := CleanupForObject(ctx, s.log, c, &obj, *timeout); err != nil {
 			return err
 		}
 	}
@@ -451,7 +451,7 @@ func (s *State) cleanupNamespace(ctx context.Context, c client.Client, namespace
 			return err
 		}
 		if options.WaitForDeletion {
-			return WaitForObjectToBeDeleted(ctx, c, ns, *timeout)
+			return WaitForObjectToBeDeleted(ctx, s.log, c, ns, *timeout)
 		}
 	}
 
@@ -465,7 +465,7 @@ func (s *State) CleanupState(ctx context.Context, opts ...CleanupOption) error {
 }
 
 // CleanupForObject cleans up a object from a cluster
-func CleanupForObject(ctx context.Context, c client.Client, obj client.Object, timeout time.Duration) error {
+func CleanupForObject(ctx context.Context, log utils.Logger, c client.Client, obj client.Object, timeout time.Duration) error {
 	if err := c.Get(ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -479,7 +479,7 @@ func CleanupForObject(ctx context.Context, c client.Client, obj client.Object, t
 			return err
 		}
 	}
-	if err := WaitForObjectToBeDeleted(ctx, c, obj, timeout); err != nil {
+	if err := WaitForObjectToBeDeleted(ctx, log, c, obj, timeout); err != nil {
 		if err := removeFinalizer(ctx, c, obj); err != nil {
 			return err
 		}
@@ -505,7 +505,7 @@ func (s *State) CleanupForInstallation(ctx context.Context, c client.Client, obj
 	}
 
 	var innerErr error
-	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		innerErr = s.addReconcileAnnotation(ctx, c, obj)
 		return innerErr == nil, nil
 	}); err != nil {
@@ -515,7 +515,7 @@ func (s *State) CleanupForInstallation(ctx context.Context, c client.Client, obj
 		return err
 	}
 
-	if err := WaitForObjectToBeDeleted(ctx, c, obj, timeout); err != nil {
+	if err := WaitForObjectToBeDeleted(ctx, s.log, c, obj, timeout); err != nil {
 		if err := removeFinalizer(ctx, c, obj); err != nil {
 			return err
 		}
@@ -524,7 +524,7 @@ func (s *State) CleanupForInstallation(ctx context.Context, c client.Client, obj
 }
 
 // CleanupForExecution cleans up an execution from a cluster
-func CleanupForExecution(ctx context.Context, c client.Client, obj *lsv1alpha1.Execution, timeout time.Duration) error {
+func CleanupForExecution(ctx context.Context, log utils.Logger, c client.Client, obj *lsv1alpha1.Execution, timeout time.Duration) error {
 	if err := c.Get(ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -543,7 +543,7 @@ func CleanupForExecution(ctx context.Context, c client.Client, obj *lsv1alpha1.E
 		return err
 	}
 
-	if err := WaitForObjectToBeDeleted(ctx, c, obj, timeout); err != nil {
+	if err := WaitForObjectToBeDeleted(ctx, log, c, obj, timeout); err != nil {
 		if err := removeFinalizer(ctx, c, obj); err != nil {
 			return err
 		}
@@ -553,7 +553,7 @@ func CleanupForExecution(ctx context.Context, c client.Client, obj *lsv1alpha1.E
 }
 
 // CleanupForDeployItem cleans up a deploy item from a cluster
-func CleanupForDeployItem(ctx context.Context, c client.Client, obj *lsv1alpha1.DeployItem, timeout time.Duration) error {
+func CleanupForDeployItem(ctx context.Context, log utils.Logger, c client.Client, obj *lsv1alpha1.DeployItem, timeout time.Duration) error {
 	if err := c.Get(ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -572,7 +572,7 @@ func CleanupForDeployItem(ctx context.Context, c client.Client, obj *lsv1alpha1.
 		return err
 	}
 
-	if err := WaitForObjectToBeDeleted(ctx, c, obj, timeout); err != nil {
+	if err := WaitForObjectToBeDeleted(ctx, log, c, obj, timeout); err != nil {
 		if err := removeFinalizer(ctx, c, obj); err != nil {
 			return err
 		}
@@ -586,6 +586,7 @@ func (s *State) addReconcileAnnotation(ctx context.Context, c client.Client, obj
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
+		s.log.Logfln("addReconcileAnnotation: failed to get object: %w", err)
 		return err
 	}
 
@@ -595,7 +596,8 @@ func (s *State) addReconcileAnnotation(ctx context.Context, c client.Client, obj
 			if readError := c.Get(ctx, kutil.ObjectKeyFromObject(obj), obj); apierrors.IsNotFound(readError) {
 				return nil
 			}
-			err = errors.Wrap(err, "Failed to add reconcile annotation to installation during cleanup")
+			s.log.Logfln("addReconcileAnnotation: update failed: %w", err)
+			err = errors.Wrap(err, "Failed to add reconcile annotation during cleanup")
 			return err
 		}
 	}
@@ -650,7 +652,7 @@ func updateJobIdForExecution(ctx context.Context, c client.Client, obj *lsv1alph
 }
 
 // WaitForObjectToBeDeleted waits for a object to be deleted.
-func WaitForObjectToBeDeleted(ctx context.Context, c client.Client, obj client.Object, timeout time.Duration) error {
+func WaitForObjectToBeDeleted(ctx context.Context, log utils.Logger, c client.Client, obj client.Object, timeout time.Duration) error {
 	var (
 		lastErr error
 		uObj    client.Object
@@ -661,6 +663,7 @@ func WaitForObjectToBeDeleted(ctx context.Context, c client.Client, obj client.O
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}
+			log.Logfln("WaitForObjectToBeDeleted: failed to get object: %w", err)
 			lastErr = err
 			return false, nil
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority 3

**What this PR does / why we need it**:

This pull request enhances the logging during the cleanup of integration tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
