### PR TITLE
Fix Nilpointer due to Missing EventRecorder

### DIFF
--- a/pkg/landscaper/operation/operation.go
+++ b/pkg/landscaper/operation/operation.go
@@ -43,6 +43,7 @@ func (o *Operation) Copy() *Operation {
 	return &Operation{
 		client:            o.client,
 		scheme:            o.scheme,
+		eventRecorder:     o.eventRecorder,
 		componentRegistry: o.componentRegistry,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a nilpointer in the installation controller:

```
{"level":"info","ts":"2024-01-04T12:40:57.636Z","logger":"controllers.installation","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","reconciledResourceKind":"Installation","reconcileID":"e1608856-72f1-4242-a918-dea8b27147cd"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x27fb33f]

goroutine 249 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/src/github.com/gardener/landscaper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:115 +0x1e5
panic({0x2bd13c0?, 0x51e32e0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/gardener/landscaper/pkg/landscaper/installations.(*Operation).CreateEventFromCondition(...)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/installations/operation.go:387
github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations.(*Operation).createOrUpdateNewInstallation(0xc02c15af18, {0x36911d0, 0xc026bf64e0}, 0xc026beec80, 0xc02beff930, 0x0)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations/subinstallations.go:312 +0x9bf
github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations.(*Operation).createOrUpdateSubinstallations(0xc02c15af18, {0x36911d0, 0xc026bf64e0}, 0x6?, {0xc030de4120, 0x5, 0x7?})
	/go/src/github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations/subinstallations.go:241 +0x1e6
github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations.(*Operation).Ensure(0xc02c15af18, {0x36911d0, 0xc026bf64e0}, 0xc000448380?)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/installations/subinstallations/subinstallations.go:73 +0x36f
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).CreateImportsAndSubobjects(0xc01d5f9198?, {0x36911d0, 0xc026bf64e0}, 0xc00095a800, 0x1?, 0x1?)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/reconcile.go:539 +0x11e
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).handlePhaseInit(0xc0002ef7c0, {0x36911d0, 0xc026bf64e0}, 0xc026beec80, 0x18?)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/reconcile.go:248 +0x132
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).handleReconcilePhase(0xc0002ef7c0, {0x36911d0, 0xc026bf64e0}, 0xc026beec80)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/reconcile.go:64 +0x4c5
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).reconcileInstallation(0xc0002ef7c0, {0x36911d0?, 0xc026bf64e0?}, 0xc026beec80)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/controller.go:267 +0x6d4
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).handleAutomaticReconcile(0xc0002ef7c0, {0x36911d0, 0xc026bf64e0}, 0xc026beec80)
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/controller.go:202 +0x3c5
github.com/gardener/landscaper/pkg/landscaper/controllers/installations.(*Controller).Reconcile(0xc0002ef7c0, {0x36911d0, 0xc026bf63c0}, {{{0xc00e0cfae0?, 0x0?}, {0xc00e1c1530?, 0x4108c5?}}})
	/go/src/github.com/gardener/landscaper/pkg/landscaper/controllers/installations/controller.go:162 +0x83d
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
