### PR TITLE
enhance extract-module-version script

### DIFF
--- a/hack/extract-module-version.sh
+++ b/hack/extract-module-version.sh
@@ -9,10 +9,19 @@ set -euo pipefail
 PROJECT_ROOT="$(realpath $(dirname $0)/..)"
 mod="$1"
 
-version="$(cat "$PROJECT_ROOT/go.mod" | grep "$mod ")" # fetch line containing the version
+version="$(cat "$PROJECT_ROOT/go.mod" | grep -m 1 "$mod ")" # fetch line containing the version
 version=${version%%//*} # remove potential comment at end of line
 version=$(sed -r 's@^[[:blank:]]+|[[:blank:]]+$@@g' <<< $version) # remove leading and trailing whitespace
 version=${version#$mod' '}
+
+# resolve replace directives
+if cat "$PROJECT_ROOT/go.mod" | grep "$mod => $mod" &>/dev/null || cat "$PROJECT_ROOT/go.mod" | grep "$mod $version => $mod" &>/dev/null; then
+  version="$(cat "$PROJECT_ROOT/go.mod" | grep -E -m 1 "$mod .*=> $mod")" # fetch line containing the replace
+  version=${version%%//*} # remove potential comment at end of line
+  version=${version##*'=>'} # remove everything before the '=>'
+  version=$(sed -r 's@^[[:blank:]]+|[[:blank:]]+$@@g' <<< $version) # remove leading and trailing whitespace
+  version=${version#$mod' '}
+fi
 
 if [[ ${NO_PREFIX:-"false"} != "false" ]]; then
   version=${version#v}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `hack/extract-module-version.sh` script broke when the specified module was part of a `replace` directive in the `go.mod` file. Now it not only doesn't fail, but it also takes the replace into account and returns the correct version (as long as there is only one replace for the module defined, it still can't handle multiple ones).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
