### PR TITLE
aggregate view role also to administrators

### DIFF
--- a/charts/landscaper/charts/rbac/templates/aggregation-clusterroles.yaml
+++ b/charts/landscaper/charts/rbac/templates/aggregation-clusterroles.yaml
@@ -29,6 +29,7 @@ metadata:
   name: {{ include "landscaper.aggregation.view.clusterRoleName" . }}
   labels:
     rbac.landscaper.gardener.cloud/aggregate-to-view: "true"
+    rbac.landscaper.gardener.cloud/aggregate-to-admin: "true"
     {{- include "landscaper.labels" . | nindent 4 }}
   {{- with .Values.aggregation.admin.annotations }}
   annotations:


### PR DESCRIPTION
**What this PR does / why we need it**:

View subjects must also be aggregated into admin roles.
Therefore the `rbac.landscaper.gardener.cloud/aggregate-to-admin: "true"` label mustbe set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix landscaper view cluster aggregation role.
```
