### PR TITLE
Update deprecated gardenlinux to 1312.3.0

### DIFF
--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -26,7 +26,7 @@ spec:
           type: n1-standard-4
           image:
             name: gardenlinux
-            version: 1312.1.0
+            version: 1312.3.0
           architecture: amd64
         zones:
           - europe-west1-b


### PR DESCRIPTION
**What this PR does / why we need it**:
[gardenlinux 1312.1.0 has been deprecated](https://pages.github.tools.sap/kubernetes/gardener/docs/landscapes/live/pam/#gardenlinux)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Update to gardenlinux to 1312.3.0
```
