### PR TITLE
Handle panics

### DIFF
--- a/controller-utils/pkg/logging/constants/constants.go
+++ b/controller-utils/pkg/logging/constants/constants.go
@@ -83,6 +83,8 @@ const (
 	KeyExportKey = "exportKey"
 	// KeyManagedResourcePolicy is for the manage policy of a resource.
 	KeyManagedResourcePolicy = "managedResourcePolicy"
+	// KeyString is for generic strings.
+	KeyString = "someString"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"

--- a/pkg/deployer/lib/controller.go
+++ b/pkg/deployer/lib/controller.go
@@ -176,8 +176,19 @@ func NewController(lsUncachedClient, lsCachedClient, hostUncachedClient, hostCac
 	}
 }
 
-func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger, ctx := logging.MustStartReconcileFromContext(ctx, req, nil)
+func (c *controller) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, err error) {
+	_, ctx = logging.MustStartReconcileFromContext(ctx, req, nil)
+
+	result = reconcile.Result{}
+	defer lsutil.HandlePanics(ctx, &result)
+
+	result, err = c.innerReconcile(ctx, req)
+
+	return result, err
+}
+
+func (c *controller) innerReconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	c.workerCounter.EnterWithLog(logger, 70, c.callerName)
 	defer c.workerCounter.Exit()

