### PR TITLE
Repository Contexts

### DIFF
--- a/pkg/components/blueprinthandler_test.go
+++ b/pkg/components/blueprinthandler_test.go
@@ -70,7 +70,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource("blueprint-dir", nil))
@@ -96,7 +96,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 
@@ -134,7 +134,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource("corrupted-blueprint", nil))
@@ -152,7 +152,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource("corrupted-blueprint-tar", nil))

--- a/pkg/components/components_test.go
+++ b/pkg/components/components_test.go
@@ -158,8 +158,8 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), cdref))
 
-		oRaForCnudie := Must(ocmfactory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH_VALID}, nil, nil))
-		oRaForOcm := Must(ocmfactory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALOCMREPOPATH_VALID}, nil, nil))
+		oRaForCnudie := Must(ocmfactory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH_VALID}, nil, nil))
+		oRaForOcm := Must(ocmfactory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALOCMREPOPATH_VALID}, nil, nil))
 
 		// the 3 registry accesses should all behave the same and the interface methods should return the same data
 		oRaForCnudieCv := Must(oRaForCnudie.GetComponentVersion(ctx, cdref))
@@ -239,7 +239,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 			Version:           "1.0.0",
 		}
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: "./"}, nil, inlineDescriptor))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		Expect(compvers.GetComponentDescriptor()).To(YAMLEqual(inlineDescriptor))
@@ -252,7 +252,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(referencedComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res, err := compvers.GetResource("non-existent-resource", nil)
@@ -269,7 +269,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(referencedComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource(GENERIC_RESOURCE_NAME, nil))
@@ -289,7 +289,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withoutRepoctxComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).To(HaveOccurred())
@@ -303,7 +303,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withInvalidAccessTypeComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).ToNot(HaveOccurred())
@@ -325,7 +325,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withInvalidReferenceComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).ToNot(HaveOccurred())
@@ -352,7 +352,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(invalidComponentComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).To(HaveOccurred())
@@ -365,7 +365,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 	// Check nil argument handling of facade methods
 	DescribeTable("prevent null pointer exceptions", func(factory model.Factory, registryRootPath string) {
 		// Test registry access
-		registryAccess, err := factory.NewRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil)
+		registryAccess, err := factory.CreateRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil)
 		Expect(registryAccess).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -376,7 +376,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		// Organize a valid component version
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), cdref))
-		registryAccess, err = factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err = factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil)
 		Expect(registryAccess).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/components/jsonschemahandler_test.go
+++ b/pkg/components/jsonschemahandler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withJSONSchemasComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 
@@ -91,7 +91,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withJSONSchemasComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 

