### PR TITLE
Decouple clients

### DIFF
--- a/cmd/helm-deployer-controller/app/app.go
+++ b/cmd/helm-deployer-controller/app/app.go
@@ -37,8 +37,7 @@ func NewHelmDeployerControllerCommand(ctx context.Context) *cobra.Command {
 
 func (o *options) run(ctx context.Context) error {
 	o.DeployerOptions.Log.Info("Starting helm deployer", lc.KeyVersion, version.Get().GitVersion)
-	if err := helmctrl.AddDeployerToManager(o.DeployerOptions.Log, o.DeployerOptions.LsMgr, o.DeployerOptions.HostMgr,
-		o.Config, "helm"); err != nil {
+	if err := helmctrl.AddDeployerToManager(o.DeployerOptions, o.Config, "helm"); err != nil {
 		return fmt.Errorf("unable to setup helm controller")
 	}
 	return o.DeployerOptions.StartManagers(ctx)

--- a/pkg/agent/add.go
+++ b/pkg/agent/add.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gardener/landscaper/pkg/deployer/lib/cmd"
+
 	"k8s.io/apimachinery/pkg/selection"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -88,7 +90,17 @@ func AddToManager(ctx context.Context, logger logging.Logger, lsMgr manager.Mana
 			},
 		},
 	}
-	if err := helmctlr.AddDeployerToManager(log, lsMgr, hostMgr, helmConfig, callerName); err != nil {
+
+	do := cmd.DefaultOptions{
+		LsKubeconfig: "",
+		Log:          log,
+		LsMgr:        lsMgr,
+		HostMgr:      hostMgr,
+		LsClient:     nil,
+		HostClient:   nil,
+	}
+
+	if err := helmctlr.AddDeployerToManager(&do, helmConfig, callerName); err != nil {
 		return err
 	}
 

--- a/pkg/deployer/helm/deployer.go
+++ b/pkg/deployer/helm/deployer.go
@@ -67,9 +67,7 @@ func NewDeployer(log logging.Logger,
 		hostClient:  hostKubeClient,
 		config:      config,
 		sharedCache: sharedCache,
-		hooks:       extension.ReconcileExtensionHooks{},
 	}
-	dep.hooks.RegisterHookSetup(cr.ContinuousReconcileExtensionSetup(dep.NextReconcile))
 	return dep, nil
 }
 

--- a/pkg/deployer/helm/helm_suite_test.go
+++ b/pkg/deployer/helm/helm_suite_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	deployercmd "github.com/gardener/landscaper/pkg/deployer/lib/cmd"
+
 	"github.com/google/uuid"
 
 	"github.com/gardener/landscaper/pkg/deployer/helm/realhelmdeployer"
@@ -131,7 +133,16 @@ var _ = Describe("Template", func() {
 				NewClient:          lsutils.NewUncachedClient(lsutils.LsResourceClientBurstDefault, lsutils.LsResourceClientQpsDefault),
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(helm.AddDeployerToManager(logging.Wrap(simplelogger.NewIOLogger(GinkgoWriter)), mgr, mgr, helmv1alpha1.Configuration{},
+
+			do := deployercmd.DefaultOptions{
+				LsKubeconfig: "",
+				Log:          logging.Wrap(simplelogger.NewIOLogger(GinkgoWriter)),
+				LsMgr:        mgr,
+				HostMgr:      mgr,
+				LsClient:     nil,
+				HostClient:   nil,
+			}
+			Expect(helm.AddDeployerToManager(&do, helmv1alpha1.Configuration{},
 				"helmintegration"+utils.GetNextCounter())).To(Succeed())
 
 			timeout.ActivateStandardTimeoutChecker()

--- a/pkg/landscaper/controllers/installations/reconcile_delete_test.go
+++ b/pkg/landscaper/controllers/installations/reconcile_delete_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Delete", func() {
 			Expect(testutils.CreateExampleDefaultContext(ctx, testenv.Client, state.Namespace)).To(Succeed())
 
 			Expect(installationsctl.AddControllerToManager(logging.Wrap(simplelogger.NewIOLogger(GinkgoWriter)), mgr, mgr,
-				&config.LandscaperConfiguration{}, "inst-"+testutils.GetNextCounter())).To(Succeed())
+				&config.LandscaperConfiguration{}, "inst-"+testutils.GetNextCounter(), nil, nil)).To(Succeed())
 			go func() {
 				Expect(mgr.Start(ctx)).To(Succeed())
 			}()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     backup|certification|cost|delivery|deployers|manifest-deployer|helm-deployer|container-deployer|dev-productivity|documentation|high-availability|logging|monitoring|oci|open-source|operations|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers (numerical value): 1 (blocker)|2 (critical)|3 (normal)|4 (low priority)|5 (nice to have)

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area deployers
/kind enhancement
/priority 3

**What this PR does / why we need it**:

Decouple clients to allow using a cached client for the controllers. This prevents additional calls to the API server of the resource cluster  as long as only the meta data are required. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
- reduce calls to the API server of the resource cluster 
```
