### PR TITLE
frontmatter added to deployer docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 
 ## Deployers
 
-- [What is an Deployer?](deployer/README.md)
+- [What are Deployers ?](deployer/README.md)
 - [Container Deployer](deployer/container.md)
 - [Deployer Resource Health-/Readiness Checks](deployer/healthchecks.md)
 - [Helm Deployer](deployer/helm.md)

--- a/docs/deployer/README.md
+++ b/docs/deployer/README.md
@@ -1,4 +1,8 @@
-# What is an Deployer?
+---
+title: Landscaper Deployer
+sidebar_position: 4
+---
+# What are Deployers ?
 
 The landscaper offloads most work to so called Deployers.
 These deployers are meant to have specific deploy, install and update logic.
@@ -7,10 +11,10 @@ These deployers are meant to have specific deploy, install and update logic.
 
 The following deployers are available out of the box with the Landscaper. Further deployer could be implemented and registered.
 
-- [Mock](mock.md)
-- [Helm](helm.md)
-- [Kubernetes Manifest](manifest.md)
-- [Container](container.md)
+- [Mock](mock)
+- [Helm](helm)
+- [Kubernetes Manifest](manifest)
+- [Container](container)
 
 
 ## Common Documentation

--- a/docs/deployer/container.md
+++ b/docs/deployer/container.md
@@ -1,3 +1,8 @@
+---
+title: Container Deployer
+sidebar_position: 4
+---
+
 # Container Deployer
 
 The container deployer is a controller that allows you to run whatever coding you need to set up your cloud environment.

--- a/docs/deployer/healthchecks.md
+++ b/docs/deployer/healthchecks.md
@@ -1,3 +1,8 @@
+---
+title: Deployer Resource Health-/Readiness Checks
+sidebar_position: 7
+---
+
 # Deployer Resource Health-/Readiness Checks
 
 The Helm and Manifest deployers can check the health of the resources they just deployed. This document describes how the health checks work and how they can be configured.

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -1,3 +1,8 @@
+---
+title: Helm Deployer
+sidebar_position: 1
+---
+
 # Helm Deployer
 
 The helm deployer is a controller that reconciles DeployItems of type `landscaper.gardener.cloud/helm`. There are two

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -1,3 +1,8 @@
+---
+title: Manifest Deployer
+sidebar_position: 3
+---
+
 # Kubernetes Manifest Deployer
 
 The kubernetes manifest deployer is a controller that reconciles DeployItems of type `landscaper.gardener.cloud/kubernetes-manifest`.

--- a/docs/deployer/manifest_deletion.md
+++ b/docs/deployer/manifest_deletion.md
@@ -1,3 +1,8 @@
+---
+title: Deletion of Manifest and Manifest-Only Helm DeployItems
+sidebar_position: 6
+---
+
 # Deletion of Manifest and Manifest-Only Helm DeployItems
 
 This chapter is only relevant for:

--- a/docs/deployer/mock.md
+++ b/docs/deployer/mock.md
@@ -1,3 +1,8 @@
+---
+title: Mock Deployer
+sidebar_position: 5
+---
+
 # Mock Deployer
 
 The mock deployer is a controller that reconciles DeployItems of type `landscaper.gardener.cloud/mock`. 


### PR DESCRIPTION
**What this PR does / why we need it**:
frontmatter added to deployer docs for doc generation
documentation index updated