### PR TITLE
Make cache access more robust

### DIFF
--- a/pkg/landscaper/controllers/execution/controller.go
+++ b/pkg/landscaper/controllers/execution/controller.go
@@ -266,7 +266,10 @@ func (c *controller) handlePhaseProgressing(ctx context.Context, exec *lsv1alpha
 }
 
 func (c *controller) handlePhaseCompleting(ctx context.Context, exec *lsv1alpha1.Execution) lserrors.LsError {
-	exec.Status.DeployItemCache.OrphanedDIs = nil
+
+	if exec.Status.DeployItemCache != nil {
+		exec.Status.DeployItemCache.OrphanedDIs = nil
+	}
 
 	forceReconcile := false
 	o := execution.NewOperation(operation.NewOperation(c.lsClient, c.scheme, c.eventRecorder), exec, forceReconcile)

--- a/pkg/landscaper/controllers/installations/reconcile.go
+++ b/pkg/landscaper/controllers/installations/reconcile.go
@@ -96,7 +96,9 @@ func (c *Controller) handleReconcilePhase(ctx context.Context, inst *lsv1alpha1.
 				read_write_layer.W000024, false)
 		}
 
-		inst.Status.SubInstCache.OrphanedSubs = nil
+		if inst.Status.SubInstCache != nil {
+			inst.Status.SubInstCache.OrphanedSubs = nil
+		}
 		if err := c.setInstallationPhaseAndUpdate(ctx, inst, lsv1alpha1.InstallationPhases.ObjectsCreated, nil,
 			read_write_layer.W000025, false); err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Make cache access more robust.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
NONE
```
