### PR TITLE
Hello World: Include namespace reg note and link

### DIFF
--- a/docs/guided-tour/hello-world/README.md
+++ b/docs/guided-tour/hello-world/README.md
@@ -21,6 +21,7 @@ First of all, we need to create two custom resources:
    kubectl apply -f <path to target.yaml>
    kubectl apply -f <path to installation.yaml>
    ```
+Please note: In case you are using a Landscaper instance managed by Landscaper-as-a-Service, you cannot create a namespace directly. Instead, you have to follow the procedure described [here](https://github.com/gardener/landscaper-service/blob/main/docs/usage/Namespaceregistration.md).
 
 Alternative (which requires the [Landscaper CLI](https://github.com/gardener/landscapercli)):
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a note to use the namespace registration procedure when creating a namespace in a LaaS-managed Landscaper instance.