### PR TITLE
add FromContextOrPanic method to logging library

### DIFF
--- a/controller-utils/pkg/logging/logger.go
+++ b/controller-utils/pkg/logging/logger.go
@@ -199,6 +199,16 @@ func FromContextWithFallback(ctx context.Context, fallback Logger, keysAndValues
 	return log, ctx
 }
 
+// FromContextOrPanic tries to fetch a logger from the context.
+// If that fails, the function panics.
+func FromContextOrPanic(ctx context.Context) Logger {
+	log, err := FromContext(ctx)
+	if err != nil {
+		panic(fmt.Errorf("logger could not be fetched from context: %w", err))
+	}
+	return log
+}
+
 // NewContextWithDiscard adds a discard logger to the given context and returns the new context.
 func NewContextWithDiscard(ctx context.Context) context.Context {
 	return NewContext(ctx, Discard())

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/logging/logger.go
@@ -199,6 +199,16 @@ func FromContextWithFallback(ctx context.Context, fallback Logger, keysAndValues
 	return log, ctx
 }
 
+// FromContextOrPanic tries to fetch a logger from the context.
+// If that fails, the function panics.
+func FromContextOrPanic(ctx context.Context) Logger {
+	log, err := FromContext(ctx)
+	if err != nil {
+		panic(fmt.Errorf("logger could not be fetched from context: %w", err))
+	}
+	return log
+}
+
 // NewContextWithDiscard adds a discard logger to the given context and returns the new context.
 func NewContextWithDiscard(ctx context.Context) context.Context {
 	return NewContext(ctx, Discard())


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `FromContextOrPanic` function to the logging library.
Whether or not a logger can be fetched from the context does usually not depend on anything dynamic. This means that a logger not being contained in the context when it is expected to be there is usually due to an error in the code, which can be spotted easier when the program panics if it happens.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The logging library has a new `FromContextOrPanic` function.
```
