### PR TITLE
chore(ci): upgrade integration tests to go v1.22.4

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -15,7 +15,7 @@ landscaper:
         ocm_repository: landscaper
     steps:
       verify:
-        image: 'golang:1.22.2'
+        image: 'golang:1.22.4'
       ocm_build_and_publish:
         image: europe-docker.pkg.dev/gardener-project/releases/cicd/job-image:1.2360.0
         privilege_mode: privileged

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -43,7 +43,7 @@ landscaper:
           - integration-test
           depends:
           - ocm_build_and_publish
-          image: 'europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.2-alpine3.19'
+          image: 'europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.4-alpine3.19'
           output_dir: 'integration_test'
         format:
           publish_to:
@@ -56,7 +56,7 @@ landscaper:
         integration_test:
           depends:
           - ocm_build_and_publish
-          image: 'europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.2-alpine3.19'
+          image: 'europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.4-alpine3.19'
           execute:
           - integration-test-pr
       traits:
@@ -82,7 +82,7 @@ landscaper:
           - integration-test
           depends:
           - ocm_build_and_publish
-          image: 'europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.2-alpine3.19'
+          image: 'europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.4-alpine3.19'
           output_dir: 'integration_test'
         update_release:
           inputs:


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrading the integration test image to run tests with new go 1.22.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
