### PR TITLE
Fix template map to cdv2

### DIFF
--- a/pkg/landscaper/installations/executions/template/common/utils.go
+++ b/pkg/landscaper/installations/executions/template/common/utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
-	"github.com/gardener/component-spec/bindings-go/codec"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
 	v2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
@@ -108,7 +107,8 @@ func ConvertMapCdToCompDescV2(mapCd map[string]interface{}) (*types.ComponentDes
 			return nil, err
 		}
 	case SCHEMA_VERSION_V2:
-		if err := codec.Decode(data, &descriptor); err != nil {
+		err = runtime.DefaultYAMLEncoding.Unmarshal(data, &descriptor)
+		if err != nil {
 			return nil, err
 		}
 	default:


### PR DESCRIPTION
**What this PR does / why we need it**:

During templating, in case of component descriptor version v2, the component-spec lib was used to decode the map into the cdv2 ComponentDescriptor type.

The component-spec lib uses some strange checks while decoding which are longer valid with components created by the ocm lib.

Therefore the map is directly unmarshalled by the yaml decoder.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Avoid component-spec decode for templating component descriptor conversions.
```
