### PR TITLE
Bugfix ocm config

### DIFF
--- a/charts/container-deployer/templates/clusterrole.yaml
+++ b/charts/container-deployer/templates/clusterrole.yaml
@@ -58,7 +58,6 @@ rules:
   - "pods/status"
   - "secrets"
   - "serviceaccounts"
-  - "configmaps"
   verbs:
   - "*"
 
@@ -66,6 +65,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - configmaps
   verbs:
   - get
   - list

--- a/charts/helm-deployer/templates/clusterrole.yaml
+++ b/charts/helm-deployer/templates/clusterrole.yaml
@@ -34,6 +34,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - configmaps
   verbs:
   - get
   - watch

--- a/docs/usage/Context.md
+++ b/docs/usage/Context.md
@@ -45,9 +45,9 @@ configurations:
   config.mydeployer.mydomain.org: ... # custom configuration, not evaluated by landscaper
 ```
 
->**DEPRECATED:**  
-> The `repositoryContext` has been deprecated and is superseded by the specification of resolvers in the `ocmConfig` as
-> shown and explained below.
+>**NOTE:**  
+> Due to some implementation details, the `repositoryContext` is still required, even if resolvers are specified in the 
+> `ocmConfig` as shown and explained below.
 
 The repository context is usually the location where the component descriptors are stored in an OCI registry. For the 
 example above it is expected that the component descriptors are stored under `example.com/component-descriptors/`.
@@ -84,7 +84,8 @@ So this config map is a representation of the [ocm configfile](https://ocm.softw
 concept as a kubernetes API object. Consequently, you can test certain ocm configurations locally, using your ocm 
 configfile (located at $HOME/.ocmconfig per default) and the ocm-cli and then copy the files contents into the config 
 map under the key `.ocmconfig`.
-The `resolvers` can be used to replace the `repositoryContext` specification in the Context object. This also allows to
+While the `repositoryContext` is currently still required, in the future, `resolvers` will likely replace the 
+`repositoryContext` specification in the Context object entirely. The `resolvers` also allows to
 specify multiple repositories. So, the component specified in the installation can reference a component located in
 another repository. In the example above, a component called `github.com/acme.org/component` stored in 
 `ghcr.io/ocm-example-repo-1` can have a reference to a component called `github.com/acme.org/referenced-component` 

--- a/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
+++ b/pkg/landscaper/installations/executions/template/gotemplate/funcs.go
@@ -235,7 +235,7 @@ func getResourceKeyGoFunc(cv model.ComponentVersion) func(args ...interface{}) (
 		// which the deployer would forward to the webserver and the webserver determines the root component to resolve
 		// this reference by watching the installation (this way, we would ensure that the deployer can only get
 		// resources from its legitimate component)
-		resource, resourceCv, err := utils.ResolveResourceReference(compvers, *resourceRef, nil)
+		resource, resourceCv, err := utils.ResolveResourceReference(compvers, *resourceRef, compvers.GetContext().GetResolver())
 		if err != nil {
 			return "", fmt.Errorf("unable to resolve relative resource reference: %w", err)
 		}
@@ -287,7 +287,7 @@ func getResourceContentGoFunc(cv model.ComponentVersion) func(args ...interface{
 			return "", err
 		}
 
-		resource, _, err := utils.ResolveResourceReference(compvers, *resourceRef, nil)
+		resource, _, err := utils.ResolveResourceReference(compvers, *resourceRef, compvers.GetContext().GetResolver())
 		if err != nil {
 			return "", fmt.Errorf("unable to resolve relative resource reference: %w", err)
 		}

--- a/pkg/landscaper/installations/executions/template/spiff/funcs.go
+++ b/pkg/landscaper/installations/executions/template/spiff/funcs.go
@@ -163,7 +163,7 @@ func spiffGetResourceKey(cv model.ComponentVersion) func(arguments []interface{}
 		// which the deployer would forward to the webserver and the webserver determines the root component to resolve
 		// this reference by watching the installation (this way, we would ensure that the deployer can only get
 		// resources from its legitimate component)
-		resource, resourceCv, err := utils.ResolveResourceReference(compvers, *resourceRef, nil)
+		resource, resourceCv, err := utils.ResolveResourceReference(compvers, *resourceRef, compvers.GetContext().GetResolver())
 		if err != nil {
 			return info.Error("unable to resolve relative resource reference: %w", err)
 		}
@@ -221,7 +221,7 @@ func spiffGetResourceContent(cv model.ComponentVersion) func(arguments []interfa
 			return info.Error(err)
 		}
 
-		resource, _, err := utils.ResolveResourceReference(compvers, *resourceRef, nil)
+		resource, _, err := utils.ResolveResourceReference(compvers, *resourceRef, compvers.GetContext().GetResolver())
 		if err != nil {
 			return info.Error("unable to resolve relative resource reference: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
During the preparation of the demo for the review meeting, I discovered two bugs in the ocm config implementation. 

1) When using the `getResourceKey()` templating function, it did not work since the function internally didn't pass the resolver. This is resolved now.
2) The helm deployer's cluster role did not have sufficient rbac authorizations to read configmaps. This is resolved now, too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
