### PR TITLE
Additional targets

### DIFF
--- a/apis/deployer/utils/managedresource/types.go
+++ b/apis/deployer/utils/managedresource/types.go
@@ -43,6 +43,12 @@ type Manifest struct {
 	// AnnotateBeforeDelete defines annotations that are being set before the manifest is being deleted.
 	// +optional
 	AnnotateBeforeDelete map[string]string `json:"annotateBeforeDelete,omitempty"`
+	// PatchAfterDeployment defines a patch that is being applied after an object has been deployed.
+	// +optional
+	PatchAfterDeployment *runtime.RawExtension `json:"patchAfterDeployment,omitempty"`
+	// PatchBeforeDelete defines a patch that is being applied before an object is being deleted.
+	// +optional
+	PatchBeforeDelete *runtime.RawExtension `json:"patchBeforeDelete,omitempty"`
 }
 
 // ManagedResourceStatusList describes a list of managed resource statuses.
@@ -78,6 +84,9 @@ type ManagedResourceStatus struct {
 	// AnnotateBeforeDelete defines annotations that are being set before the manifest is being deleted.
 	// +optional
 	AnnotateBeforeDelete map[string]string `json:"annotateBeforeDelete,omitempty"`
+	// PatchBeforeDelete defines a patch that is being applied before an object is being deleted.
+	// +optional
+	PatchBeforeDelete *runtime.RawExtension `json:"patchBeforeDelete,omitempty"`
 	// Policy defines the manage policy for that resource.
 	Policy ManifestPolicy `json:"policy,omitempty"`
 	// Resources describes the managed kubernetes resource.
@@ -104,6 +113,12 @@ type Export struct {
 	// FromObjectReference describes that the jsonpath points to a object reference where the actual value is read from.
 	// This is helpful if for example a deployed resource referenced a secret and that exported value is in that secret.
 	FromObjectReference *FromObjectReference `json:"fromObjectRef,omitempty"`
+
+	// TargetName specifies the target from which the objects for the export are read.
+	// The value typically comes from a target import parameter, for example: {{.imports.myCluster.metadata.name}}.
+	// TargetName is optional; the default is the target specified in the deployitem.
+	// +optional
+	TargetName *string `json:"targetName,omitempty"`
 }
 
 // FromObjectReference describes that the jsonpath points to a object reference where the actual value is read from.

--- a/apis/deployer/utils/managedresource/types_deletiongroup.go
+++ b/apis/deployer/utils/managedresource/types_deletiongroup.go
@@ -40,6 +40,9 @@ type CustomResourceGroup struct {
 
 	// +optional
 	DeleteAllResources bool `json:"deleteAllResources,omitempty"`
+
+	// +optional
+	TargetName *string `json:"targetName,omitempty"`
 }
 
 type ResourceType struct {

--- a/apis/deployer/utils/managedresource/zz_generated.deepcopy.go
+++ b/apis/deployer/utils/managedresource/zz_generated.deepcopy.go
@@ -24,6 +24,11 @@ func (in *CustomResourceGroup) DeepCopyInto(out *CustomResourceGroup) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TargetName != nil {
+		in, out := &in.TargetName, &out.TargetName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -74,6 +79,11 @@ func (in *Export) DeepCopyInto(out *Export) {
 	if in.FromObjectReference != nil {
 		in, out := &in.FromObjectReference, &out.FromObjectReference
 		*out = new(FromObjectReference)
+		**out = **in
+	}
+	if in.TargetName != nil {
+		in, out := &in.TargetName, &out.TargetName
+		*out = new(string)
 		**out = **in
 	}
 	return
@@ -138,6 +148,11 @@ func (in *ManagedResourceStatus) DeepCopyInto(out *ManagedResourceStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.PatchBeforeDelete != nil {
+		in, out := &in.PatchBeforeDelete, &out.PatchBeforeDelete
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	out.Resource = in.Resource
 	return
 }
@@ -195,6 +210,16 @@ func (in *Manifest) DeepCopyInto(out *Manifest) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.PatchAfterDeployment != nil {
+		in, out := &in.PatchAfterDeployment, &out.PatchAfterDeployment
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PatchBeforeDelete != nil {
+		in, out := &in.PatchBeforeDelete, &out.PatchBeforeDelete
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/apis/deployer/utils/readinesschecks/types_healthchecks.go
+++ b/apis/deployer/utils/readinesschecks/types_healthchecks.go
@@ -36,6 +36,11 @@ type CustomReadinessCheckConfiguration struct {
 	LabelSelector *LabelSelectorSpec `json:"labelSelector,omitempty"`
 	// Requirements is the actual readiness check which compares an object's property to a value
 	Requirements []RequirementSpec `json:"requirements"`
+	// TargetName specifies the target from which the objects for the readiness check are read.
+	// The value typically comes from a target import parameter, for example: {{.imports.myCluster.metadata.name}}.
+	// TargetName is optional; the default is the target specified in the deployitem.
+	// +optional
+	TargetName *string `json:"targetName,omitempty"`
 }
 
 // LabelSelectorSpec contains paramters used to select objects by their labels

--- a/apis/deployer/utils/readinesschecks/zz_generated.deepcopy.go
+++ b/apis/deployer/utils/readinesschecks/zz_generated.deepcopy.go
@@ -34,6 +34,11 @@ func (in *CustomReadinessCheckConfiguration) DeepCopyInto(out *CustomReadinessCh
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TargetName != nil {
+		in, out := &in.TargetName, &out.TargetName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/apis/openapi/zz_generated.openapi.go
+++ b/apis/openapi/zz_generated.openapi.go
@@ -15560,6 +15560,12 @@ func schema_apis_deployer_utils_managedresource_CustomResourceGroup(ref common.R
 							Format: "",
 						},
 					},
+					"targetName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -15625,6 +15631,13 @@ func schema_apis_deployer_utils_managedresource_Export(ref common.ReferenceCallb
 						SchemaProps: spec.SchemaProps{
 							Description: "FromObjectReference describes that the jsonpath points to a object reference where the actual value is read from. This is helpful if for example a deployed resource referenced a secret and that exported value is in that secret.",
 							Ref:         ref("github.com/gardener/landscaper/apis/deployer/utils/managedresource.FromObjectReference"),
+						},
+					},
+					"targetName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetName specifies the target from which the objects for the export are read. The value typically comes from a target import parameter, for example: {{.imports.myCluster.metadata.name}}. TargetName is optional; the default is the target specified in the deployitem.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -15725,6 +15738,12 @@ func schema_apis_deployer_utils_managedresource_ManagedResourceStatus(ref common
 							},
 						},
 					},
+					"patchBeforeDelete": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PatchBeforeDelete defines a patch that is being applied before an object is being deleted.",
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+						},
+					},
 					"policy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Policy defines the manage policy for that resource.",
@@ -15744,7 +15763,7 @@ func schema_apis_deployer_utils_managedresource_ManagedResourceStatus(ref common
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ObjectReference"},
+			"k8s.io/api/core/v1.ObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 
@@ -15798,6 +15817,18 @@ func schema_apis_deployer_utils_managedresource_Manifest(ref common.ReferenceCal
 									},
 								},
 							},
+						},
+					},
+					"patchAfterDeployment": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PatchAfterDeployment defines a patch that is being applied after an object has been deployed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+						},
+					},
+					"patchBeforeDelete": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PatchBeforeDelete defines a patch that is being applied before an object is being deleted.",
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
 				},
