### PR TITLE
helmChartRepository access type deprecation

### DIFF
--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -272,9 +272,23 @@ The full example can be found
 [here](https://github.com/gardener/landscaper-examples/tree/master/helm-deployer/real-helm-deployment).
 
 #### Specifying a helm chart via component descriptor
+Alternatively, the provider configuration can reference a resource in the component. An explanation of the current 
+idiomatic way to do this can be found in the guided tour [here](../guided-tour/blueprints/helm-chart-resource/README.md).
+The approach shown below is deprecated.
+
+> **_DEPRECATED:__** This use case can be covered with the `getResourceKey()` templating function in a more convenient
+> way.
 
 Alternatively, the provider configuration can reference a resource in the component descriptor.
 Repository URL, chart name, and chart version are then specified in that resource in the component descriptor. 
+
+> **_NOTE_:** The `helmChartRepository` access type shown in the component descriptor below and used in the templating
+> here, does not exist in the ocm.   
+> Instead, ocm supports an access type `helm`, as specified in the spec
+> [here](https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/02-access-types/helm.md).
+> Thus, if you switch from this deprecated solution to the current one (using the `getResourceKey` templating function),
+> be aware that you **HAVE TO** specify the access as access type `helm` with the corresponding properties as specified
+> in the referred ocm spec.
 
 Provider configuration:
 

--- a/docs/guided-tour/basics/upgrade/README.md
+++ b/docs/guided-tour/basics/upgrade/README.md
@@ -16,7 +16,7 @@ First, we deploy the original hello-world helm chart:
 
 1. Add the kubeconfig of your target cluster to your [target.yaml](installation/target.yaml) at the specified location.
 
-2. On the Landscaper resource cluster, create a namespace `example` and apply your [target.yaml](installation/target.yaml) and [installation.yaml](installation/installation.yaml):
+2. On the Landscaper resource cluster, create a namespace `example` and apply your [target.yaml](installation/target.yaml) and [installation.yaml](installation/installation-1.0.0.yaml):
    
    ```shell
    kubectl create ns example

--- a/docs/guided-tour/blueprints/helm-chart-resource/README.md
+++ b/docs/guided-tour/blueprints/helm-chart-resource/README.md
@@ -128,6 +128,13 @@ Let us mention a variation of this example. Above, we have stored our Helm chart
 Of course, you can also store your Helm chart in a Helm chart repository. In that case, the entry in the component 
 descriptor would have the following format:
 
+> **_NOTE_:** The helm access type `helmChartRepository`, as shown below, does not exist in the ocm. Instead, ocm
+> supports an access type `helm`, as specified in the spec 
+> [here](https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/02-access-types/helm.md).
+> Thus, if you switch from this deprecated solution to the current one (using the `getResourceKey` templating function),
+> be aware that you **HAVE TO** specify the access as access type `helm` with the corresponding properties as specified
+> in the referred ocm spec.
+
 ```yaml
   resources:
     - name: example-chart


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR documents the deprecation of the `helmChartRepository` access types and its incompatibility with the new `getResourceKey` templating function.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Deprecation of helmChartRepository access type
```