--- a/pkg/landscaper/controllers/deployitem/reconcile.go
+++ b/pkg/landscaper/controllers/deployitem/reconcile.go
@@ -22,9 +22,20 @@ import (
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
-func (con *controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (con *controller) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, err error) {
 	logger := con.log.StartReconcile(req)
 	ctx = logging.NewContext(ctx, logger)
+
+	result = reconcile.Result{}
+	defer lsutil.HandlePanics(ctx, &result)
+
+	result, err = con.reconcile(ctx, req)
+
+	return result, err
+}
+
+func (con *controller) reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	con.workerCounter.EnterWithLog(logger, 70, "di-timeout")
 	defer con.workerCounter.Exit()

--- a/pkg/landscaper/controllers/targetsync/targetsync_controller.go
+++ b/pkg/landscaper/controllers/targetsync/targetsync_controller.go
@@ -79,8 +79,20 @@ func NewTargetSyncController(lsUncachedClient, lsCachedClient client.Client, log
 }
 
 // Reconcile reconciles requests for TargetSyncs
-func (c *TargetSyncController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger, ctx := c.log.StartReconcileAndAddToContext(ctx, req)
+func (c *TargetSyncController) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, err error) {
+	_, ctx = c.log.StartReconcileAndAddToContext(ctx, req)
+
+	result = reconcile.Result{}
+	defer utils.HandlePanics(ctx, &result)
+
+	result, err = c.reconcile(ctx, req)
+
+	return result, err
+}
+
+// Reconcile reconciles requests for TargetSyncs
+func (c *TargetSyncController) reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, nil)
 
 	targetSync := &lsv1alpha1.TargetSync{}
 	if err := c.lsUncachedClient.Get(ctx, req.NamespacedName, targetSync); err != nil {

--- a/pkg/utils/panic_handler.go
+++ b/pkg/utils/panic_handler.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging/constants"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+)
+
+func HandlePanics(ctx context.Context, result *reconcile.Result) {
+	logger, _ := logging.FromContextOrNew(ctx, nil)
+
+	if r := recover(); r != nil {
+		result.Requeue = true
+		result.RequeueAfter = time.Minute * 5
+
+		debug.PrintStack()
+
+		if err, ok := r.(runtime.Error); ok {
+			logger.Error(err, "observed a panic", "recoverResult", r,
+				constants.KeyString, string(debug.Stack()))
+
+			if err.Error() == "runtime error: invalid memory address or nil pointer dereference" {
+				logger.Error(err, "Recovered from a nil pointer dereference or invalid memory address error")
+				return
+			}
+
+			if strings.HasPrefix(err.Error(), "runtime error: index out of range") {
+				logger.Error(err, "Recovered from an index out of range error")
+				return
+			}
+
+			if strings.HasPrefix(err.Error(), "runtime error: integer divide by zero") {
+				logger.Error(err, "Recovered from a integer divide by zero error")
+				return
+			}
+
+			if strings.HasPrefix(err.Error(), "interface conversion:") {
+				logger.Error(err, "Recovered from a type assertion error")
+				return
+			}
+
+		} else if err2, ok := r.(error); ok {
+			logger.Error(err2, "observed a panic", "recoverResult", r, constants.KeyString, string(debug.Stack()))
+		} else {
+			logger.Error(nil, "observed a panic", "recoverResult", r, constants.KeyString, string(debug.Stack()))
+		}
+
+		panic(r)
+	}
+}

--- a/pkg/utils/panic_handler_test.go
+++ b/pkg/utils/panic_handler_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	lsutil "github.com/gardener/landscaper/pkg/utils"
+)
+
+type testController struct {
+	innerReconcile func(ctx context.Context) (result reconcile.Result, err error)
+}
+
+func (c *testController) reconcile(ctx context.Context) (result reconcile.Result, err error) {
+	result = reconcile.Result{}
+	defer lsutil.HandlePanics(ctx, &result)
+
+	result, err = c.innerReconcile(ctx)
+
+	return result, err
+}
+
+var _ = Describe("Panic Handler", func() {
+
+	It("should handle the case without a panic", func() {
+		c := testController{
+			innerReconcile: func(ctx context.Context) (reconcile.Result, error) {
+				result := reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Minute}
+				return result, nil
+			},
+		}
+
+		res, err := c.reconcile(context.Background())
+		Expect(res.Requeue).To(BeTrue())
+		Expect(res.RequeueAfter).To(Equal(2 * time.Minute))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle a nilpointer", func() {
+		c := testController{
+			innerReconcile: func(ctx context.Context) (reconcile.Result, error) {
+				var n *int
+				m := *n + 1 // provoke a nilpointer
+				result := reconcile.Result{Requeue: true, RequeueAfter: time.Duration(m) * time.Minute}
+				return result, nil
+			},
+		}
+
+		res, err := c.reconcile(context.Background())
+		Expect(res.Requeue).To(BeTrue())
+		Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle index out of range", func() {
+		c := testController{
+			innerReconcile: func(ctx context.Context) (reconcile.Result, error) {
+				names := []string{
+					"a1",
+					"a2",
+					"a3",
+				}
+				fmt.Println("Name:", names[len(names)])
+				result := reconcile.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}
+				return result, nil
+			},
+		}
+
+		res, err := c.reconcile(context.Background())
+		Expect(res.Requeue).To(BeTrue())
+		Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle a panic other than a nilpointer", func() {
+		defer func() {
+			r := recover()
+			Expect(r).NotTo(BeNil())
+		}()
+
+		c := testController{
+			innerReconcile: func(ctx context.Context) (reconcile.Result, error) {
+				if ctx != nil {
+					panic("test")
+				}
+				result := reconcile.Result{Requeue: true, RequeueAfter: time.Minute}
+				return result, nil
+			},
+		}
+
+		_, err := c.reconcile(context.Background())
+		Expect(err).To(BeNil())
+	})
+
+	It("should handle divide by zero", func() {
+		c := testController{
+			innerReconcile: func(ctx context.Context) (reconcile.Result, error) {
+
+				a := 1
+				b := 2
+				b = a + b
+				c := a / (4 - b - a)
+				fmt.Println("C:", c)
+				result := reconcile.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}
+				return result, nil
+			},
+		}
+
+		res, err := c.reconcile(context.Background())
+		Expect(res.Requeue).To(BeTrue())
+		Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle type assertion error", func() {
+		c := testController{
+			innerReconcile: func(ctx context.Context) (reconcile.Result, error) {
+
+				var i interface{} = "hello"
+
+				_, ok := i.(int)
+				if ok {
+					fmt.Println("Successful type assertion")
+				} else {
+					fmt.Println("Type assertion failed")
+				}
+
+				j := i.(int) // This will cause a panic: interface conversion: interface {} is string, not int
+				fmt.Println(j)
+
+				result := reconcile.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}
+				return result, nil
+			},
+		}
+
+		res, err := c.reconcile(context.Background())
+		Expect(res.Requeue).To(BeTrue())
+		Expect(res.RequeueAfter).To(Equal(5 * time.Minute))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+})

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/constants/constants.go
@@ -83,6 +83,8 @@ const (
 	KeyExportKey = "exportKey"
 	// KeyManagedResourcePolicy is for the manage policy of a resource.
 	KeyManagedResourcePolicy = "managedResourcePolicy"
+	// KeyString is for generic strings.
+	KeyString = "someString"
 
 	// MsgStartReconcile is the message which is displayed at the beginning of a new reconcile loop.
 	MsgStartReconcile = "Starting reconcile"


### PR DESCRIPTION
**What this PR does / why we need it**:

Recovers panics in the controllers. If the panic is a nilpointer, it is logged and the reconcile is requeued after some time. The controller pod does not restart in this case.

Other panics are raised again as panic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Make controllers more robust against nilpointer panics
```
