### PR TITLE
fix pipeline loop

### DIFF
--- a/.ci/format
+++ b/.ci/format
@@ -20,6 +20,6 @@ source "$PROJECT_ROOT/.ci/ensure-go"
     exit 0
   fi
 
-  git add --all
+  git add "*.go" docs/README.md
   git commit -m "[ci skip] formatting and documentation index"
 )

--- a/.ci/integration-test
+++ b/.ci/integration-test
@@ -13,7 +13,7 @@ set -euo pipefail
 
 PROJECT_ROOT="$(realpath $(dirname $0)/..)"
 FULL_INTEGRATION_TEST_PATH="$(realpath "$INTEGRATION_TEST_PATH")"
-USE_OCM_LIB=${1}
+USE_OCM_LIB=${1:-}
 
 "$PROJECT_ROOT/.ci/int-test" "1" | tee "$FULL_INTEGRATION_TEST_PATH/ttt.log"
 

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,7 +5,8 @@
 landscaper:
   template: 'default'
   base_definition:
-    repo: ~
+    repo:
+      disable_ci_skip: True
     traits:
       version:
         preprocess: 'inject-commit-hash'

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.99.0-dev-bfcfa044e3727ff58436d7263c8ab2314feaa48a
+v0.99.0-dev


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the pipeline running amok.

There were two issues with the previous approach which should be fixed with this PR:
- The pipeline ignored the `[ci skip]` because it seems that this has to be explicitly enabled in the pipeline definition.
- The formatting script accidentally also committed the changed `VERSION` file.

