### PR TITLE
Update OCM Version to v0.15.0 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ API_REF_GEN_VERSION ?= v0.1.0
 # renovate: datasource=github-releases depName=jqlang/jq
 JQ_VERSION ?= v1.7.1
 # renovate: datasource=github-releases depName=open-component-model/ocm
-OCM_VERSION ?= v0.14.0
+OCM_VERSION ?= v0.15.0
 # renovate: datasource=github-releases depName=golang/mock
 MOCKGEN_VERSION ?= v1.6.0
 # renovate: datasource=github-releases depName=distribution/distribution


### PR DESCRIPTION
**What this PR does / why we need it**:

Update OCM version used for the build to `v0.15.0`.

**Which issue(s) this PR fixes**:

Fixes the following error during build jobs:

```
Installing OCM tooling v0.14.0 ...
[INFO]  Downloading metadata https://api.github.com/repos/open-component-model/ocm/releases/tags/v0.14.0
[INFO]  Using 0.14.0 as release
[INFO]  Downloading hash https://github.com/open-component-model/ocm/releases/download/v0.14.0/ocm-0.14.0-linux-amd64.tar.gz.sha256
make: *** [Makefile:196: ocm] Error 22
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- Update OCM version used for the build to v0.15.0
```
