### PR TITLE
fix effective version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 REPO_ROOT                                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION                                        := $(shell cat $(REPO_ROOT)/VERSION)
-EFFECTIVE_VERSION                              := $(VERSION)-$(shell git rev-parse HEAD)
+EFFECTIVE_VERSION                              := $(shell $(REPO_ROOT)/hack/get-version.sh)
 
 REGISTRY                                       := europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper
 DOCKER_BUILDER_NAME := "ls-multiarch"


### PR DESCRIPTION
**What this PR does / why we need it**:

The effective version in the Makefile was never set correctly in the Makefile. When starting a release build this leads to incorrect version used for the new ocm created component version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix effective version in Makefile
```
