### PR TITLE
extract OCM version from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ CODE_GEN_VERSION ?= $(shell  $(REPO_ROOT)/hack/extract-module-version.sh k8s.io/
 CONTROLLER_TOOLS_VERSION ?= v0.12.0
 FORMATTER_VERSION ?= v0.16.0
 LINTER_VERSION ?= 1.55.2
-OCM_VERSION ?= 0.4.3
+OCM_VERSION ?= $(shell  NO_PREFIX=true $(REPO_ROOT)/hack/extract-module-version.sh github.com/open-component-model/ocm)
 API_REF_GEN_VERSION ?= v0.0.10
 JQ_VERSION ?= 1.6
 

--- a/hack/extract-module-version.sh
+++ b/hack/extract-module-version.sh
@@ -14,4 +14,8 @@ version=${version%%//*} # remove potential comment at end of line
 version=$(sed -r 's@^[[:blank:]]+|[[:blank:]]+$@@g' <<< $version) # remove leading and trailing whitespace
 version=${version#$mod' '}
 
+if [[ ${NO_PREFIX:-"false"} != "false" ]]; then
+  version=${version#v}
+fi
+
 echo "$version"


### PR DESCRIPTION
**What this PR does / why we need it**:
The OCM CLI version used for building the component descriptor is now derived from the OCM dependency in the go.mod file instead of being hardcoded (to a really old version) in the Makefile.