@@ -15938,6 +15969,13 @@ func schema_apis_deployer_utils_readinesschecks_CustomReadinessCheckConfiguratio
 									},
 								},
 							},
+						},
+					},
+					"targetName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetName specifies the target from which the objects for the readiness check are read. The value typically comes from a target import parameter, for example: {{.imports.myCluster.metadata.name}}. TargetName is optional; the default is the target specified in the deployitem.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/docs/deployer/healthchecks.md
+++ b/docs/deployer/healthchecks.md
@@ -66,6 +66,8 @@ readinessChecks:
       - value: 1
       - value: 2
       - value: 3
+    # alternative cluster to get the resource values
+    targetName: someOtherTargetName
 ```
 
 ## Default readiness checks
@@ -104,3 +106,8 @@ A field that is specified by its `jsonPath` will be extracted from each of the s
 - `notIn`: the given field mut _not_ match _to any_ of the given values
 
 Allowed values are given as a list of key-value pairs with the key always being `value` and the value being a valid desired value. Values can be either primitives like ints, strings or bools as well as complex types.
+
+If some values of k8s resources are checked, the default target of a DeployItem determines the cluster
+from where these values are fetched. You can specify another `targetName`, which is used to get these values 
+from a different cluster. This is helpful if your DeployItem deploys something to some cluster which itself
+deploys some stuff to a second cluster and your check requires to access the resources on this second cluster.

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -111,6 +111,8 @@ spec:
           - value: 1
           - value: 2
           - value: 3
+        # alternative cluster to get the resource values
+        targetName: someOtherTargetName
 
     # Name of the release: helm install [name]
     name: my-release
@@ -158,6 +160,38 @@ The value is taken from a rendered resource and a jsonpath to the value.
 For a complete documentation of the available jsonPath see here (https://kubernetes.io/docs/reference/kubectl/jsonpath/).
 
 :warning: Only unique identifiable resources (_apiVersion_, _kind_, _name_ and _namespace_).
+
+If some values of k8s resources are exported, the default target of a DeployItem determines the cluster
+from where these values are fetched. You can specify another `targetName`, which is used to get these values
+from a different cluster. This is helpful if your DeployItem deploys something to some cluster which itself
+deploys some stuff to a second cluster and your check requires to access the resources on this second cluster.
+
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: myDeployItemName
+spec:
+  ...
+  
+  target: 
+    import: my-cluster
+
+  config:
+    ...
+    
+    exports:
+      exports:
+      - key: someKey
+        jsonPath: .data.somekey 
+        fromResource: 
+          apiVersion: someVersion
+          kind: someKind
+          name: someName
+          namespace: someNamespace
+        # optional: other target cluster to fetch the export data  
+        targetName: otherTargetName
+```
 
 ## Manifest-Only Deployment
 

