### PR TITLE
use pinned ocm version v0.6.0

### DIFF
--- a/.ci/component_descriptor_ocm
+++ b/.ci/component_descriptor_ocm
@@ -19,11 +19,12 @@ if ! which make 1>/dev/null; then
 fi
 
 # install ocm cli
-#if ! which ocm 1>/dev/null; then
-#  curl -s https://ocm.software/install.sh | bash
-#fi
-
-curl -s https://ocm.software/install.sh | OCM_VERSION=0.6.0 bash
+OCM_VERSION=0.6.0
+if which ocm 1>/dev/null; then
+  curl -s https://ocm.software/install.sh | OCM_VERSION=${OCM_VERSION} bash -s "$(which ocm)"
+else
+  curl -s https://ocm.software/install.sh | OCM_VERSION=${OCM_VERSION} bash
+fi
 
 # start docker daemon
 launch-dockerd.sh

--- a/.ci/component_descriptor_ocm
+++ b/.ci/component_descriptor_ocm
@@ -19,9 +19,11 @@ if ! which make 1>/dev/null; then
 fi
 
 # install ocm cli
-if ! which ocm 1>/dev/null; then
-  curl -s https://ocm.software/install.sh | bash
-fi
+#if ! which ocm 1>/dev/null; then
+#  curl -s https://ocm.software/install.sh | bash
+#fi
+
+curl -s https://ocm.software/install.sh | OCM_VERSION=0.6.0 bash
 
 # start docker daemon
 launch-dockerd.sh

--- a/.ci/component_descriptor_ocm
+++ b/.ci/component_descriptor_ocm
@@ -21,7 +21,7 @@ fi
 # install ocm cli
 OCM_VERSION=0.6.0
 if which ocm 1>/dev/null; then
-  curl -s https://ocm.software/install.sh | OCM_VERSION=${OCM_VERSION} bash -s "$(which ocm)"
+  curl -s https://ocm.software/install.sh | OCM_VERSION=${OCM_VERSION} bash -s "$(dirname $(which ocm))"
 else
   curl -s https://ocm.software/install.sh | OCM_VERSION=${OCM_VERSION} bash
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

There is currently an incompatability in the pipeline with the newest ocm version.
Use a pinned ocm version v0.6.0 for now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
use ocm version v0.6.0
```
