### PR TITLE
Update kubernetes and gardenlinux version of test clusters

### DIFF
--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -26,7 +26,7 @@ spec:
           type: n1-standard-4
           image:
             name: gardenlinux
-            version: 1312.7.0
+            version: 1443.10.0
           architecture: amd64
         zones:
           - europe-west1-b
@@ -42,7 +42,7 @@ spec:
   region: europe-west1
   secretBindingName: laas-canary
   kubernetes:
-    version: "1.28"
+    version: "1.29"
   purpose: evaluation
   addons:
     kubernetesDashboard:

--- a/hack/testcluster/pkg/resources/shootcluster_workerless_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_workerless_template.yaml
@@ -15,7 +15,7 @@ spec:
       runtimeConfig:
         apps/v1: true
         batch/v1: true
-    version: "1.28"
+    version: "1.29"
   hibernation:
     schedules:
       - start: 00 {{ .hour }} * * 1,2,3,4,5,6,0


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update kubernetes version of test clusters to 1.29.
- Update gardenlinux version of test clusters to 1443.10.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Update kubernetes version of test clusters to 1.29.
- Update gardenlinux version of test clusters to 1443.10.0.
```
