### PR TITLE
Fix link in docu

### DIFF
--- a/docs/guided-tour/basics/manifest-deployer/README.md
+++ b/docs/guided-tour/basics/manifest-deployer/README.md
@@ -22,7 +22,7 @@ In the current example, we will show how the same task can be achieved with the 
 This deployer is great if you want to deploy some Kubernetes manifests without going the extra mile of building a 
 Helm chart for these manifests. The Kubernetes manifests are directly included in the blueprint of the Installation.
 
-Let's look at the blueprint of the [Installation](installation/installation.yaml). It contains one DeployItem:
+Let's look at the blueprint of the [Installation](installation/installation.yaml.tpl). It contains one DeployItem:
 
 ```yaml
 deployItems:

--- a/docs/guided-tour/basics/multiple-deployitems/README.md
+++ b/docs/guided-tour/basics/multiple-deployitems/README.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Deploying Multiple Helm Charts with One Installation
 
-It is possible to combine multiple deployments in one Installation. We will demonstrate this with the blueprint in [this Installation](./installation/installation.yaml). It contains two DeployItems. Each of them deploys the hello-world Helm chart, but to two different clusters. Therefore, the Installation 
+It is possible to combine multiple deployments in one Installation. We will demonstrate this with the blueprint in [this Installation](./installation/installation.yaml.tpl). It contains two DeployItems. Each of them deploys the hello-world Helm chart, but to two different clusters. Therefore, the Installation 
 imports two Target objects: [target-1.yaml](./installation/target-1.yaml) and 
 [target-2.yaml](./installation/target-2.yaml).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a link in the docu of the guided tour.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
On https://github.com/hoffimar/landscaper/blob/patch-1/docs/guided-tour/basics/multiple-deployitems/README.md the links to target-1 and target-2 are also broken, since the 2 targets are created dynamically by the shell script only.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
