### PR TITLE
Investigate strict checks

### DIFF
--- a/cmd/landscaper-agent/app/options.go
+++ b/cmd/landscaper-agent/app/options.go
@@ -8,9 +8,10 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
-	"k8s.io/utils/pointer"
 	"os"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime/serializer"

--- a/cmd/landscaper-controller/app/app.go
+++ b/cmd/landscaper-controller/app/app.go
@@ -7,9 +7,10 @@ package app
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/pointer"
 	"os"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/spf13/cobra"

--- a/pkg/deployer/lib/cmd/default.go
+++ b/pkg/deployer/lib/cmd/default.go
@@ -9,9 +9,10 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
-	"k8s.io/utils/pointer"
 	"os"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	flag "github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"

--- a/pkg/utils/webhook/webhook.go
+++ b/pkg/utils/webhook/webhook.go
@@ -28,13 +28,13 @@ var InstallationWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context,
 	logger, _ := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "InstallationWebhookLogic"})
 	inst := &lscore.Installation{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, inst); err != nil {
-		logger.Debug("Decoding failed:" + err.Error())
+		logger.Debug("Decoding failed: " + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateInstallation(inst); len(errs) > 0 {
 		aggErr := errs.ToAggregate().Error()
-		logger.Debug("Validation failed:" + aggErr)
+		logger.Debug("Validation failed: " + aggErr)
 		return admission.Denied(aggErr)
 	}
 
@@ -48,13 +48,13 @@ var DeployItemWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, r
 
 	di := &lscore.DeployItem{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, di); err != nil {
-		logger.Debug("Decoding failed:" + err.Error())
+		logger.Debug("Decoding failed: " + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateDeployItem(di); len(errs) > 0 {
 		aggErr := errs.ToAggregate().Error()
-		logger.Debug("Validation failed:" + aggErr)
+		logger.Debug("Validation failed: " + aggErr)
 		return admission.Denied(aggErr)
 	}
 
@@ -62,7 +62,7 @@ var DeployItemWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, r
 	if req.Operation == admissionv1.Update {
 		oldDi := &lscore.DeployItem{}
 		if _, _, err := dec.Decode(req.OldObject.Raw, nil, oldDi); err != nil {
-			logger.Debug("Decoding old failed:" + err.Error())
+			logger.Debug("Decoding old failed: " + err.Error())
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if oldDi.Spec.Type != di.Spec.Type {
@@ -81,13 +81,13 @@ var ExecutionWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, re
 
 	exec := &lscore.Execution{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, exec); err != nil {
-		logger.Debug("Decoding failed:" + err.Error())
+		logger.Debug("Decoding failed: " + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateExecution(exec); len(errs) > 0 {
 		aggErr := errs.ToAggregate().Error()
-		logger.Debug("Validation failed:" + aggErr)
+		logger.Debug("Validation failed: " + aggErr)
 		return admission.Denied(aggErr)
 	}
 
@@ -101,13 +101,13 @@ var TargetWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, req a
 
 	t := &lscore.Target{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, t); err != nil {
-		logger.Debug("Decoding failed:" + err.Error())
+		logger.Debug("Decoding failed: " + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateTarget(t); len(errs) > 0 {
 		aggErr := errs.ToAggregate().Error()
-		logger.Debug("Validation failed:" + aggErr)
+		logger.Debug("Validation failed: " + aggErr)
 		return admission.Denied(aggErr)
 	}
 

--- a/pkg/utils/webhook/webhook.go
+++ b/pkg/utils/webhook/webhook.go
@@ -25,13 +25,17 @@ import (
 // INSTALLATION
 
 var InstallationWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, req admission.Request, dec runtime.Decoder) admission.Response {
+	logger, _ := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "InstallationWebhookLogic"})
 	inst := &lscore.Installation{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, inst); err != nil {
+		logger.Debug("Decoding failed:" + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateInstallation(inst); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		aggErr := errs.ToAggregate().Error()
+		logger.Debug("Validation failed:" + aggErr)
+		return admission.Denied(aggErr)
 	}
 
 	return admission.Allowed("Installation is valid")
@@ -44,17 +48,21 @@ var DeployItemWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, r
 
 	di := &lscore.DeployItem{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, di); err != nil {
+		logger.Debug("Decoding failed:" + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateDeployItem(di); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		aggErr := errs.ToAggregate().Error()
+		logger.Debug("Validation failed:" + aggErr)
+		return admission.Denied(aggErr)
 	}
 
 	// check if the type was updated for update events
 	if req.Operation == admissionv1.Update {
 		oldDi := &lscore.DeployItem{}
 		if _, _, err := dec.Decode(req.OldObject.Raw, nil, oldDi); err != nil {
+			logger.Debug("Decoding old failed:" + err.Error())
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if oldDi.Spec.Type != di.Spec.Type {
@@ -69,13 +77,18 @@ var DeployItemWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, r
 // EXECUTION
 
 var ExecutionWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, req admission.Request, dec runtime.Decoder) admission.Response {
+	logger, _ := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "ExecutionWebhookLogic"})
+
 	exec := &lscore.Execution{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, exec); err != nil {
+		logger.Debug("Decoding failed:" + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateExecution(exec); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		aggErr := errs.ToAggregate().Error()
+		logger.Debug("Validation failed:" + aggErr)
+		return admission.Denied(aggErr)
 	}
 
 	return admission.Allowed("Execution is valid")
@@ -84,13 +97,18 @@ var ExecutionWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, re
 // TARGET
 
 var TargetWebhookLogic webhooklib.WebhookLogic = func(ctx context.Context, req admission.Request, dec runtime.Decoder) admission.Response {
+	logger, _ := logging.FromContextOrNew(ctx, []interface{}{lc.KeyMethod, "ExecutionWebhookLogic"})
+
 	t := &lscore.Target{}
 	if _, _, err := dec.Decode(req.Object.Raw, nil, t); err != nil {
+		logger.Debug("Decoding failed:" + err.Error())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	if errs := validation.ValidateTarget(t); len(errs) > 0 {
-		return admission.Denied(errs.ToAggregate().Error())
+		aggErr := errs.ToAggregate().Error()
+		logger.Debug("Validation failed:" + aggErr)
+		return admission.Denied(aggErr)
 	}
 
 	return admission.Allowed("Target is valid")


### PR DESCRIPTION
**What this PR does / why we need it**:

If a field in some object (Installation, Execution etc.) is not required anymore, we are not to allowed to remove it from our CRDs and types as long as it is still used by some customer because our strict validation does not allow additional fields. A better behaviour would be to allow those fields and ignore/remove them during processing. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