--- a/docs/deployer/manifest.md
+++ b/docs/deployer/manifest.md
@@ -86,6 +86,8 @@ spec:
           - value: 1
           - value: 2
           - value: 3
+        # alternative cluster to get the resource values
+        targetName: someOtherTargetName
 
     manifests: # list of kubernetes manifests
     - policy: manage | fallback | ignore | keep | immutable
@@ -98,6 +100,18 @@ spec:
       annotateBeforeDelete:
         annotationA: valueA
         annotationB: valueB
+      # Optional: The specified yaml is merged into the manifest and the manifest is updated. This is executed after 
+      # all manifests of the DeployItem were deployed
+      patchAfterDeployment:
+        # example
+        spec:
+          suspend: true
+      # Optional: The specified yaml is merged into the manifest and the manifest is updated. This is executed before
+      # the manifest is deleted.
+      patchBeforeDelete:
+        # example
+        spec:
+          suspend: false
       # the manifest specification
       manifest:
         apiVersion: v1
@@ -139,6 +153,38 @@ spec:
     deletionGroups: []
     # Optional. Allows to customize the deletion behaviour during an update.
     deletionGroupsDuringUpdate: []
+```
+
+If some values of k8s resources are exported, the default target of a DeployItem determines the cluster
+from where these values are fetched. You can specify another `targetName`, which is used to get these values
+from a different cluster. This is helpful if your DeployItem deploys something to some cluster which itself
+deploys some stuff to a second cluster and your check requires to access the resources on this second cluster.
+
+```yaml
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: DeployItem
+metadata:
+  name: myDeployItemName
+spec:
+  ...
+  
+  target: 
+    import: my-cluster
+
+  config:
+    ...
+    
+    exports:
+      exports:
+      - key: someKey
+        jsonPath: .data.somekey 
+        fromResource: 
+          apiVersion: someVersion
+          kind: someKind
+          name: someName
+          namespace: someNamespace
+        # optional: other target cluster to fetch the export data  
+        targetName: otherTargetName
 ```
 
 ### Update Strategy

--- a/docs/deployer/manifest_deletion.md
+++ b/docs/deployer/manifest_deletion.md
@@ -249,6 +249,23 @@ deletionGroups:
       type: crds
 ```
 
+### Deleting resources from a second cluster
+
+By default, the resources are deleted from the cluster specified in the target of the DeployItem.
+You can specify another `targetName`, which is used to determine a different cluster from where the resources are
+removed. This is helpful if your DeployItem deploys something to some cluster which itself
+deploys some stuff to a second cluster, and you must clean up the resources on this second cluster.
+This additional setting is only allowed in combination with `deleteAllResources: true`.
+
+```yaml
+deletionGroups:
+  - customResourceGroup:
+      resources:
+        - apiVersion: v1
+          kind: mycustomresource
+      deleteAllResources: true
+      targetName: someOtherTarget # optional different target
+
 ## Deletion Behaviour During Update
 
 During an update of a DeployItem, resources which belonged to the old version, but no longer to the new version,
@@ -299,6 +316,7 @@ deletionGroups:
             - namespace2
       forceDelete: (true | false)
       deleteAllResources: (true | false)
+      targetName: ... (optional)
 ```
 
 #### Deletion groups

--- a/docs/guided-tour/kustomize/02-podinfo/README.md
+++ b/docs/guided-tour/kustomize/02-podinfo/README.md
@@ -45,7 +45,7 @@ shown in the second row.
         type: gitHub
         repoUrl: https://github.com/stefanprodan/podinfo
         commit: 0b1481aa8ed0a6c34af84f779824a74200d5c1d6  # required
-        ref: 6.7.0                                        # optional
+        ref: 6.7.0
     ```
 
   The [template for the deploy item](blueprint/deploy-execution.yaml) takes them from there:

--- a/docs/guided-tour/kustomize/03-dataflow/blueprints/gitrepository/deploy-execution.yaml
+++ b/docs/guided-tour/kustomize/03-dataflow/blueprints/gitrepository/deploy-execution.yaml
@@ -24,7 +24,7 @@ deployItems:
               {{- $res := getResource .cd "name" "landscaper-gitrepo" }}
               url: {{ $res.access.repoUrl }}
               ref:
-                tag: {{ $res.access.ref }}
+                commit: {{ $res.access.commit }}
               path: ./docs/guided-tour/kustomize/03-dataflow/resources
               interval: 876000h
               timeout: 60s

--- a/docs/guided-tour/kustomize/03-dataflow/commands/component-constructor.yaml
+++ b/docs/guided-tour/kustomize/03-dataflow/commands/component-constructor.yaml
@@ -45,4 +45,4 @@ components:
         access:
           type: gitHub
           repoUrl: https://github.com/gardener/landscaper
-          commit: 4e7052d9739e7f122eecf346b0f0729d0dae50d1
+          commit: 2d9a02e1e3d0d36cbfedb28975dde8f4d6fdbb11

--- a/docs/proposals/helm-manifest-deployer-ordering.md
+++ b/docs/proposals/helm-manifest-deployer-ordering.md
@@ -237,6 +237,23 @@ deletionGroups:
       type: crds
 ```
 
