### PR TITLE
Reference go patch version 1.21.4

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 run:
   concurrency: 4
   deadline: 10m
-  go: '1.21'
+  go: '1.21.4'
 
   skip-files:
   - "zz_generated.*\\.go$"

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/landscaper/apis
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gardener/component-spec/bindings-go v0.0.66

--- a/controller-utils/go.mod
+++ b/controller-utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/landscaper/controller-utils
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000

--- a/controller-utils/vendor/modules.txt
+++ b/controller-utils/vendor/modules.txt
@@ -22,7 +22,7 @@ github.com/fsnotify/fsnotify
 github.com/gardener/component-spec/bindings-go/apis/v2
 github.com/gardener/component-spec/bindings-go/utils/selector
 # github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000 => ../apis
-## explicit; go 1.21
+## explicit; go 1.21.4
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/core
 github.com/gardener/landscaper/apis/core/v1alpha1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/landscaper
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -548,7 +548,7 @@ github.com/gardener/component-spec/bindings-go/utils/selector
 ## explicit; go 1.16
 github.com/gardener/image-vector/pkg
 # github.com/gardener/landscaper/apis v0.0.0-00010101000000-000000000000 => ./apis
-## explicit; go 1.21
+## explicit; go 1.21.4
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/config/install
 github.com/gardener/landscaper/apis/config/v1alpha1
@@ -586,7 +586,7 @@ github.com/gardener/landscaper/apis/mediatype
 github.com/gardener/landscaper/apis/schema
 github.com/gardener/landscaper/apis/utils
 # github.com/gardener/landscaper/controller-utils v0.0.0-00010101000000-000000000000 => ./controller-utils
-## explicit; go 1.21
+## explicit; go 1.21.4
 github.com/gardener/landscaper/controller-utils/pkg/crdmanager
 github.com/gardener/landscaper/controller-utils/pkg/errors
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes release pipeline as go version is read from go.mod, but no binary for go1.21.linux can be found on https://go.dev/dl/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
Upgrade to go v1.21.4
```
