### PR TITLE
pin setup-envtest to release-0.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ LINTER_VERSION ?= 1.55.2
 OCM_VERSION ?= $(shell  NO_PREFIX=true $(REPO_ROOT)/hack/extract-module-version.sh github.com/open-component-model/ocm)
 API_REF_GEN_VERSION ?= v0.0.10
 JQ_VERSION ?= 1.6
+SETUP_ENVTEST_VERSION ?= release-0.16
 
 .PHONY: localbin
 localbin: ## Creates the local bin folder, if it doesn't exist. Not meant to be called manually, used as requirement for the other tool commands.
@@ -176,7 +177,7 @@ golangci-lint: localbin ## Download golangci-lint locally if necessary. If wrong
 envtest: localbin ## Download envtest-setup locally if necessary.
 	@test -s $(LOCALBIN)/setup-envtest || \
 	( echo "Installing setup-envtest ..."; \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest )
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION) )
 
 .PHONY: ocm
 ocm: localbin ## Install OCM CLI if necessary.


### PR DESCRIPTION
**What this PR does / why we need it**:

Latest update of setup-envtest no longer works with go 1.21
Pin the version to 0.16.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Pin setup-envtest to release-0.16
```
