### PR TITLE
Registry access options

### DIFF
--- a/pkg/components/blueprinthandler_test.go
+++ b/pkg/components/blueprinthandler_test.go
@@ -70,8 +70,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource("blueprint-dir", nil))
 
@@ -96,8 +97,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 
 		bptar := Must(compvers.GetResource("blueprint-tar", nil))
@@ -134,8 +136,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource("corrupted-blueprint", nil))
 
@@ -152,8 +155,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withBlueprintsComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource("corrupted-blueprint-tar", nil))
 

--- a/pkg/components/components_test.go
+++ b/pkg/components/components_test.go
@@ -158,8 +158,12 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), cdref))
 
-		oRaForCnudie := Must(ocmfactory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH_VALID}, nil, nil))
-		oRaForOcm := Must(ocmfactory.NewRegistryAccess(ctx, nil, nil, nil, &config.LocalRegistryConfiguration{RootPath: LOCALOCMREPOPATH_VALID}, nil, nil))
+		oRaForCnudie := Must(ocmfactory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: LOCALCNUDIEREPOPATH_VALID},
+		}))
+		oRaForOcm := Must(ocmfactory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: LOCALOCMREPOPATH_VALID},
+		}))
 
 		// the 3 registry accesses should all behave the same and the interface methods should return the same data
 		oRaForCnudieCv := Must(oRaForCnudie.GetComponentVersion(ctx, cdref))
@@ -239,8 +243,10 @@ var _ = Describe("facade implementation compatibility tests", func() {
 			Version:           "1.0.0",
 		}
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: "./"}, nil, inlineDescriptor))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: "./"},
+			InlineCd:            inlineDescriptor,
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		Expect(compvers.GetComponentDescriptor()).To(YAMLEqual(inlineDescriptor))
 	},
@@ -252,8 +258,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(referencedComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res, err := compvers.GetResource("non-existent-resource", nil)
 		Expect(err).To(HaveOccurred())
@@ -269,8 +276,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(referencedComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 		res := Must(compvers.GetResource(GENERIC_RESOURCE_NAME, nil))
 
@@ -289,8 +297,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withoutRepoctxComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).To(HaveOccurred())
 		Expect(compvers).To(BeNil())
@@ -303,8 +312,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withInvalidAccessTypeComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(compvers).ToNot(BeNil())
@@ -325,8 +335,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withInvalidReferenceComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(compvers).ToNot(BeNil())
@@ -352,8 +363,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(invalidComponentComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers, err := registryAccess.GetComponentVersion(ctx, cdref)
 		Expect(err).To(HaveOccurred())
 		Expect(compvers).To(BeNil())
@@ -365,7 +377,7 @@ var _ = Describe("facade implementation compatibility tests", func() {
 	// Check nil argument handling of facade methods
 	DescribeTable("prevent null pointer exceptions", func(factory model.Factory, registryRootPath string) {
 		// Test registry access
-		registryAccess, err := factory.NewRegistryAccess(ctx, nil, nil, nil, nil, nil, nil, nil)
+		registryAccess, err := factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{})
 		Expect(registryAccess).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
 
@@ -376,8 +388,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		// Organize a valid component version
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(componentReference), cdref))
-		registryAccess, err = factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil)
+		registryAccess, err = factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		})
 		Expect(registryAccess).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/components/jsonschemahandler_test.go
+++ b/pkg/components/jsonschemahandler_test.go
@@ -61,8 +61,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withJSONSchemasComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 
 		jsonschema := Must(compvers.GetResource("jsonschema", nil))
@@ -91,8 +92,9 @@ var _ = Describe("facade implementation compatibility tests", func() {
 		cdref := &v1alpha1.ComponentDescriptorReference{}
 		MustBeSuccessful(runtime.DefaultYAMLEncoding.Unmarshal([]byte(withJSONSchemasComponentReference), cdref))
 
-		registryAccess := Must(factory.NewRegistryAccess(ctx, nil, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: registryRootPath}, nil, nil))
+		registryAccess := Must(factory.NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: registryRootPath},
+		}))
 		compvers := Must(registryAccess.GetComponentVersion(ctx, cdref))
 
 		jsonschemaUnknown := Must(compvers.GetResource("jsonschema-unknown-mediatype", nil))

--- a/pkg/components/model/factory.go
+++ b/pkg/components/model/factory.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
-	"github.com/gardener/component-spec/bindings-go/ctf"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,6 +17,15 @@ import (
 	helmv1alpha1 "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1"
 	"github.com/gardener/landscaper/pkg/components/model/types"
 )
