### PR TITLE
Note about the creation of targets 

### DIFF
--- a/docs/guided-tour/hello-world/README.md
+++ b/docs/guided-tour/hello-world/README.md
@@ -14,6 +14,12 @@ First of all, we need to create two custom resources:
 
 1. Add the kubeconfig of your target cluster to your [target.yaml](installation/target.yaml) at the specified location.
 
+   > **Note:**  
+   > If your target cluster is a Gardener Shoot cluster, it is **not** possible to use an oidc / gardenlogin kubeconfig in a Target.  
+   > If you have only such a kubeconfig, see 
+   > ["Constructing a Target Resource"](https://github.com/gardener/landscaper/blob/master/docs/guided-tour//targets/README.md)
+   > how to construct a kubeconfig and a Target, that you can use with the Landscaper.
+
 2. On the Landscaper resource cluster, create a namespace `example` and apply your [target.yaml](installation/target.yaml) and the [installation.yaml](installation/installation.yaml):
    
    ```shell

--- a/docs/guided-tour/targets/README.md
+++ b/docs/guided-tour/targets/README.md
@@ -1,0 +1,103 @@
+# Constructing a Target Resource
+
+Suppose you want to use the Landscaper to deploy an application on some kubernetes cluster, the so-called *target cluster*.
+You need to create a `Target` custom resource which contains a kubeconfig for the target cluster.
+
+If your target cluster is a Gardener shoot cluster, you typically have an oidc / gardenlogin kubeconfig for the target cluster.
+It is **not** possible to use such a kubeconfig in a `Target` custom resource.
+In the following we describe how to build a kubeconfig which you can use in a `Target`.
+It will be based on a ServiceAccount token.
+
+
+### Define Names
+
+First, let's define some names for the resources we are going to create. You can choose your own names.
+
+```shell
+export serviceaccount_name=admin
+export serviceaccount_namespace=guided-tour
+export clusterrolebinding_name=guided-tour-admin
+```
+
+
+### Create ServiceAccount 
+
+On the target cluster, create the Namespace and ServiceAccount:
+
+```shell
+kubectl create namespace ${serviceaccount_namespace}
+kubectl create serviceaccount -n ${serviceaccount_namespace} ${serviceaccount_name}
+```
+
+
+### Create ClusterRoleBinding
+
+Create a ClusterRoleBinding which binds the ServiceAccount to the ClusterRole `cluster-admin`. 
+You can choose another ClusterRole. However, it must grant enough permissions to deploy applications to your target cluster:
+
+```shell
+mako-render "./resources/clusterrolebinding.yaml.tpl" \
+  --var "clusterrolebinding_name=${clusterrolebinding_name}" \
+  --var "serviceaccount_name=${serviceaccount_name}" \
+  --var "serviceaccount_namespace=${serviceaccount_namespace}" \
+  | kubectl apply -f -
+```
+
+Alternatively, you can manually apply the [ClusterRoleBinding manifest](./resources/clusterrolebinding.yaml.tpl) 
+(replace the variables).
+
+
+### Create ServiceAccount Token
+
+Create a token for the ServiceAccount:
+
+```shell
+token=$(kubectl create token -n ${serviceaccount_namespace} ${serviceaccount_name} --duration=7776000s)
+```
+
+
+### Build the Kubeconfig
+
+Copy your kubeconfig, and replace the `users[].user` section (insert your token for the variable):
+
+```yaml
+apiVersion: v1
+kind: Config
+
+...
+
+users:
+  - name: ...
+    user:
+      token: <insert your token here>
+```
+
+Check whether you can access your target cluster with this kubeconfig.
+
+
+### Create Target
+
+We can now create a Target custom resource using the kubeconfig t
+
+On the **resource cluster**, you can now create a `Target` custom resource containing the above kubeconfig:
+
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Target
+metadata:
+  name: my-cluster
+  namespace: example
+spec:
+  type: landscaper.gardener.cloud/kubernetes-cluster
+  config:
+    kubeconfig: |
+      apiVersion: v1                          # <-------------------------- replace with your kubeconfig
+      kind: Config                            #
+                                              #
+      ...                                     #
+                                              #
+      users:                                  #
+        - name: ...                           #
+          user:                               #
+            token:  <insert your token here>  #
+```

--- a/docs/guided-tour/targets/resources/clusterrolebinding.yaml.tpl
+++ b/docs/guided-tour/targets/resources/clusterrolebinding.yaml.tpl
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${clusterrolebinding_name}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: ${serviceaccount_name}
+    namespace: ${serviceaccount_namespace}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a note to the guided tour, that a target must not contain an oidc kubeconfig. Explains how to create a target/kubeconfig based on a service account token.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
- Extension of the guided tour: note about the creation of targets 
```
