### PR TITLE
fix format step

### DIFF
--- a/.ci/format
+++ b/.ci/format
@@ -15,11 +15,11 @@ source "$PROJECT_ROOT/.ci/ensure-go"
   cd "$PROJECT_ROOT"
   make format generate-docs
 
-  if [ -z "$(git status --porcelain=v1)" ]; then
+  git add "*.go" docs/README.md
+  if ! git status --porcelain=v1 | grep -e '^M\s\s' 1>/dev/null; then
     echo "nothing to commit"
     exit 0
   fi
 
-  git add "*.go" docs/README.md
   git commit -m "[ci skip] formatting and documentation index"
 )

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -48,6 +48,9 @@ landscaper:
         format:
           publish_to:
           - source
+          depends:
+          - verify
+          - integration_test
     pull-request:
       steps:
         integration_test:
@@ -93,3 +96,6 @@ landscaper:
         format:
           publish_to:
           - source
+          depends:
+          - verify
+          - integration_test


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes a bug that could break the `format` pipeline step.
- Ensures that `format` is executed after `verify` and `integration_test` in the pipeline.
