### PR TITLE
Renovate for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,19 +135,19 @@ REGISTRY_BINARY ?= $(LOCALBIN)/registry
 
 ## Tool Versions
 CODE_GEN_VERSION ?= $(shell  $(REPO_ROOT)/hack/extract-module-version.sh k8s.io/code-generator)
-# renovate: datasource=go depName=sigs.k8s.io/controller-tools
+# renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.12.0
-# renovate: datasource=go depName=golang.org/x/tools/cmd/goimports
+# renovate: datasource=github-tags depName=golang/tools
 FORMATTER_VERSION ?= v0.19.0
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 LINTER_VERSION ?= v1.57.2
-# renovate: datasource=go depName=github.com/elastic/crd-ref-docs
+# renovate: datasource=github-releases depName=elastic/crd-ref-docs
 API_REF_GEN_VERSION ?= v0.0.12
 # renovate: datasource=github-releases depName=jqlang/jq
 JQ_VERSION ?= v1.7.1
-# renovate: datasource=go depName=github.com/open-component-model/ocm
+# renovate: datasource=github-releases depName=open-component-model/ocm
 OCM_VERSION ?= v0.8.0
-# renovate: datasource=go depName=github.com/golang/mock
+# renovate: datasource=github-releases depName=golang/mock
 MOCKGEN_VERSION ?= v1.6.0
 # renovate: datasource=github-releases depName=distribution/distribution
 REGISTRY_VERSION ?= v3.0.0-alpha.1

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
         "(^|/)Makefile$"
       ],
       "matchStrings": [
-        "# renovate: datasource=go depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV |ARG )?.+?_VERSION ?(?:\\?=|=)\"? ?v?(?<currentValue>.+?)\"?\\s"
+        "# renovate: datasource=go depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_VERSION ?(?:\\?=|=)\"? ?v?(?<currentValue>.+?)\"?\\s"
       ]
     },
     {
@@ -46,7 +46,7 @@
         "(^|/)Makefile$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>(?!go\\s)[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV |ARG )?.+?_VERSION ?(?:\\?=|=)\"? ?(?<currentValue>.+?)\"?\\s"
+        "# renovate: datasource=(?<datasource>(?!go\\s)[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_VERSION ?(?:\\?=|=)\"? ?(?<currentValue>.+?)\"?\\s"
       ]
     }
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,16 +29,26 @@
   ],
   "customManagers": [
     {
+      "description": "Match go datasources (does not consider the v prefix (e.g. v1.2.3) as part of the version)",
       "customType": "regex",
       "fileMatch": [
-        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
-        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$",
         "(^|/)Makefile$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV |ARG )?.+?_VERSION ?(?:\\?=|=)\"?(?<currentValue>.+?)\"?\\s"
+        "# renovate: datasource=go depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV |ARG )?.+?_VERSION ?(?:\\?=|=)\"? ?v?(?<currentValue>.+?)\"?\\s"
+      ]
+    },
+    {
+
+      "description": "Match other datasources but go (considers the v prefix (e.g. v1.2.3) as part of the version)",
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)Makefile$"
       ],
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>(?!go\\s)[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV |ARG )?.+?_VERSION ?(?:\\?=|=)\"? ?(?<currentValue>.+?)\"?\\s"
+      ]
     }
+
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,26 +29,16 @@
   ],
   "customManagers": [
     {
-      "description": "Match go datasources (does not consider the v prefix (e.g. v1.2.3) as part of the version)",
+      "description": "Match in Makefile",
       "customType": "regex",
       "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$",
         "(^|/)Makefile$"
       ],
       "matchStrings": [
-        "# renovate: datasource=go depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_VERSION ?(?:\\?=|=)\"? ?v?(?<currentValue>.+?)\"?\\s"
-      ]
-    },
-    {
-
-      "description": "Match other datasources but go (considers the v prefix (e.g. v1.2.3) as part of the version)",
-      "customType": "regex",
-      "fileMatch": [
-        "(^|/)Makefile$"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>(?!go\\s)[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_VERSION ?(?:\\?=|=)\"? ?(?<currentValue>.+?)\"?\\s"
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV |ARG )?.+?_VERSION ?(?:\\?=|=)\"? ?(?<currentValue>.+?)\"?\\s"
       ]
     }
-
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Here, we introduce a special Makefile custom Manager for datasource=go to fix the following issue:

Although renovate seemed to be able to detect the go versions with the v prefix (v1.2.3), the prefix will not replace a v1.2.3 with v1.2.4 but with 1.2.4 (thus, omit the prefix) if datasource=go (probably since in the module file, the versions are also omitted). But commands such as go install module@v1.2.3 do not work with module@1.2.3.

An alternative would be to strictly not use the go datasource and instead use github-releases.

Since renovate uses the re2 regex flavor which does not support positive lookahead, there is no clean way to define another manager that cares about all datasources but go (since you would need the (?!go) lookahead). Thus, use github-releases instead.
Therefore, I decided to go the alternative way and specify github-releases as datasource instead. Let's see if this works.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