--- a/pkg/components/model/factory.go
+++ b/pkg/components/model/factory.go
@@ -7,25 +7,27 @@ package model
 import (
 	"context"
 
-	"github.com/mandelsoft/vfs/pkg/vfs"
-
 	"github.com/gardener/component-spec/bindings-go/ctf"
+	"github.com/mandelsoft/vfs/pkg/vfs"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/landscaper/apis/config"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	helmv1alpha1 "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1"
+	"github.com/gardener/landscaper/pkg/components/model/componentoverwrites"
 	"github.com/gardener/landscaper/pkg/components/model/types"
 )
 
 type RegistryAccessOptions struct {
-	Fs                  vfs.FileSystem
-	OcmConfig           *corev1.ConfigMap
-	Secrets             []corev1.Secret
-	LocalRegistryConfig *config.LocalRegistryConfiguration
-	OciRegistryConfig   *config.OCIConfiguration
-	InlineCd            *types.ComponentDescriptor
+	Fs                           vfs.FileSystem
+	OcmConfig                    *corev1.ConfigMap
+	AdditionalRepositoryContexts []types.PrioritizedRepositoryContext
+	Overwriter                   componentoverwrites.Overwriter
+	Secrets                      []corev1.Secret
+	LocalRegistryConfig          *config.LocalRegistryConfiguration
+	OciRegistryConfig            *config.OCIConfiguration
+	InlineCd                     *types.ComponentDescriptor
 }
 
 type Factory interface {
@@ -60,7 +62,7 @@ type Factory interface {
 	//
 	// [component-cli]: https://github.com/gardener/component-cli
 	// [ocmlib]: https://github.com/open-component-model/ocm
-	NewRegistryAccess(ctx context.Context, options RegistryAccessOptions) (RegistryAccess, error)
+	NewRegistryAccess(ctx context.Context, options *RegistryAccessOptions) (RegistryAccess, error)
 
 	CreateRegistryAccess(ctx context.Context,
 		fs vfs.FileSystem,

--- a/pkg/components/model/factory.go
+++ b/pkg/components/model/factory.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Factory interface {
-	// NewRegistryAccess provides an instance of a RegistryAccess, which is an interface for dealing with ocm
+	// CreateRegistryAccess provides an instance of a RegistryAccess, which is an interface for dealing with ocm
 	// components.Technically, it is a facade either backed by the [component-cli] or by the [ocmlib].
 	//
 	// fs allows to pass a file system that is considered for resolving local components or artifacts as well as other
@@ -52,7 +52,7 @@ type Factory interface {
 	// [component-cli]: https://github.com/gardener/component-cli
 	// [ocmlib]: https://github.com/open-component-model/ocm
 	// TODO: rework this constructor method and replace essentially all parameters with an Option, so that this can easily be extended in the future
-	NewRegistryAccess(ctx context.Context,
+	CreateRegistryAccess(ctx context.Context,
 		fs vfs.FileSystem,
 		ocmconfig *corev1.ConfigMap,
 		secrets []corev1.Secret,

--- a/pkg/components/model/factory.go
+++ b/pkg/components/model/factory.go
@@ -19,8 +19,17 @@ import (
 	"github.com/gardener/landscaper/pkg/components/model/types"
 )
 
+type RegistryAccessOptions struct {
+	Fs                  vfs.FileSystem
+	OcmConfig           *corev1.ConfigMap
+	Secrets             []corev1.Secret
+	LocalRegistryConfig *config.LocalRegistryConfiguration
+	OciRegistryConfig   *config.OCIConfiguration
+	InlineCd            *types.ComponentDescriptor
+}
+
 type Factory interface {
-	// CreateRegistryAccess provides an instance of a RegistryAccess, which is an interface for dealing with ocm
+	// NewRegistryAccess provides an instance of a RegistryAccess, which is an interface for dealing with ocm
 	// components.Technically, it is a facade either backed by the [component-cli] or by the [ocmlib].
 	//
 	// fs allows to pass a file system that is considered for resolving local components or artifacts as well as other
@@ -51,7 +60,8 @@ type Factory interface {
 	//
 	// [component-cli]: https://github.com/gardener/component-cli
 	// [ocmlib]: https://github.com/open-component-model/ocm
-	// TODO: rework this constructor method and replace essentially all parameters with an Option, so that this can easily be extended in the future
+	NewRegistryAccess(ctx context.Context, options RegistryAccessOptions) (RegistryAccess, error)
+
 	CreateRegistryAccess(ctx context.Context,
 		fs vfs.FileSystem,
 		ocmconfig *corev1.ConfigMap,

--- a/pkg/components/model/types/componentdescriptor.go
+++ b/pkg/components/model/types/componentdescriptor.go
@@ -19,3 +19,8 @@ type Resource = cdv2.Resource
 type Source = cdv2.Source
 
 type UnstructuredTypedObject = cdv2.UnstructuredTypedObject
+
+type PrioritizedRepositoryContext struct {
+	RepositoryContext *UnstructuredTypedObject
+	Priority          int
+}

--- a/pkg/components/ocmlib/factory.go
+++ b/pkg/components/ocmlib/factory.go
@@ -50,7 +50,7 @@ type Factory struct{}
 
 var _ model.Factory = &Factory{}
 
-func (*Factory) NewRegistryAccess(ctx context.Context,
+func (*Factory) CreateRegistryAccess(ctx context.Context,
 	fs vfs.FileSystem,
 	ocmconfig *corev1.ConfigMap,
 	secrets []corev1.Secret,
@@ -60,7 +60,7 @@ func (*Factory) NewRegistryAccess(ctx context.Context,
 	additionalBlobResolvers ...ctf.TypedBlobResolver) (model.RegistryAccess, error) {
 
 	logger, _ := logging.FromContextOrNew(ctx, nil)
-	pm := utils.StartPerformanceMeasurement(&logger, "NewRegistryAccess")
+	pm := utils.StartPerformanceMeasurement(&logger, "CreateRegistryAccess")
 	defer pm.StopDebug()
 
 	if fs == nil {

--- a/pkg/components/ocmlib/ocm_test.go
+++ b/pkg/components/ocmlib/ocm_test.go
@@ -155,7 +155,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 		// method can deal with the legacy ComponentDescriptorReference type rather than testing ocmlib functionality
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
@@ -169,7 +169,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 
 		Expect(reflect.DeepEqual(cv.GetComponentDescriptor(), compdesc)).To(BeTrue())
@@ -185,7 +185,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALOCMREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALOCMREPOPATH}, nil, nil, nil))
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 
 		Expect(reflect.DeepEqual(cv.GetComponentDescriptor(), compdesc)).To(BeTrue())
@@ -202,7 +202,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 			Expect(f.Close()).To(Succeed())
 		}
 		// Create a Registry Access and check whether credentials are properly set and can be found
-		r := Must(factory.NewRegistryAccess(ctx, fs, nil, nil, nil, &config.OCIConfiguration{
+		r := Must(factory.CreateRegistryAccess(ctx, fs, nil, nil, nil, &config.OCIConfiguration{
 			ConfigFiles: []string{"testdata/dockerconfig.json"},
 		}, nil)).(*RegistryAccess)
 		creds := Must(ociid.GetCredentials(r.octx, HOSTNAME1, "/test/repo"))
@@ -217,7 +217,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 			Data: map[string][]byte{corev1.DockerConfigJsonKey: dockerconfigdata},
 		}}
 		// Create a Registry Access and check whether credentials are properly set and can be found
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, secrets, nil, nil, nil)).(*RegistryAccess)
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, secrets, nil, nil, nil)).(*RegistryAccess)
 		creds := Must(ociid.GetCredentials(r.octx, HOSTNAME1, "/test/repo"))
 		props := creds.Properties()
 		Expect(props["username"]).To(Equal(USERNAME))
@@ -229,7 +229,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 		secrets := []corev1.Secret{{
 			Data: map[string][]byte{".ocmcredentialconfig": ociocmconfigdata},
 		}}
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, secrets, nil, nil, nil, nil)).(*RegistryAccess)
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, secrets, nil, nil, nil, nil)).(*RegistryAccess)
 		creds := Must(ociid.GetCredentials(r.octx, HOSTNAME1, "/test/repo"))
 		props := creds.Properties()
 		Expect(props["username"]).To(Equal(USERNAME))
@@ -240,7 +240,7 @@ var _ = Describe("ocm-lib facade implementation", func() {
 		ocmconfig := &corev1.ConfigMap{
 			Data: map[string]string{`.ocmconfig`: string(ociocmconfigdata)},
 		}
-		r := Must(factory.NewRegistryAccess(ctx, nil, ocmconfig, nil, nil, nil, nil)).(*RegistryAccess)
+		r := Must(factory.CreateRegistryAccess(ctx, nil, ocmconfig, nil, nil, nil, nil)).(*RegistryAccess)
 		creds := Must(ociid.GetCredentials(r.octx, HOSTNAME1, "/test/repo"))
 		props := creds.Properties()
 		Expect(props["username"]).To(Equal(USERNAME))
@@ -403,7 +403,7 @@ version: 1.0.0
 `
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(inlineComponentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil))
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
 		res := Must(cv.GetResource("blueprint", nil))
@@ -493,7 +493,7 @@ version: 1.0.0
 `
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(inlineComponentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil))
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
 		res := Must(cv.GetResource("blueprint", nil))
@@ -507,7 +507,7 @@ version: 1.0.0
 	It("ocm config is nil", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
@@ -527,7 +527,7 @@ configurations:
 		}
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
@@ -547,7 +547,7 @@ configurations:
 		}
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReferenceWithoutContext), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
@@ -567,7 +567,7 @@ configurations:
 		}
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReferenceWithWrongContext), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 
 		cv := Must(r.GetComponentVersion(ctx, cdref))
 		Expect(cv).NotTo(BeNil())
