### PR TITLE
add validation support for targetMap type

### DIFF
--- a/apis/core/validation/blueprint_test.go
+++ b/apis/core/validation/blueprint_test.go
@@ -165,6 +165,16 @@ var _ = Describe("Blueprint", func() {
 				"Detail": Equal("conditional imports on required import"),
 			}))))
 		})
+
+		It("should validate a targetMap import type", func() {
+			importDefinition := core.ImportDefinition{}
+			importDefinition.Name = "myimport"
+			importDefinition.TargetType = "test"
+			importDefinition.Type = core.ImportTypeTargetMap
+
+			allErrs := validation.ValidateBlueprintImportDefinitions(field.NewPath("x"), []core.ImportDefinition{importDefinition})
+			Expect(allErrs).To(HaveLen(0))
+		})
 	})
 
 	Context("ExportDefinitions", func() {

--- a/apis/core/validation/helper.go
+++ b/apis/core/validation/helper.go
@@ -18,6 +18,7 @@ var importTypesWithExpectedConfig = map[string][]string{
 	string(core.ImportTypeData):       {"Schema"},
 	string(core.ImportTypeTarget):     {"TargetType"},
 	string(core.ImportTypeTargetList): {"TargetType"},
+	string(core.ImportTypeTargetMap):  {"TargetType"},
 }
 var exportTypesWithExpectedConfig = map[string][]string{
 	string(core.ExportTypeData):   {"Schema"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The blueprint validation was missing the `targetMap` type.
This PR adds the type as a valid type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Add targetMap type support for blueprint validation
```
