### PR TITLE
add landscaper aggregation cluster roles

### DIFF
--- a/charts/landscaper/charts/rbac/templates/_helpers.tpl
+++ b/charts/landscaper/charts/rbac/templates/_helpers.tpl
@@ -35,3 +35,15 @@ Create the name of the service account to use
 {{- define "landscaper.user.serviceAccountName" -}}
 {{- default "landscaper-user" .Values.global.serviceAccount.user.name }}
 {{- end }}
+
+{{/*
+Create the name of the of the aggregation cluster roles
+*/}}
+{{- define "landscaper.aggregation.admin.clusterRoleName" -}}
+{{- default "landscaper:aggregate-to-admin" .Values.aggregation.admin.name }}
+{{- end }}
+
+{{- define "landscaper.aggregation.view.clusterRoleName" -}}
+{{- default "landscaper:aggregate-to-view" .Values.aggregation.view.name}}
+{{- end }}
+

--- a/charts/landscaper/charts/rbac/templates/aggregation-clusterroles.yaml
+++ b/charts/landscaper/charts/rbac/templates/aggregation-clusterroles.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.aggregation.admin.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "landscaper.aggregation.admin.clusterRoleName" . }}
+  labels:
+    rbac.landscaper.gardener.cloud/aggregate-to-admin: "true"
+    {{- include "landscaper.labels" . | nindent 4 }}
+  {{- with .Values.aggregation.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+    - landscaper.gardener.cloud
+    resources:
+      - "*"
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+{{- end }}
+---
+{{- if .Values.aggregation.view.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "landscaper.aggregation.view.clusterRoleName" . }}
+  labels:
+    rbac.landscaper.gardener.cloud/aggregate-to-view: "true"
+    {{- include "landscaper.labels" . | nindent 4 }}
+  {{- with .Values.aggregation.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+    - landscaper.gardener.cloud
+    resources:
+    - "*"
+    verbs:
+    - get
+    - list
+    - watch
+{{- end }}

--- a/charts/landscaper/charts/rbac/values.yaml
+++ b/charts/landscaper/charts/rbac/values.yaml
@@ -26,3 +26,23 @@ global:
       # The name of the service account to use.
       # If not set and create is true, the default will be "landscaper-user"
       name: ""
+
+aggregation:
+  admin:
+    # Specifies whether the admin aggregation cluster role shall be created
+    create: true
+    # Annotations to add to the admin aggregation cluster role
+    annotations: {}
+    # The name of the admin aggregation cluster role.
+    # If not set and create is true, the default will be "landscaper:aggregate-to-admin"
+    name: ""
+
+  view:
+    # Specifies whether the view aggregation cluster role shall be created
+    create: true
+    # Annotations to add to the view aggregation cluster role
+    annotations: {}
+    # The name of the view aggregation cluster role.
+    # If not set and create is true, the default will be "landscaper:view"
+    name: ""
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a `landscaper:aggregate-to-admin`and a `landscaper:aggregate-to-view` cluster role to the Landscaper RBAC Helm chart.

These cluster roles can be used to form aggregation cluster roles.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add admin and view aggregation cluster roles.
```
