### PR TITLE
run make revendor before integration test

### DIFF
--- a/.ci/integration-test-runner
+++ b/.ci/integration-test-runner
@@ -18,6 +18,8 @@ DURATION_FOR_CLUSTER_DELETION=48h
 
 PROJECT_ROOT="$(realpath $(dirname $0)/..)"
 
+make -C $PROJECT_ROOT revendor
+
 echo "Run integration tests with cluster and registry creation"
 echo "Source path: ${PROJECT_ROOT}"
 echo "Gardener kubeconfig path: ${GARDENER_KUBECONFIG_PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to manually run `make revendor` to tidy the go dependencies before running the int test helper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Run `make revendor` before integration test.
```
