### PR TITLE
Updated links for new docu generation

### DIFF
--- a/docs/guided-tour/basics/upgrade/README.md
+++ b/docs/guided-tour/basics/upgrade/README.md
@@ -5,7 +5,7 @@ For prerequisites see [here](../../README.md#prerequisites-and-basic-definitions
 In this example, we start by deploying the hello-world Helm chart in its original version `1.0.0`. 
 Afterwards, we will upgrade the Installation so that it deploys the newer version `1.0.1` of the chart.
 
-You can find the new Helm chart [here](chart/hello-world). It replaces the ConfigMap of the original chart version by
+You can find the new Helm chart [here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/basics/upgrade/chart/hello-world). It replaces the ConfigMap of the original chart version by
 a Secret. The new chart version can be found in our
 [public registry](https://eu.gcr.io/gardener-project/landscaper/examples/charts/hello-world:1.0.1).
 

--- a/docs/guided-tour/blueprints/echo-server/README.md
+++ b/docs/guided-tour/blueprints/echo-server/README.md
@@ -6,21 +6,24 @@ For prerequisites, see [here](../../README.md#prerequisites-and-basic-definition
 
 The example uses the following resources:
 
-- a blueprint, which you can find [locally](./blueprint), and 
+- a blueprint, which you can find [here](https://github.com/gardener/landscaper/blob/master/docs/guided-tour/blueprints/echo-server/blueprint/blueprint.yaml), and 
   uploaded [in an OCI registry](https://eu.gcr.io/gardener-project/landscaper/examples/blueprints/guided-tour/echo-server),
-- a Helm chart which you can also find [locally](./blueprint) and
+- a Helm chart which you can also find [here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/blueprints/echo-server/chart/echo-server) and
   uploaded [in an OCI registry](https://eu.gcr.io/gardener-project/landscaper/examples/charts/guided-tour/echo-server),
 - the Docker image [hashicorp/http-echo](https://hub.docker.com/r/hashicorp/http-echo) as an external resource.
 
-You can find the file system representations of the extended component versions [here](./component-archive/). 
-It is an advantage to have them all in one place, in a standard format. 
-Otherwise, you would have to search images spread somewhere in charts, perhaps even mixed with some templating.
-Moreover, the component versions can be used by other tools for example for transport or signing. 
+All of these resources are described/bundled in a so-called _component-archive_. You can find the file system representations of the extended component versions [here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/blueprints/echo-server/component-archive).
 
+
+Describing required resources in a standard format (for which we use the "Open Component Model") has several advantages. This Guided Tour can not go into all the details about that model, so you might want to read about the core concepts, the benefits and the available tools on the official website under [https://ocm.software](https://ocm.software).
+
+
+Without a consistent description for your component and its technical resources, you would have to search images spread somewhere in charts, perhaps even mixed with some templating.
+Moreover, such standardized component version descriptor files can be used by other tools to perform other lifecycle management activities like consistent transports into other environments or to do signing/verification of software components.
 
 ## OCI Image Resource in the Component Descriptor
 
-The [echo-server Helm chart](./chart/echo-server) in this example consists of a `Deployment` and a `Service`.
+The [echo-server Helm chart](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/blueprints/echo-server/chart/echo-server) in this example consists of a `Deployment` and a `Service`.
 The `Deployment` uses a container image. However, instead of a hard-coded image reference in
 the [deployment.yaml](./chart/echo-server/templates/deployment.yaml), we rather maintain the image reference in the
 component descriptor. In detail, the connection is the following:

--- a/docs/guided-tour/blueprints/external-blueprint/README.md
+++ b/docs/guided-tour/blueprints/external-blueprint/README.md
@@ -15,13 +15,11 @@ becomes possible if we store the Blueprint at a referencable location, e.g. an O
 
 ## The Example Blueprint
 
-You can find the blueprint for the current example [here](./blueprint). Note that the blueprint is a directory, and not
-just the [blueprint/blueprint.yaml](./blueprint/blueprint.yaml) file. In future examples the blueprint directory will
-contain further files.
+You can find the blueprint for the current example [here](https://github.com/gardener/landscaper/blob/master/docs/guided-tour/blueprints/external-blueprint/blueprint). Note that the blueprint is a directory, and not just the [blueprint/blueprint.yaml](./blueprint/blueprint.yaml) file. In future examples the blueprint directory will contain further files.
 
 We have uploaded the blueprint
 [here](https://eu.gcr.io/gardener-project/landscaper/examples/blueprints/guided-tour/external-blueprint) into an OCI
-registry, from where the Landscaper can access it. You can find the commands which we have used to upload the blueprint
+registry, from where the Landscaper can access it. You can find the commands, which we have used to upload the blueprint
 in this script: [commands/push-blueprint.sh](./commands/push-blueprint.sh).
 
 
@@ -105,7 +103,7 @@ with the component version embedding the blueprint as a local blob.
 
 #### Component Version with External Resource  
 A file system representation of a component version containing the resource through an external reference is shown
-[here](./component-archive/v2-external).  The corresponding component-descriptor describing that component version is
+[here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/blueprints/external-blueprint/component-archive/v2-external). The corresponding component-descriptor describing that component version is
 stored as a top-level file. The component descriptor contains only a single _resource_ with the `name: blueprint`. This
 resource has an _access_ of `type: ociArtifact` that contains a reference to the previously uploaded image.  Besides the
 component-descriptor, there is a directory called blobs at the top-level. This is where the local blobs of a embedded
@@ -114,7 +112,7 @@ through an external reference, this directory is empty.
 
 #### Component Version with Local Resource  
 A file system representation of a component version containing the resource as a local blob is shown
-[here](./component-archive/v2-local).  Again, the corresponding component-descriptor describing that component version
+[here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/blueprints/external-blueprint/component-archive/v2-local).  Again, the corresponding component-descriptor describing that component version
 is stored as a top-level file. Exactly as before, the component descriptor contains only a single _resource_ with the
 `name: blueprint`. But now, this resource has an _access_ of `type: localBlob`. Instead of an `imageReference`, this
 _access_ of `type: localBlob` has a `localReference`. This is the sha256 hash value of the blueprint. If you open the

--- a/docs/guided-tour/blueprints/helm-chart-resource/README.md
+++ b/docs/guided-tour/blueprints/helm-chart-resource/README.md
@@ -24,8 +24,7 @@ Therefore, we will now modify the previous example as follows:
 
 ## The Component Version
 
-You can find the file system representations of the extended component versions [here](./component-archive), and
-in the OCI registry [here](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/helm-chart-resource).
+You can find the file system representations of the extended component versions [here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/blueprints/helm-chart-resource/component-archive/v2-external), and in the OCI registry [here](https://eu.gcr.io/gardener-project/landscaper/examples/component-descriptors/github.com/gardener/landscaper-examples/guided-tour/helm-chart-resource).
 
 The list of resources of the component descriptor within the component version has two entries now, one for the 
 blueprint and one for the Helm chart. The entry for the Helm chart has the name `hello-world-chart` and contains the 

--- a/docs/guided-tour/hello-world/README.md
+++ b/docs/guided-tour/hello-world/README.md
@@ -4,7 +4,7 @@ In this example, we use the Landscaper to deploy a simple Helm chart.
 
 For prerequisites, see [here](https://github.com/gardener/landscaper/tree/master/docs/guided-tour#prerequisites-and-basic-definitions).
 
-Our [hello-world Helm chart](chart/hello-world) is minimalistic on purpose, in order to concentrate on Landscaper rather than Helm features. Therefore, the chart only deploys a ConfigMap. We have uploaded the chart to a [public registry](https://eu.gcr.io/gardener-project/landscaper/examples/charts/hello-world:1.0.0) from where the Landscaper reads it during the deployment.
+Our [hello-world Helm chart](https://github.com/gardener/landscaper/tree/Updated-Links-for-docu-generation/docs/guided-tour/hello-world/chart/hello-world) is minimalistic on purpose, in order to concentrate on Landscaper rather than Helm features. Therefore, the chart only deploys a ConfigMap. We have uploaded the chart to a [public registry](https://eu.gcr.io/gardener-project/landscaper/examples/charts/hello-world:1.0.0) from where the Landscaper reads it during the deployment.
 
 ## Procedure
 
@@ -24,11 +24,11 @@ First of all, we need to create two custom resources:
 
 Alternative (which requires the [Landscaper CLI](https://github.com/gardener/landscapercli)):
 
-1. In your [commands/settings file](./commands/settings), specify 
+1. In your [commands/settings file](https://github.com/gardener/landscaper/blob/master/docs/guided-tour/hello-world/commands/settings), specify 
    - the path to the kubeconfig of your Landscaper resource cluster and
    - the path to the kubeconfig of your target cluster.
 
-2. Run script [commands/apply-target-and-installation.sh](./commands/apply-target-and-installation.sh).
+2. Run script [commands/apply-target-and-installation.sh](https://github.com/gardener/landscaper/blob/master/docs/guided-tour/hello-world/commands/apply-target-and-installation.sh).
 
 ## Landscaper Processes the Installation
 

--- a/docs/guided-tour/templating/components/README.md
+++ b/docs/guided-tour/templating/components/README.md
@@ -36,7 +36,7 @@ We have uploaded these three component descriptors into an OCI registry, so that
 
 ## The Blueprint
 
-The [blueprint](./blueprint) of the present example belongs to the root component. Part of the blueprint is a 
+The [blueprint](https://github.com/gardener/landscaper/tree/master/docs/guided-tour/templating/components/blueprint) of the present example belongs to the root component. Part of the blueprint is a 
 [deploy execution](./blueprint/deploy-execution.yaml). The deploy execution is a [Go Template][2], 
 which is used to generate a DeployItem. 
 The template can be filled with values from a certain data structure. The following fields in this data structure 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some relative links to folders (not files) have been updated to absolute links. 
This is required as docusaurus is not able to link to folders via relative URLs.