@@ -587,7 +587,7 @@ configurations:
 		}
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReferenceWithWrongContext), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: "./testdata/localcnudierepos/other"}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, ocmconfig, nil, &config.LocalRegistryConfiguration{RootPath: "./testdata/localcnudierepos/other"}, nil, nil, nil))
 
 		cv, err := r.GetComponentVersion(ctx, cdref)
 		Expect(cv).To(BeNil())
@@ -598,7 +598,7 @@ configurations:
 	It("repository context is not set and ocm config does not set resolvers", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReferenceWithoutContext), &cdref))
-		r := Must(factory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
+		r := Must(factory.CreateRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH}, nil, nil, nil))
 		cv, err := r.GetComponentVersion(ctx, cdref)
 		Expect(cv).To(BeNil())
 		Expect(err).ToNot(BeNil())

--- a/pkg/components/ocmlib/registryaccess.go
+++ b/pkg/components/ocmlib/registryaccess.go
@@ -10,24 +10,22 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	"github.com/gardener/landscaper/pkg/utils"
-
 	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
+	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/signing/handlers/rsa"
 	"github.com/open-component-model/ocm/pkg/signing/signutils"
 
-	"github.com/gardener/landscaper/pkg/components/model/types"
-
-	"github.com/open-component-model/ocm/pkg/contexts/ocm"
-	"github.com/open-component-model/ocm/pkg/runtime"
-
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/pkg/components/model"
+	"github.com/gardener/landscaper/pkg/components/model/componentoverwrites"
+	"github.com/gardener/landscaper/pkg/components/model/types"
 	_ "github.com/gardener/landscaper/pkg/components/ocmlib/repository/inline"
 	_ "github.com/gardener/landscaper/pkg/components/ocmlib/repository/local"