+
+type RegistryAccessOptions struct {
+	Fs                  vfs.FileSystem
+	OcmConfig           *corev1.ConfigMap
+	Secrets             []corev1.Secret
+	LocalRegistryConfig *config.LocalRegistryConfiguration
+	OciRegistryConfig   *config.OCIConfiguration
+	InlineCd            *types.ComponentDescriptor
+}
 
 type Factory interface {
 	// NewRegistryAccess provides an instance of a RegistryAccess, which is an interface for dealing with ocm
@@ -51,15 +59,7 @@ type Factory interface {
 	//
 	// [component-cli]: https://github.com/gardener/component-cli
 	// [ocmlib]: https://github.com/open-component-model/ocm
-	// TODO: rework this constructor method and replace essentially all parameters with an Option, so that this can easily be extended in the future
-	NewRegistryAccess(ctx context.Context,
-		fs vfs.FileSystem,
-		ocmconfig *corev1.ConfigMap,
-		secrets []corev1.Secret,
-		localRegistryConfig *config.LocalRegistryConfiguration,
-		ociRegistryConfig *config.OCIConfiguration,
-		inlineCd *types.ComponentDescriptor,
-		additionalBlobResolvers ...ctf.TypedBlobResolver) (RegistryAccess, error)
+	NewRegistryAccess(ctx context.Context, options *RegistryAccessOptions) (RegistryAccess, error)
 
 	// NewHelmRepoResource returns a helm chart resource that is stored in a helm chart repository.
 	NewHelmRepoResource(ctx context.Context,

--- a/pkg/components/registries/registries_test.go
+++ b/pkg/components/registries/registries_test.go
@@ -42,8 +42,9 @@ var _ = Describe("cdutils Tests", func() {
 
 	It("should return each referenced component only once when resolving component references", func() {
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-		registryAccess, err = GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err = GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(repositoryContext.UnmarshalJSON([]byte(`{"type":"local"}`))).To(Succeed())

--- a/pkg/deployer/container/container_reconcile.go
+++ b/pkg/deployer/container/container_reconcile.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dockerreference "github.com/containerd/containerd/reference/docker"
@@ -591,7 +593,12 @@ func (c *Container) parseAndSyncSecrets(ctx context.Context, defaultLabels map[s
 			}
 		}
 
-		registryAccess, err := registries.GetFactory(c.Context.UseOCM).NewRegistryAccess(ctx, fs, ocmConfig, nil, nil, c.Configuration.OCI, c.ProviderConfiguration.ComponentDescriptor.Inline)
+		registryAccess, err := registries.GetFactory(c.Context.UseOCM).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			Fs:                fs,
+			OcmConfig:         ocmConfig,
+			OciRegistryConfig: c.Configuration.OCI,
+			InlineCd:          c.ProviderConfiguration.ComponentDescriptor.Inline,
+		})
 		if err != nil {
 			erro = fmt.Errorf("unable create registry reference to resolve component descriptor for ref %#v: %w", c.ProviderConfiguration.Blueprint.Reference, err)
 			return

--- a/pkg/deployer/container/init/init.go
+++ b/pkg/deployer/container/init/init.go
@@ -158,8 +158,12 @@ func run(ctx context.Context, opts *options, kubeClient client.Client, fs vfs.Fi
 			}
 		}
 
-		registryAccess, err = registries.GetFactory(opts.UseOCM).NewRegistryAccess(ctx, fs, ocmConfig, nil, nil,
-			ociconfig, providerConfig.ComponentDescriptor.Inline)
+		registryAccess, err = registries.GetFactory(opts.UseOCM).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			Fs:                fs,
+			OcmConfig:         ocmConfig,
+			OciRegistryConfig: ociconfig,
+			InlineCd:          providerConfig.ComponentDescriptor.Inline,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
+++ b/pkg/deployer/helm/chartresolver/chartresolver_suite_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -322,8 +324,9 @@ var _ = Describe("GetChart", func() {
 			localCtx = localOctx.BindTo(localCtx)
 
 			// Setup Test
-			registry, err := registries.GetFactory(true).NewRegistryAccess(localCtx, nil, nil, nil,
-				&config.LocalRegistryConfiguration{RootPath: "./testdata/ocmrepo"}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(localCtx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: "./testdata/ocmrepo"},
+			})
 			Expect(err).To(BeNil())
 
 			cdref := &lsv1alpha1.ComponentDescriptorReference{}

--- a/pkg/landscaper/controllers/installations/registry.go
+++ b/pkg/landscaper/controllers/installations/registry.go
@@ -60,7 +60,13 @@ func (c *Controller) SetupRegistries(ctx context.Context, op *operation.Operatio
 	}
 
 	if registry == nil {
-		registry, err = registries.GetFactory(contextObj.UseOCM).NewRegistryAccess(ctx, nil, ocmConfig, secrets, c.LsConfig.Registry.Local, c.LsConfig.Registry.OCI, inlineCd)
+		registry, err = registries.GetFactory(contextObj.UseOCM).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			OcmConfig:           ocmConfig,
+			Secrets:             secrets,
+			LocalRegistryConfig: c.LsConfig.Registry.Local,
+			OciRegistryConfig:   c.LsConfig.Registry.OCI,
+			InlineCd:            inlineCd,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/landscaper/installations/context_test.go
+++ b/pkg/landscaper/installations/context_test.go
@@ -7,6 +7,8 @@ package installations_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	testutils2 "github.com/gardener/landscaper/pkg/components/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
@@ -60,8 +62,9 @@ var _ = Describe("Context", func() {
 		fakeClient = testenv.Client
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 		op = lsoperation.NewOperation(api.LandscaperScheme, record.NewFakeRecorder(1024), fakeClient).SetComponentsRegistry(registryAccess)
 	})

--- a/pkg/landscaper/installations/executions/executions_test.go
+++ b/pkg/landscaper/installations/executions/executions_test.go
@@ -7,6 +7,8 @@ package executions_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
@@ -74,7 +76,9 @@ var _ = Describe("DeployItemExecutions", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry/root"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil, localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/executions/operation_test.go
+++ b/pkg/landscaper/installations/executions/operation_test.go
@@ -57,8 +57,9 @@ var _ = Describe("Execution Operation", func() {
 		testInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry/root"}
-		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(repositoryContext.UnmarshalJSON([]byte(`{"type":"local"}`))).To(Succeed())

--- a/pkg/landscaper/installations/executions/template/template_test.go
+++ b/pkg/landscaper/installations/executions/template/template_test.go
@@ -364,8 +364,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "local","filePath": "./"}`))).To(Succeed())
-			registry, err := registries.GetFactory(useOCM).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
+			registry, err := registries.GetFactory(useOCM).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-" + schemaVersionSuffix, Version: "1.0.0"})
@@ -427,8 +428,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "local","filePath": "./"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v2-mixed", Version: "1.0.0"})
@@ -483,8 +485,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "local","filePath": "./"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "localocmrepository")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "example.com/landscaper-component-v3alpha1-mixed", Version: "1.0.0"})
@@ -539,8 +542,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "github.com/root", Version: "1.0.0"})
@@ -575,8 +579,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "github.com/root", Version: "1.0.0"})
@@ -611,8 +616,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "github.com/root", Version: "1.0.0"})
@@ -650,8 +656,9 @@ func runTestSuite(testdataDir, sharedTestdataDir string) {
 			// Preparation to conveniently be able to access the respective component versions
 			repositoryContext := &cdv2.UnstructuredTypedObject{}
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type": "CommonTransportFormat/v1","filePath": "testdata/shared_data/ctf-local-blobs", "fileFormat": "directory"}`))).To(Succeed())
-			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, nil, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")}, nil, nil)
+			registry, err := registries.GetFactory(true).NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: filepath.Join(sharedTestdataDir, "ctf-local-blobs")},
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			componentVersion, err := registry.GetComponentVersion(ctx, &lsv1alpha1.ComponentDescriptorReference{RepositoryContext: repositoryContext, ComponentName: "github.com/root", Version: "1.0.0"})

--- a/pkg/landscaper/installations/exports/constructor_test.go
+++ b/pkg/landscaper/installations/exports/constructor_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
@@ -62,8 +64,9 @@ var _ = Describe("Constructor", func() {
 		Expect(testutils.CreateExampleDefaultContext(ctx, fakeClient, "test1", "test2", "test3", "test4", "test5", "test6"))
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/imports/conditional_imports_test.go
+++ b/pkg/landscaper/installations/imports/conditional_imports_test.go
@@ -7,6 +7,8 @@ package imports_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
@@ -69,8 +71,9 @@ var _ = Describe("ConditionalImports", func() {
 		createDefaultContextsForNamespace(fakeClient)
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/imports/constructor_test.go
+++ b/pkg/landscaper/installations/imports/constructor_test.go
@@ -7,6 +7,8 @@ package imports_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
@@ -60,8 +62,9 @@ var _ = Describe("Constructor", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/imports/importexec_test.go
+++ b/pkg/landscaper/installations/imports/importexec_test.go
@@ -7,6 +7,8 @@ package imports_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
@@ -74,8 +76,9 @@ var _ = Describe("ImportExecutions", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/reconcilehelper/validation_test.go
+++ b/pkg/landscaper/installations/reconcilehelper/validation_test.go
@@ -7,6 +7,8 @@ package reconcilehelper_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 
@@ -57,8 +59,9 @@ var _ = Describe("Validation", func() {
 		fakeInstallations = state.Installations
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "../testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		operation, err := lsoperation.NewBuilder().WithLsUncachedClient(fakeClient).Scheme(api.LandscaperScheme).WithEventRecorder(record.NewFakeRecorder(1024)).ComponentRegistry(registryAccess).Build(ctx)

--- a/pkg/landscaper/installations/subinstallations/subinstallations_test.go
+++ b/pkg/landscaper/installations/subinstallations/subinstallations_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/gardener/landscaper/pkg/components/model"
+
 	"github.com/gardener/landscaper/pkg/components/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
@@ -136,8 +138,9 @@ var _ = Describe("SubInstallation", func() {
 		Expect(utils.CreateExampleDefaultContext(ctx, testenv.Client, "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8", "test9", "test10", "test11", "test12")).To(Succeed())
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		op, err = lsoperation.NewBuilder().

--- a/pkg/landscaper/jsonschema/jsonschema_suite_test.go
+++ b/pkg/landscaper/jsonschema/jsonschema_suite_test.go
@@ -417,9 +417,13 @@ var _ = Describe("jsonschema", func() {
 				},
 			}
 
-			blobResolver := testutils2.NewLocalFilesystemBlobResolver(blobFs)
-			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, blobFs, nil, nil,
-				&apiconfig.LocalRegistryConfiguration{RootPath: "./blobs"}, nil, cd, blobResolver)
+			//blobResolver := testutils2.NewLocalFilesystemBlobResolver(blobFs)
+			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				Fs:                  blobFs,
+				LocalRegistryConfig: &apiconfig.LocalRegistryConfiguration{RootPath: "./blobs"},
+				InlineCd:            cd,
+				// AdditionalBlocResolvers: blobResolver
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			// read component from registry
@@ -568,8 +572,11 @@ var _ = Describe("jsonschema", func() {
 `, strings.Split(testenv.Addr, ":")[0], strings.Split(testenv.Addr, ":")[1], testenv.BasicAuth.Username, testenv.BasicAuth.Password, testenv.Certificate.CA))
 			secrets := []corev1.Secret{{
 				Data: map[string][]byte{`.ocmcredentialconfig`: config}}}
-			registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, fs, nil, secrets, nil,
-				ociconfig, nil)
+			registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				Fs:                fs,
+				Secrets:           secrets,
+				OciRegistryConfig: ociconfig,
+			})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -875,8 +882,9 @@ var _ = Describe("jsonschema", func() {
 			var err error
 
 			localregistryconfig = &apiconfig.LocalRegistryConfiguration{RootPath: "./testdata/registry"}
-			registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-				localregistryconfig, nil, nil)
+			registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: localregistryconfig,
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(repositoryContext.UnmarshalJSON([]byte(`{"type":"local"}`))).To(Succeed())
@@ -891,8 +899,9 @@ var _ = Describe("jsonschema", func() {
 		})
 
 		It("should resolve with explicit repository context", func() {
-			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-				localregistryconfig, nil, nil)
+			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: localregistryconfig,
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			referenceResolver := jsonschema.NewReferenceResolver(&jsonschema.ReferenceContext{
@@ -910,8 +919,9 @@ var _ = Describe("jsonschema", func() {
 		})
 
 		It("should not resolve without explicit repository context", func() {
-			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-				localregistryconfig, nil, nil)
+			registryAccess, err := registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+				LocalRegistryConfig: localregistryconfig,
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			referenceResolver := jsonschema.NewReferenceResolver(&jsonschema.ReferenceContext{

--- a/pkg/landscaper/registry/components/cdutils/uri_test.go
+++ b/pkg/landscaper/registry/components/cdutils/uri_test.go
@@ -131,8 +131,10 @@ var _ = Describe("URI", func() {
 		_, err = file.Write(cd2data)
 		Expect(err).ToNot(HaveOccurred())
 
-		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, memFs, nil, nil,
-			&config.LocalRegistryConfiguration{RootPath: "./"}, nil, nil)
+		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			Fs:                  memFs,
+			LocalRegistryConfig: &config.LocalRegistryConfiguration{RootPath: "./"},
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		repositorySpec = &cdv2.UnstructuredTypedObject{}

--- a/pkg/utils/landscaper/installation_simulator_test.go
+++ b/pkg/utils/landscaper/installation_simulator_test.go
@@ -94,8 +94,9 @@ var _ = Describe("Installation Simulator", func() {
 		var err error
 
 		localregistryconfig := &config.LocalRegistryConfiguration{RootPath: testDataDir}
-		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, nil, nil, nil,
-			localregistryconfig, nil, nil)
+		registryAccess, err = registries.GetFactory().NewRegistryAccess(ctx, &model.RegistryAccessOptions{
+			LocalRegistryConfig: localregistryconfig,
+		})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(repositoryContext.UnmarshalJSON([]byte(`{"type":"local"}`))).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR only refactors method `NewRegistryAccess` of the ocm facade. It introduces an options object to simplify future refactoring.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
- Refactoring: options object for method NewRegistryAccess.
```
