### PR TITLE
Remove deprecated secretRef field from Target structure

### DIFF
--- a/apis/core/v1alpha1/targettypes/kubernetes_cluster.go
+++ b/apis/core/v1alpha1/targettypes/kubernetes_cluster.go
@@ -28,9 +28,6 @@ const DefaultKubeconfigKey = "kubeconfig"
 // ValueRef holds a value that can be either defined by string or by a secret ref.
 type ValueRef struct {
 	StrVal *string `json:"-"`
-
-	// deprecated
-	SecretRef *v1alpha1.SecretReference `json:"secretRef,omitempty"`
 }
 
 // kubeconfigJSON is a helper struct for decoding.
@@ -38,34 +35,16 @@ type kubeconfigJSON struct {
 	Kubeconfig *ValueRef `json:"kubeconfig"`
 }
 
-// valueRefJSON is a helper struct to decode json into a secret ref object.
-type valueRefJSON struct {
-	SecretRef *v1alpha1.SecretReference `json:"secretRef,omitempty"`
-}
-
 // MarshalJSON implements the json marshaling for a JSON
 func (v ValueRef) MarshalJSON() ([]byte, error) {
-	if v.StrVal != nil {
-		return json.Marshal(v.StrVal)
-	}
-	ref := valueRefJSON{
-		SecretRef: v.SecretRef,
-	}
-	return json.Marshal(ref)
+	return json.Marshal(v.StrVal)
 }
 
 // UnmarshalJSON implements json unmarshaling for a JSON
 func (v *ValueRef) UnmarshalJSON(data []byte) error {
-	ref := &valueRefJSON{}
-	err := json.Unmarshal(data, ref)
-	if err == nil && ref.SecretRef != nil {
-		// parsing into secret reference was successful
-		v.SecretRef = ref.SecretRef
-		return nil
-	}
 	// parse into string instead
 	var strVal string
-	err = json.Unmarshal(data, &strVal)
+	err := json.Unmarshal(data, &strVal)
 	if err == nil {
 		v.StrVal = &strVal
 		return nil

--- a/apis/core/v1alpha1/types_target_test.go
+++ b/apis/core/v1alpha1/types_target_test.go
@@ -1,0 +1,52 @@
+package v1alpha1_test
+
+import (
+	"encoding/json"
+	"github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("Target", func() {
+
+	It("should marshal a target with inline kubeconfig", func() {
+		targetConfig := &targettypes.KubernetesClusterTargetConfig{
+			Kubeconfig: targettypes.ValueRef{
+				StrVal: ptr.To("a: 1\nb: 2"),
+			},
+		}
+		targetConfigJSON, err := json.Marshal(targetConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(targetConfigJSON).To(MatchJSON(`{"kubeconfig":"a: 1\nb: 2"}`))
+
+		target := &v1alpha1.Target{
+			Spec: v1alpha1.TargetSpec{
+				Type: targettypes.KubernetesClusterTargetType,
+				Configuration: &v1alpha1.AnyJSON{
+					RawMessage: targetConfigJSON,
+				},
+			},
+		}
+		targetJSON, err := json.Marshal(target)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(targetJSON).To(MatchJSON(`{"metadata":{"creationTimestamp":null},"spec":{"type":"landscaper.gardener.cloud/kubernetes-cluster","config":{"kubeconfig":"a: 1\nb: 2"}}}`))
+	})
+
+	It("should unmarshal a target with inline kubeconfig", func() {
+		targetJSON := []byte(`{"metadata":{"creationTimestamp":null},"spec":{"type":"landscaper.gardener.cloud/kubernetes-cluster","config":{"kubeconfig":"a: 1\nb: 2"}}}`)
+		target := &v1alpha1.Target{}
+		Expect(json.Unmarshal(targetJSON, target)).To(Succeed())
+
+		configJSON := target.Spec.Configuration.RawMessage
+		config := &targettypes.KubernetesClusterTargetConfig{}
+		Expect(json.Unmarshal(configJSON, config)).To(Succeed())
+		Expect(config).To(Equal(&targettypes.KubernetesClusterTargetConfig{
+			Kubeconfig: targettypes.ValueRef{
+				StrVal: ptr.To("a: 1\nb: 2"),
+			},
+		}))
+	})
+})

--- a/apis/core/v1alpha1/types_target_test.go
+++ b/apis/core/v1alpha1/types_target_test.go
@@ -2,11 +2,13 @@ package v1alpha1_test
 
 import (
 	"encoding/json"
-	"github.com/gardener/landscaper/apis/core/v1alpha1"
-	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
 )
 
 var _ = Describe("Target", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

The content of a Target can be maintained in a referenced Secret. The correct field in a Target for such a reference is `.spec.secretRef`. This does not change.

Long ago, there was another field for the reference, namely `.spec.config.kubeconfig.secretRef`. This field has been deprecated for a long time and will be removed with this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Cleanup deprecated fields from Target structure
```