+	"github.com/gardener/landscaper/pkg/utils"
 )
 
 type RegistryAccess struct {
@@ -36,6 +34,7 @@ type RegistryAccess struct {
 	inlineSpec       ocm.RepositorySpec
 	inlineRepository ocm.Repository
 	resolver         ocm.ComponentVersionResolver
+	Overwriter       componentoverwrites.Overwriter
 }
 
 var _ model.RegistryAccess = (*RegistryAccess)(nil)

--- a/pkg/components/registries/registries_test.go
+++ b/pkg/components/registries/registries_test.go
@@ -42,7 +42,7 @@ var _ = Describe("cdutils Tests", func() {
 
 	It("should return each referenced component only once when resolving component references", func() {
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-		registryAccess, err = GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err = GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -591,7 +591,7 @@ func (c *Container) parseAndSyncSecrets(ctx context.Context, defaultLabels map[s
 			}
 		}
 
-		registryAccess, err := registries.GetFactory(c.Context.UseOCM).NewRegistryAccess(ctx, fs, ocmConfig, nil, nil, c.Configuration.OCI, c.ProviderConfiguration.ComponentDescriptor.Inline)
+		registryAccess, err := registries.GetFactory(c.Context.UseOCM).CreateRegistryAccess(ctx, fs, ocmConfig, nil, nil, c.Configuration.OCI, c.ProviderConfiguration.ComponentDescriptor.Inline)
 		if err != nil {
 			erro = fmt.Errorf("unable create registry reference to resolve component descriptor for ref %#v: %w", c.ProviderConfiguration.Blueprint.Reference, err)
 			return

--- a/pkg/deployer/container/init/init.go
+++ b/pkg/deployer/container/init/init.go
@@ -158,7 +158,7 @@ func run(ctx context.Context, opts *options, kubeClient client.Client, fs vfs.Fi
 			}
 		}
 
-		registryAccess, err = registries.GetFactory(opts.UseOCM).NewRegistryAccess(ctx, fs, ocmConfig, nil, nil,
+		registryAccess, err = registries.GetFactory(opts.UseOCM).CreateRegistryAccess(ctx, fs, ocmConfig, nil, nil,
 			ociconfig, providerConfig.ComponentDescriptor.Inline)
 		if err != nil {
 			return err

--- a/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
+++ b/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
@@ -322,7 +322,7 @@ var _ = Describe("GetChart", func() {
 			localCtx = localOctx.BindTo(localCtx)
 
 			// Setup Test
-			registry, err := registries.GetFactory(true).NewRegistryAccess(localCtx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(localCtx, nil, nil, nil,
 				&config.LocalRegistryConfiguration{RootPath: "./testdata/ocmrepo"}, nil, nil)
 			Expect(err).To(BeNil())
 

--- a/pkg/landscaper/controllers/installations/controller.go
+++ b/pkg/landscaper/controllers/installations/controller.go
@@ -357,7 +357,7 @@ func (c *Controller) initPrerequisites(ctx context.Context, inst *lsv1alpha1.Ins
 		return nil, lserrors.NewWrappedError(err, currOp, "CalculateContext", err.Error())
 	}
 
-	if err := c.SetupRegistries(ctx, op, lsCtx.External.Context, lsCtx.External.RegistryPullSecrets(), inst); err != nil {
+	if err := c.SetupRegistries(ctx, op, &lsCtx.External, inst); err != nil {
 		return nil, lserrors.NewWrappedError(err, currOp, "SetupRegistries", err.Error())
 	}
 

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -60,7 +60,7 @@ func (c *Controller) SetupRegistries(ctx context.Context, op *operation.Operatio
 	}
 
 	if registry == nil {
-		registry, err = registries.GetFactory(contextObj.UseOCM).NewRegistryAccess(ctx, nil, ocmConfig, secrets, c.LsConfig.Registry.Local, c.LsConfig.Registry.OCI, inlineCd)
+		registry, err = registries.GetFactory(contextObj.UseOCM).CreateRegistryAccess(ctx, nil, ocmConfig, secrets, c.LsConfig.Registry.Local, c.LsConfig.Registry.OCI, inlineCd)
 		if err != nil {
 			return err
 		}

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Context", func() {
 		fakeClient = testenv.Client
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		op = lsoperation.NewOperation(api.LandscaperScheme, record.NewFakeRecorder(1024), fakeClient).SetComponentsRegistry(registryAccess)

--- a/pkg/landscaper/installations/executions/executions_test.go
+++ b/pkg/landscaper/installations/executions/executions_test.go
@@ -74,7 +74,7 @@ var _ = Describe("DeployItemExecutions", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry/root"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil, localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil, localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/executions/operation_test.go
+++ b/pkg/landscaper/installations/executions/operation_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Execution Operation", func() {
 		testInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry/root"}
-		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err = registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/executions/template/template_test.go
+++ b/pkg/landscaper/installations/executions/template/template_test.go
@@ -364,7 +364,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "local","filePath": "./"}`))).To(Succeed())
-			registry, err := registries.GetFactory(useOCM).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(useOCM).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -427,7 +427,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "local","filePath": "./"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -483,7 +483,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "local","filePath": "./"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -539,7 +539,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -575,7 +575,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -611,7 +611,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -650,7 +650,7 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
+			registry, err := registries.GetFactory(true).CreateRegistryAccess(ctx, nil, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/exports/constructor_test.go
+++ b/pkg/landscaper/installations/exports/constructor_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Constructor", func() {
 		Expect(testutils.CreateExampleDefaultContext(ctx, fakeClient, "test1", "test2", "test3", "test4", "test5", "test6"))
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/imports/conditional_imports_test.go
+++ b/pkg/landscaper/installations/imports/conditional_imports_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ConditionalImports", func() {
 		createDefaultContextsForNamespace(fakeClient)
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Constructor", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/imports/importexec_test.go
+++ b/pkg/landscaper/installations/imports/importexec_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ImportExecutions", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/reconcilehelper/validation_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/validation_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Validation", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -136,7 +136,7 @@ var _ = Describe("SubInstallation", func() {
 		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8", "test9", "test10", "test11", "test12")).To(Succeed())
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/jsonschema/jsonschema_suite_test.go
+++ b/pkg/landscaper/jsonschema/jsonschema_suite_test.go
@@ -418,7 +418,7 @@ var _ = Describe("jsonschema", func() {
 			}
 
 			blobResolver := testutils2.NewLocalFilesystemBlobResolver(blobFs)
-			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, blobFs, nil, nil,
+			registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, blobFs, nil, nil,
 				&apiconfig.LocalRegistryConfiguration{RootPath: "./blobs"}, nil, cd, blobResolver)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -568,7 +568,7 @@ var _ = Describe("jsonschema", func() {
 `, strings.Split(testenv.Addr, ":")[0], strings.Split(testenv.Addr, ":")[1], testenv.BasicAuth.Username, testenv.BasicAuth.Password, testenv.Certificate.CA))
 			secrets := []corev1.Secret{{
 				Data: map[string][]byte{`.ocmcredentialconfig`: config}}}
-			registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, fs, nil, secrets, nil,
+			registryAccess, err = registries.GetFactory().CreateRegistryAccess(ctx, fs, nil, secrets, nil,
 				ociconfig, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -875,7 +875,7 @@ var _ = Describe("jsonschema", func() {
 			var err error
 
 			localregistryconfig := &apiconfig.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-			registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+			registryAccess, err = registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 				localregistryconfig, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -891,7 +891,7 @@ var _ = Describe("jsonschema", func() {
 		})
 
 		It("should resolve with explicit repository context", func() {
-			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+			registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 				localregistryconfig, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -910,7 +910,7 @@ var _ = Describe("jsonschema", func() {
 		})
 
 		It("should not resolve without explicit repository context", func() {
-			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+			registryAccess, err := registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 				localregistryconfig, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/landscaper/registry/components/cdutils/uri_test.go
+++ b/pkg/landscaper/registry/components/cdutils/uri_test.go
@@ -131,7 +131,7 @@ var _ = Describe("URI", func() {
 		_, err = file.Write(cd2data)
 		Expect(err).ToNot(HaveOccurred())
 
-		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, memFs, nil, nil,
+		registryAccess, err = registries.GetFactory().CreateRegistryAccess(ctx, memFs, nil, nil,
 			&config.LocalRegistryConfiguration{RootPath: "./"}, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/utils/landscaper/installation_simulator_test.go
+++ b/pkg/utils/landscaper/installation_simulator_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Installation Simulator", func() {
 		var err error
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: testDataDir}
-		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
+		registryAccess, err = registries.GetFactory().CreateRegistryAccess(ctx, nil, nil, nil,
 			localregistryconfig, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Extend RegistryAccess by repository contexts of installation and context resource.
- Extend RegistryAccess by component overwriter.
- Introduce an options object for the constructor of RegistryAccess.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Consolidate handling of repository contexts
```
