### PR TITLE
Make repository context in context resource optional

### DIFF
--- a/pkg/landscaper/blueprints/resolve.go
+++ b/pkg/landscaper/blueprints/resolve.go
@@ -141,9 +141,6 @@ func Resolve(
 	if cdRef == nil {
 		return nil, fmt.Errorf("no component descriptor reference defined")
 	}
-	if cdRef.RepositoryContext == nil {
-		return nil, fmt.Errorf("no respository context defined")
-	}
 	if registryAccess == nil {
 		return nil, fmt.Errorf("did not get a working component descriptor resolver")
 	}

--- a/pkg/landscaper/installations/context.go
+++ b/pkg/landscaper/installations/context.go
@@ -295,7 +295,7 @@ func GetExternalContext(ctx context.Context, kubeClient client.Client, inst *lsv
 	if cond != nil {
 		inst.Status.Conditions = lsv1alpha1helper.MergeConditions(inst.Status.Conditions, *cond)
 	}
-	if cdRef.RepositoryContext == nil {
+	if cdRef.RepositoryContext == nil && (lsCtx.OCMConfig == nil || len(lsCtx.OCMConfig.Name) == 0) {
 		return ExternalContext{}, MissingRepositoryContextError
 	}
 	lsCtx.RepositoryContext = cdRef.RepositoryContext


### PR DESCRIPTION
**What this PR does / why we need it**:

To process an Installation, a repository context is needed, which specifies in which OCM repos we search for component versions. It can be specified:
- in the Installation,
- in the referenced Context resource, or
- in the OCM config, that is referenced in the Context resource.

Even if repository contexts were specified in the OCM config, it was still required to specify an additional repository context in the Context resource. With this PR this is no longer required. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- It is no longer required to specify a repository context in a Context resource.
```
