### PR TITLE
Getting 1st markdown header for creating index

### DIFF
--- a/hack/generate-docs-index.sh
+++ b/hack/generate-docs-index.sh
@@ -45,8 +45,8 @@ function getDocName() {
     fi
   fi
   if [[ -f "$filename" ]]; then
-    local firstline=$(cat "$filename" | head -n 1)
-    echo "${firstline#'# '}"
+    local firstheader=$(grep -m1 "#" "$filename")
+    echo "${firstheader#'# '}"
   fi
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When first line of markdown is not a Hader 1, creating index failed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
