### PR TITLE
Fix dpanic due to non-string logging key

### DIFF
--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -518,7 +518,7 @@ func (c *Controller) setInstallationPhaseAndUpdate(ctx context.Context, inst *ls
 		// reduceLogLevelForConflicts is set on true, if conflicts might occur, e.g.
 		// - when deleting an item a touch operation might be triggered for all siblings to speed up the operation
 		if reduceLogLevelForConflicts && apierrors.IsConflict(err) {
-			logger.Info("unable to update installation status", err, err.Error())
+			logger.Info("unable to update installation status", lc.KeyError, err.Error())
 		} else {
 			logger.Error(err, "unable to update installation status")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

A logging statement in method `setInstallationPhaseAndUpdate` uses a non-string key. This causes errors as shown below. The present PR fixes this.

```json
{
  "level":"dpanic",
  "ts":"2024-05-02T07:16:17.351Z",
  "logger":"controllers.installation",
  "msg":"non-string key argument passed to logging, ignoring all later arguments",
  "reconciledResourceKind":"Installation",
  "reconciledResource":"...",
  "method":"setInstallationPhaseAndUpdate",
  "invalid key":"Op: errorWithWriteID - Reason: write - Message: write operation w000124 failed with ..."
}
```

Occurred ~260 time per day and landscape. No pod restart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- Bugfix concerning a non-string logging key.
```