+### Deleting resources from a second cluster
+
+By default, the resources are deleted from the cluster specified in the target of the DeployItem.
+You can specify another `targetName`, which is used to determine a different cluster from where the resources are
+removed. This is helpful if your DeployItem deploys something to some cluster which itself
+deploys some stuff to a second cluster, and you must clean up the resources on this second cluster.
+This additional setting is only allowed in combination with `deleteAllResources: true`.
+
+```yaml
+deletionGroups:
+  - customResourceGroup:
+      resources:
+        - apiVersion: v1
+          kind: mycustomresource
+      deleteAllResources: true
+      targetName: someOtherTarget # optional different target
+
 ### General Structure of deletion groups
 
 The general syntax of deletion groups is:
@@ -252,6 +269,7 @@ deletionGroups:
           kind:       ...
       deleteAllResources: (true | false)
       force-delete: (true | false)
+      targetName: ... (optional)
 ```
 
 #### Deletion groups

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -218,7 +218,7 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 		return restConfig, kubeClient, clientset, nil
 	}
 	if h.Target != nil {
-		restConfig, kubeClient, clientset, err := lib.GetClientMud(ctx, h.Target, h.lsUncachedClient)
+		restConfig, kubeClient, clientset, err := lib.GetRestConfigAndClientAndClientSet(ctx, h.Target, h.lsUncachedClient)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -8,12 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"strings"
-
-	"github.com/gardener/landscaper/apis/core/v1alpha1/helper"
-
-	"k8s.io/utils/ptr"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -23,10 +18,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
+	"github.com/gardener/landscaper/apis/core/v1alpha1/helper"
 	helminstall "github.com/gardener/landscaper/apis/deployer/helm/install"
 	helmv1alpha1 "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1"
 	helmv1alpha1validation "github.com/gardener/landscaper/apis/deployer/helm/v1alpha1/validation"
@@ -222,30 +218,7 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 		return restConfig, kubeClient, clientset, nil
 	}
 	if h.Target != nil {
-		targetConfig := &targettypes.KubernetesClusterTargetConfig{}
-		if err := yaml.Unmarshal([]byte(h.Target.Content), targetConfig); err != nil {
-			return nil, nil, nil, fmt.Errorf("unable to parse target confíguration: %w", err)
-		}
-
-		kubeconfigBytes, err := lib.GetKubeconfigFromTargetConfig(ctx, targetConfig, h.Target.Namespace, h.lsUncachedClient)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		kubeconfig, err := clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		restConfig, err := kubeconfig.ClientConfig()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		kubeClient, err := client.New(restConfig, client.Options{})
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		clientset, err := kubernetes.NewForConfig(restConfig)
+		restConfig, kubeClient, clientset, err := lib.GetClientMud(ctx, h.Target, h.lsUncachedClient)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -253,6 +226,7 @@ func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, k
 		h.TargetRestConfig = restConfig
 		h.TargetKubeClient = kubeClient
 		h.TargetClientSet = clientset
+
 		return restConfig, kubeClient, clientset, nil
 	}
 	return nil, nil, nil, errors.New("neither a target nor kubeconfig are defined")

--- a/pkg/deployer/lib/manifest_expansion.go
+++ b/pkg/deployer/lib/manifest_expansion.go
@@ -26,6 +26,8 @@ func ExpandManagedResourceManifests(origManifests []managedresource.Manifest) ([
 				Manifest:             rawExtensions[k],
 				AnnotateBeforeCreate: origManifest.AnnotateBeforeCreate,
 				AnnotateBeforeDelete: origManifest.AnnotateBeforeDelete,
+				PatchAfterDeployment: origManifest.PatchAfterDeployment,
+				PatchBeforeDelete:    origManifest.PatchBeforeDelete,
 			})
 		}
 	}

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -48,7 +48,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady(ctx context.Context) error {
 		return nil
 	}
 
-	targetClient, err := lib.GetTargetClient(ctx, c.Client, c.LsClient, c.DeployItem.Namespace, c.Configuration.TargetName)
+	targetClient, err := lib.GetTargetClient(ctx, c.Client, c.LsClient, c.DeployItem, c.Configuration.TargetName)
 	if err != nil {
 		return err
 	}

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck.go
@@ -23,7 +23,6 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	health "github.com/gardener/landscaper/apis/deployer/utils/readinesschecks"
 	lserror "github.com/gardener/landscaper/apis/errors"
-	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
 	"github.com/gardener/landscaper/pkg/deployer/lib"
 	"github.com/gardener/landscaper/pkg/deployer/lib/interruption"
 	"github.com/gardener/landscaper/pkg/utils"
@@ -49,36 +48,15 @@ func (c *CustomReadinessCheck) CheckResourcesReady(ctx context.Context) error {
 		return nil
 	}
 
-	// Determine the client to read the resources for this readiness check. By default, it is the target client.
-	cl := c.Client
-	if c.Configuration.TargetName != nil {
-		target := &lsv1alpha1.Target{}
-		targetKey := client.ObjectKey{
-			Name:      *c.Configuration.TargetName,
-			Namespace: c.DeployItem.Namespace,
-		}
-		err := read_write_layer.GetTarget(ctx, c.LsClient, targetKey, target, read_write_layer.R000005)
-		if err != nil {
-			return err
-		}
-
-		resolvedTarget, err := targetresolver.Resolve(ctx, target, c.LsClient)
-		if err != nil {
-			return err
-		}
-
-		_, kubeClient, _, err := lib.GetClientMud(ctx, resolvedTarget, c.LsClient)
-		if err != nil {
-			return err
-		}
-
-		cl = kubeClient
+	targetClient, err := lib.GetTargetClient(ctx, c.Client, c.LsClient, c.DeployItem.Namespace, c.Configuration.TargetName)
+	if err != nil {
+		return err
 	}
 
 	var objects []*unstructured.Unstructured
 	getObjectsFunc := func() ([]*unstructured.Unstructured, error) {
 		if c.Configuration.Resource != nil {
-			o, err := getObjectsByTypedReference(ctx, cl, c.Configuration.Resource)
+			o, err := getObjectsByTypedReference(ctx, targetClient, c.Configuration.Resource)
 			if err != nil {
 				return nil, err
 			}
@@ -86,7 +64,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady(ctx context.Context) error {
 		}
 
 		if c.Configuration.LabelSelector != nil {
-			o, err := getObjectsByLabels(ctx, cl, c.Configuration.LabelSelector)
+			o, err := getObjectsByLabels(ctx, targetClient, c.Configuration.LabelSelector)
 			if err != nil {
 				return nil, err
 			}
@@ -97,7 +75,7 @@ func (c *CustomReadinessCheck) CheckResourcesReady(ctx context.Context) error {
 	}
 
 	timeout := c.Timeout.Duration
-	if err := WaitForObjectsReady(ctx, timeout, cl, getObjectsFunc, c.CheckObject, c.InterruptionChecker, c.CurrentOp); err != nil {
+	if err := WaitForObjectsReady(ctx, timeout, targetClient, getObjectsFunc, c.CheckObject, c.InterruptionChecker, c.CurrentOp); err != nil {
 		return err
 	}
 

--- a/pkg/deployer/lib/readinesscheck/customreadinesscheck_test.go
+++ b/pkg/deployer/lib/readinesscheck/customreadinesscheck_test.go
@@ -35,7 +35,6 @@ var _ = Describe("Custom health checks", func() {
 
 	BeforeEach(func() {
 		customHealthCheck = CustomReadinessCheck{
-			Context:             logging.NewContext(ctx, logging.Discard()),
 			Client:              testenv.Client,
 			CurrentOp:           "custom health check test",
 			Timeout:             &lsv1alpha1.Duration{Duration: 180 * time.Second},
@@ -275,22 +274,22 @@ var _ = Describe("Custom health checks", func() {
 		go func() {
 			defer GinkgoRecover()
 			cm := &corev1.ConfigMap{}
-			Expect(state.Client.Get(customHealthCheck.Context,
+			Expect(state.Client.Get(ctx,
 				types.NamespacedName{
 					Name:      customHealthCheck.ManagedResources[0].Name,
 					Namespace: state.Namespace}, cm)).To(Succeed())
 
 			time.Sleep(1 * time.Second)
 			cm.Data["readyOne"] = "created"
-			Expect(state.Client.Update(customHealthCheck.Context, cm)).To(Succeed())
+			Expect(state.Client.Update(ctx, cm)).To(Succeed())
 
 			time.Sleep(1 * time.Second)
 			cm.Data["readyTwo"] = "No"
-			Expect(state.Client.Update(customHealthCheck.Context, cm)).To(Succeed())
+			Expect(state.Client.Update(ctx, cm)).To(Succeed())
 
 			time.Sleep(1 * time.Second)
 			cm.Data["readyTwo"] = "Yes"
-			Expect(state.Client.Update(customHealthCheck.Context, cm)).To(Succeed())
+			Expect(state.Client.Update(ctx, cm)).To(Succeed())
 		}()
 
 		Eventually(func() bool {
@@ -301,7 +300,7 @@ var _ = Describe("Custom health checks", func() {
 					"kind":       "ConfigMap",
 				},
 			}
-			Expect(state.Client.Get(customHealthCheck.Context,
+			Expect(state.Client.Get(ctx,
 				types.NamespacedName{
 					Name:      customHealthCheck.ManagedResources[0].Name,
 					Namespace: state.Namespace}, cm)).To(Succeed())
@@ -379,7 +378,7 @@ var _ = Describe("Custom health checks", func() {
 		}()
 
 		Eventually(func() bool {
-			return customHealthCheck.CheckResourcesReady() == nil
+			return customHealthCheck.CheckResourcesReady(ctx) == nil
 		}).WithTimeout(1 * time.Minute).Should(BeTrue())
 
 	})

--- a/pkg/deployer/lib/readinesscheck/readiness_suite_test.go
+++ b/pkg/deployer/lib/readinesscheck/readiness_suite_test.go
@@ -18,6 +18,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	"github.com/gardener/landscaper/test/utils/envtest"
 )
 
@@ -38,7 +39,7 @@ var (
 
 var _ = BeforeSuite(func() {
 	var err error
-	ctx = context.Background()
+	ctx = logging.NewContext(context.Background(), logging.Discard())
 
 	testenv, err = envtest.New(projectRoot)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/deployer/lib/resourcemanager/deletiongroup.go
+++ b/pkg/deployer/lib/resourcemanager/deletiongroup.go
@@ -7,16 +7,14 @@ import (
 	"slices"
 	"time"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
-	"github.com/gardener/landscaper/pkg/deployer/lib"
-	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/landscaper/pkg/deployer/lib"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/deployer/utils/managedresource"
@@ -43,7 +41,7 @@ func NewDeletionGroup(
 	lsUncachedClient client.Client,
 	definition managedresource.DeletionGroupDefinition,
 	deployItem *lsv1alpha1.DeployItem,
-	targetClient client.Client,
+	primaryTargetClient client.Client,
 	interruptionChecker interruption.InterruptionChecker,
 ) (group *DeletionGroup, err error) {
 	if definition.IsPredefined() && definition.IsCustom() {
@@ -53,41 +51,26 @@ func NewDeletionGroup(
 		return nil, fmt.Errorf("invalid deletion group: either predefinedResourceGroup or customResourceGroup must be set")
 	}
 
-	isCustomWithDifferentTarget := definition.IsCustom() && definition.CustomResourceGroup.TargetName != nil
-	if isCustomWithDifferentTarget && !definition.CustomResourceGroup.DeleteAllResources {
+	hasSecondaryTarget := definition.IsCustom() && definition.CustomResourceGroup.TargetName != nil
+	if hasSecondaryTarget && !definition.CustomResourceGroup.DeleteAllResources {
+		// Resources on a secondary target cluster were not deployed by the Landscaper (assuming that primary and secondary cluster are different).
+		// Therefore, a deletion group with secondary target makes only sense in combination with DeleteAllResources.
 		return nil, fmt.Errorf("invalid deletion group: customResourceGroup.DeleteAllResources must be true if TargetName is set")
 	}
 
-	cl := targetClient
-	if isCustomWithDifferentTarget {
-		target := &lsv1alpha1.Target{}
-		targetKey := client.ObjectKey{
-			Name:      *definition.CustomResourceGroup.TargetName,
-			Namespace: deployItem.Namespace,
-		}
-		err := read_write_layer.GetTarget(ctx, lsUncachedClient, targetKey, target, read_write_layer.R000007)
+	targetClient := primaryTargetClient
+	if hasSecondaryTarget {
+		targetClient, err = lib.GetTargetClient(ctx, primaryTargetClient, lsUncachedClient, deployItem.Namespace, definition.CustomResourceGroup.TargetName)
 		if err != nil {
 			return nil, err
 		}
-
-		resolvedTarget, err := targetresolver.Resolve(ctx, target, lsUncachedClient)
-		if err != nil {
-			return nil, err
-		}
-
-		_, kubeClient, _, err := lib.GetClientMud(ctx, resolvedTarget, lsUncachedClient)
-		if err != nil {
-			return nil, err
-		}
-
-		cl = kubeClient
 	}
 
 	group = &DeletionGroup{
 		definition:          definition,
 		managedResources:    []*managedresource.ManagedResourceStatus{},
 		deployItem:          deployItem,
-		targetClient:        cl,
+		targetClient:        targetClient,
 		interruptionChecker: interruptionChecker,
 	}
 
@@ -97,7 +80,7 @@ func NewDeletionGroup(
 			return nil, err
 		}
 	} else if definition.IsCustom() {
-		group.matcher = newCustomMatcher(definition.CustomResourceGroup, isCustomWithDifferentTarget)
+		group.matcher = newCustomMatcher(definition.CustomResourceGroup, hasSecondaryTarget)
 	}
 
 	return group, nil

--- a/pkg/deployer/lib/resourcemanager/deletionmanager.go
+++ b/pkg/deployer/lib/resourcemanager/deletionmanager.go
@@ -12,6 +12,7 @@ import (
 
 func DeleteManagedResources(
 	ctx context.Context,
+	lsUncachedClient client.Client,
 	managedResources managedresource.ManagedResourceStatusList,
 	groupDefinitions []managedresource.DeletionGroupDefinition,
 	targetClient client.Client,
@@ -31,7 +32,7 @@ func DeleteManagedResources(
 	groups := make([]*DeletionGroup, len(groupDefinitions))
 	for i := range groupDefinitions {
 		var err error
-		groups[i], err = NewDeletionGroup(groupDefinitions[i], deployItem, targetClient, interruptionChecker)
+		groups[i], err = NewDeletionGroup(ctx, lsUncachedClient, groupDefinitions[i], deployItem, targetClient, interruptionChecker)
 		if err != nil {
 			return err
 		}

--- a/pkg/deployer/lib/resourcemanager/exporter.go
+++ b/pkg/deployer/lib/resourcemanager/exporter.go
@@ -107,7 +107,7 @@ func (e *Exporter) Export(ctx context.Context, exports *managedresource.Exports)
 }
 
 func (e *Exporter) doExport(ctx context.Context, export managedresource.Export) (map[string]interface{}, error) {
-	targetClient, err := lib.GetTargetClient(ctx, e.kubeClient, e.lsClient, e.deployItem.Namespace, export.TargetName)
+	targetClient, err := lib.GetTargetClient(ctx, e.kubeClient, e.lsClient, e.deployItem, export.TargetName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployer/lib/resourcemanager/matcher.go
+++ b/pkg/deployer/lib/resourcemanager/matcher.go
@@ -54,20 +54,20 @@ func (m *EmptyMatcher) Match(*managedresource.ManagedResourceStatus) bool {
 	return false
 }
 
-func newCustomMatcher(custom *managedresource.CustomResourceGroup, isCustomWithDifferentTarget bool) Matcher {
+func newCustomMatcher(custom *managedresource.CustomResourceGroup, isCustomWithSecondaryTarget bool) Matcher {
 	return &CustomMatcher{
 		resourceTypes:               custom.Resources,
-		isCustomWithDifferentTarget: isCustomWithDifferentTarget,
+		isCustomWithSecondaryTarget: isCustomWithSecondaryTarget,
 	}
 }
 
 type CustomMatcher struct {
 	resourceTypes               []managedresource.ResourceType
-	isCustomWithDifferentTarget bool
+	isCustomWithSecondaryTarget bool
 }
 
 func (m *CustomMatcher) Match(res *managedresource.ManagedResourceStatus) bool {
-	if m.isCustomWithDifferentTarget {
+	if m.isCustomWithSecondaryTarget {
 		return false
 	}
 

--- a/pkg/deployer/lib/resourcemanager/matcher.go
+++ b/pkg/deployer/lib/resourcemanager/matcher.go
@@ -54,17 +54,23 @@ func (m *EmptyMatcher) Match(*managedresource.ManagedResourceStatus) bool {
 	return false
 }
 
-func newCustomMatcher(custom *managedresource.CustomResourceGroup) Matcher {
+func newCustomMatcher(custom *managedresource.CustomResourceGroup, isCustomWithDifferentTarget bool) Matcher {
 	return &CustomMatcher{
-		resourceTypes: custom.Resources,
+		resourceTypes:               custom.Resources,
+		isCustomWithDifferentTarget: isCustomWithDifferentTarget,
 	}
 }
 
 type CustomMatcher struct {
-	resourceTypes []managedresource.ResourceType
+	resourceTypes               []managedresource.ResourceType
+	isCustomWithDifferentTarget bool
 }
 
 func (m *CustomMatcher) Match(res *managedresource.ManagedResourceStatus) bool {
+	if m.isCustomWithDifferentTarget {
+		return false
+	}
+
 	for _, t := range m.resourceTypes {
 		if t.Kind == res.Resource.Kind &&
 			t.APIVersion == res.Resource.APIVersion &&

--- a/pkg/deployer/lib/target_client_provider.go
+++ b/pkg/deployer/lib/target_client_provider.go
@@ -1,0 +1,54 @@
+package lib
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/controller-utils/pkg/landscaper/targetresolver"
+	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
+)
+
+// GetTargetClient is used to determine the client to read resources for custom readiness checks, export collection, and deletion groups.
+// Usually it is the client obtained from the Target of the DeployItem.
+// In some scenarios however, the Landscaper deploys an installer on a primary target cluster, and the installer
+// deploys the actual application on a secondary target cluster.
+func GetTargetClient(
+	ctx context.Context,
+	primaryTargetClient client.Client,
+	lsClient client.Client,
+	namespace string,
+	secondaryTargetName *string) (targetClient client.Client, err error) {
+
+	if secondaryTargetName == nil {
+		return primaryTargetClient, nil
+	}
+
+	if lsClient == nil {
+		return nil, fmt.Errorf("unable to get secondary target %s, because lsClient is not initialized", *secondaryTargetName)
+	}
+
+	target := &lsv1alpha1.Target{}
+	targetKey := client.ObjectKey{
+		Name:      *secondaryTargetName,
+		Namespace: namespace,
+	}
+	err = read_write_layer.GetTarget(ctx, lsClient, targetKey, target, read_write_layer.R000005)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read secondary target %s: %w", *secondaryTargetName, err)
+	}
+
+	resolvedTarget, err := targetresolver.Resolve(ctx, target, lsClient)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve secondary target %s: %w", *secondaryTargetName, err)
+	}
+
+	_, targetClient, _, err = GetClientMud(ctx, resolvedTarget, lsClient)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get secondary target client %s: %w", *secondaryTargetName, err)
+	}
+
+	return targetClient, nil
+}

--- a/pkg/deployer/lib/target_client_provider.go
+++ b/pkg/deployer/lib/target_client_provider.go
@@ -19,7 +19,7 @@ func GetTargetClient(
 	ctx context.Context,
 	primaryTargetClient client.Client,
 	lsClient client.Client,
-	namespace string,
+	deployItem *lsv1alpha1.DeployItem,
 	secondaryTargetName *string) (targetClient client.Client, err error) {
 
 	if secondaryTargetName == nil {
@@ -30,10 +30,14 @@ func GetTargetClient(
 		return nil, fmt.Errorf("unable to get secondary target %s, because lsClient is not initialized", *secondaryTargetName)
 	}
 
+	if deployItem == nil {
+		return nil, fmt.Errorf("unable to get secondary target %s, because deployItem is not initialized", *secondaryTargetName)
+	}
+
 	target := &lsv1alpha1.Target{}
 	targetKey := client.ObjectKey{
 		Name:      *secondaryTargetName,
-		Namespace: namespace,
+		Namespace: deployItem.Namespace,
 	}
 	err = read_write_layer.GetTarget(ctx, lsClient, targetKey, target, read_write_layer.R000005)
 	if err != nil {
@@ -45,7 +49,7 @@ func GetTargetClient(
 		return nil, fmt.Errorf("unable to resolve secondary target %s: %w", *secondaryTargetName, err)
 	}
 
-	_, targetClient, _, err = GetClientMud(ctx, resolvedTarget, lsClient)
+	_, targetClient, _, err = GetRestConfigAndClientAndClientSet(ctx, resolvedTarget, lsClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get secondary target client %s: %w", *secondaryTargetName, err)
 	}

--- a/pkg/deployer/lib/utils.go
+++ b/pkg/deployer/lib/utils.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gardener/landscaper/pkg/utils/read_write_layer"
 )
 
-func GetClientMud(ctx context.Context, resolvedTarget *lsv1alpha1.ResolvedTarget, lsUncachedClient client.Client) (*rest.Config, client.Client, kubernetes.Interface, error) {
+func GetRestConfigAndClientAndClientSet(ctx context.Context, resolvedTarget *lsv1alpha1.ResolvedTarget, lsUncachedClient client.Client) (*rest.Config, client.Client, kubernetes.Interface, error) {
 	targetConfig := &targettypes.KubernetesClusterTargetConfig{}
 	if err := yaml.Unmarshal([]byte(resolvedTarget.Content), targetConfig); err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to parse target confíguration: %w", err)

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -22,10 +21,7 @@ import (
 
 	"github.com/gardener/landscaper/pkg/utils"
 
-	"k8s.io/apimachinery/pkg/util/yaml"
-
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
 	manifestinstall "github.com/gardener/landscaper/apis/deployer/manifest/install"
 	manifestv1alpha2 "github.com/gardener/landscaper/apis/deployer/manifest/v1alpha2"
 
@@ -141,30 +137,7 @@ func (m *Manifest) TargetClient(ctx context.Context) (*rest.Config, client.Clien
 		return restConfig, kubeClient, clientset, nil
 	}
 	if m.Target != nil {
-		targetConfig := &targettypes.KubernetesClusterTargetConfig{}
-		if err := yaml.Unmarshal([]byte(m.Target.Content), targetConfig); err != nil {
-			return nil, nil, nil, fmt.Errorf("unable to parse target confíguration: %w", err)
-		}
-
-		kubeconfigBytes, err := lib.GetKubeconfigFromTargetConfig(ctx, targetConfig, m.Target.Namespace, m.lsUncachedClient)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		kubeconfig, err := clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		restConfig, err := kubeconfig.ClientConfig()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		kubeClient, err := client.New(restConfig, client.Options{})
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		clientset, err := kubernetes.NewForConfig(restConfig)
+		restConfig, kubeClient, clientset, err := lib.GetClientMud(ctx, m.Target, m.lsUncachedClient)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -172,6 +145,7 @@ func (m *Manifest) TargetClient(ctx context.Context) (*rest.Config, client.Clien
 		m.TargetRestConfig = restConfig
 		m.TargetKubeClient = kubeClient
 		m.TargetClientSet = clientset
+
 		return restConfig, kubeClient, clientset, nil
 	}
 	return nil, nil, nil, errors.New("neither a target nor kubeconfig are defined")

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -137,7 +137,7 @@ func (m *Manifest) TargetClient(ctx context.Context) (*rest.Config, client.Clien
 		return restConfig, kubeClient, clientset, nil
 	}
 	if m.Target != nil {
-		restConfig, kubeClient, clientset, err := lib.GetClientMud(ctx, m.Target, m.lsUncachedClient)
+		restConfig, kubeClient, clientset, err := lib.GetRestConfigAndClientAndClientSet(ctx, m.Target, m.lsUncachedClient)
 		if err != nil {
 			return nil, nil, nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for:
- a secondary target cluster in custom readiness checks, export collection, and deletion groups,
- patching resources after their deployment, resp. before their deletion.

The first feature can be used in scenarios where the Landscaper deploys an "installer" on a target cluster 1, and then this installer creates further resources on a target cluster 2. In such a case, a readiness check typically inspects resources on target cluster 2.

The second feature allows for example to suspend an installer when a deployment has been finished.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Support for a secondary target cluster in custom readiness checks, export collection, and deletion groups.
- Support for patching resources after their deployment, resp. before their deletion.
```
