### PR TITLE
Remove kubeconfig from provider config of helm and manifest deployer

### DIFF
--- a/apis/deployer/helm/types_provider.go
+++ b/apis/deployer/helm/types_provider.go
@@ -26,11 +26,6 @@ const HelmChartRepoCredentialsKey = "helmChartRepoCredentials"
 type ProviderConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Kubeconfig is the base64 encoded kubeconfig file.
-	// By default the configured target is used to deploy the resources
-	// +optional
-	Kubeconfig string `json:"kubeconfig"`
-
 	// ReadinessChecks configures the readiness checks.
 	// +optional
 	ReadinessChecks health.ReadinessCheckConfiguration `json:"readinessChecks,omitempty"`

--- a/apis/deployer/helm/v1alpha1/types_provider.go
+++ b/apis/deployer/helm/v1alpha1/types_provider.go
@@ -24,11 +24,6 @@ const HelmChartRepoCredentialsKey = "helmChartRepoCredentials"
 type ProviderConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Kubeconfig is the base64 encoded kubeconfig file.
-	// By default the configured target is used to deploy the resources
-	// +optional
-	Kubeconfig string `json:"kubeconfig"`
-
 	// UpdateStrategy defines the strategy how the manifests are updated in the cluster.
 	// Defaults to "update".
 	// +optional

--- a/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -480,7 +480,6 @@ func Convert_helm_HelmUninstallConfiguration_To_v1alpha1_HelmUninstallConfigurat
 }
 
 func autoConvert_v1alpha1_ProviderConfiguration_To_helm_ProviderConfiguration(in *ProviderConfiguration, out *helm.ProviderConfiguration, s conversion.Scope) error {
-	out.Kubeconfig = in.Kubeconfig
 	out.UpdateStrategy = helm.UpdateStrategy(in.UpdateStrategy)
 	out.ReadinessChecks = in.ReadinessChecks
 	if err := Convert_v1alpha1_Chart_To_helm_Chart(&in.Chart, &out.Chart, s); err != nil {
@@ -506,7 +505,6 @@ func Convert_v1alpha1_ProviderConfiguration_To_helm_ProviderConfiguration(in *Pr
 }
 
 func autoConvert_helm_ProviderConfiguration_To_v1alpha1_ProviderConfiguration(in *helm.ProviderConfiguration, out *ProviderConfiguration, s conversion.Scope) error {
-	out.Kubeconfig = in.Kubeconfig
 	out.ReadinessChecks = in.ReadinessChecks
 	out.UpdateStrategy = UpdateStrategy(in.UpdateStrategy)
 	if err := Convert_helm_Chart_To_v1alpha1_Chart(&in.Chart, &out.Chart, s); err != nil {

--- a/apis/deployer/manifest/types_provider.go
+++ b/apis/deployer/manifest/types_provider.go
@@ -18,10 +18,6 @@ import (
 // ProviderConfiguration is the manifest deployer configuration that is expected in a DeployItem.
 type ProviderConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
-	// Kubeconfig is the base64 encoded kubeconfig file.
-	// By default the configured target is used to deploy the resources
-	// +optional
-	Kubeconfig string `json:"kubeconfig"`
 	// UpdateStrategy defines the strategy how the manifest are updated in the cluster.
 	// +optional
 	UpdateStrategy UpdateStrategy `json:"updateStrategy"`

--- a/apis/deployer/manifest/v1alpha1/conversions.go
+++ b/apis/deployer/manifest/v1alpha1/conversions.go
@@ -18,7 +18,6 @@ import (
 
 // Convert_v1alpha1_ProviderConfiguration_To_manifest_ProviderConfiguration is an manual conversion function.
 func Convert_v1alpha1_ProviderConfiguration_To_manifest_ProviderConfiguration(in *ProviderConfiguration, out *manifestcore.ProviderConfiguration, s conversion.Scope) error {
-	out.Kubeconfig = in.Kubeconfig
 	out.UpdateStrategy = manifestcore.UpdateStrategy(in.UpdateStrategy)
 	out.ReadinessChecks = in.ReadinessChecks
 	if in.Manifests != nil {
@@ -38,7 +37,6 @@ func Convert_v1alpha1_ProviderConfiguration_To_manifest_ProviderConfiguration(in
 
 // Convert_manifest_ProviderConfiguration_To_v1alpha1_ProviderConfiguration is an manual conversion function.
 func Convert_manifest_ProviderConfiguration_To_v1alpha1_ProviderConfiguration(in *manifestcore.ProviderConfiguration, out *ProviderConfiguration, s conversion.Scope) error {
-	out.Kubeconfig = in.Kubeconfig
 	out.UpdateStrategy = UpdateStrategy(in.UpdateStrategy)
 	out.ReadinessChecks = in.ReadinessChecks
 	if in.Manifests != nil {

--- a/apis/deployer/manifest/v1alpha1/conversions_test.go
+++ b/apis/deployer/manifest/v1alpha1/conversions_test.go
@@ -23,7 +23,6 @@ var _ = Describe("Conversion", func() {
 
 		var (
 			v1alpha1Config = &manifestv1alpha1.ProviderConfiguration{
-				Kubeconfig:     "my-kubeconfig",
 				UpdateStrategy: manifestv1alpha1.UpdateStrategyPatch,
 				Manifests: []*runtime.RawExtension{
 					{
@@ -36,7 +35,6 @@ var _ = Describe("Conversion", func() {
 			}
 
 			manifestConfig = &manifestcore.ProviderConfiguration{
-				Kubeconfig:     "my-kubeconfig",
 				UpdateStrategy: manifestcore.UpdateStrategyPatch,
 				Manifests: []managedresource.Manifest{
 					{

--- a/apis/deployer/manifest/v1alpha1/types_provider.go
+++ b/apis/deployer/manifest/v1alpha1/types_provider.go
@@ -19,10 +19,6 @@ import (
 // +k8s:conversion-gen=false
 type ProviderConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
-	// Kubeconfig is the base64 encoded kubeconfig file.
-	// By default the configured target is used to deploy the resources
-	// +optional
-	Kubeconfig string `json:"kubeconfig"`
 	// UpdateStrategy defines the strategy how the manifest are updated in the cluster.
 	// Defaults to "update".
 	// +optional

--- a/apis/deployer/manifest/v1alpha2/types_provider.go
+++ b/apis/deployer/manifest/v1alpha2/types_provider.go
@@ -17,10 +17,6 @@ import (
 // ProviderConfiguration is the manifest deployer configuration that is expected in a DeployItem
 type ProviderConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
-	// Kubeconfig is the base64 encoded kubeconfig file.
-	// By default the configured target is used to deploy the resources
-	// +optional
-	Kubeconfig string `json:"kubeconfig"`
 	// UpdateStrategy defines the strategy how the manifest are updated in the cluster.
 	// Defaults to "update".
 	// +optional

--- a/apis/deployer/manifest/v1alpha2/zz_generated.conversion.go
+++ b/apis/deployer/manifest/v1alpha2/zz_generated.conversion.go
@@ -187,7 +187,6 @@ func Convert_manifest_HPAConfiguration_To_v1alpha2_HPAConfiguration(in *manifest
 }
 
 func autoConvert_v1alpha2_ProviderConfiguration_To_manifest_ProviderConfiguration(in *ProviderConfiguration, out *manifest.ProviderConfiguration, s conversion.Scope) error {
-	out.Kubeconfig = in.Kubeconfig
 	out.UpdateStrategy = manifest.UpdateStrategy(in.UpdateStrategy)
 	out.ReadinessChecks = in.ReadinessChecks
 	out.Manifests = *(*[]managedresource.Manifest)(unsafe.Pointer(&in.Manifests))
@@ -204,7 +203,6 @@ func Convert_v1alpha2_ProviderConfiguration_To_manifest_ProviderConfiguration(in
 }
 
 func autoConvert_manifest_ProviderConfiguration_To_v1alpha2_ProviderConfiguration(in *manifest.ProviderConfiguration, out *ProviderConfiguration, s conversion.Scope) error {
-	out.Kubeconfig = in.Kubeconfig
 	out.UpdateStrategy = UpdateStrategy(in.UpdateStrategy)
 	out.ReadinessChecks = in.ReadinessChecks
 	out.Manifests = *(*[]managedresource.Manifest)(unsafe.Pointer(&in.Manifests))

--- a/apis/openapi/zz_generated.openapi.go
+++ b/apis/openapi/zz_generated.openapi.go
@@ -13492,14 +13492,6 @@ func schema_landscaper_apis_deployer_helm_ProviderConfiguration(ref common.Refer
 							Format:      "",
 						},
 					},
-					"kubeconfig": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Kubeconfig is the base64 encoded kubeconfig file. By default the configured target is used to deploy the resources",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"readinessChecks": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ReadinessChecks configures the readiness checks.",
@@ -14170,14 +14162,6 @@ func schema_apis_deployer_helm_v1alpha1_ProviderConfiguration(ref common.Referen
 							Format:      "",
 						},
 					},
-					"kubeconfig": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Kubeconfig is the base64 encoded kubeconfig file. By default the configured target is used to deploy the resources",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"updateStrategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UpdateStrategy defines the strategy how the manifests are updated in the cluster. Defaults to \"update\".",
@@ -14576,14 +14560,6 @@ func schema_landscaper_apis_deployer_manifest_ProviderConfiguration(ref common.R
 							Format:      "",
 						},
 					},
-					"kubeconfig": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Kubeconfig is the base64 encoded kubeconfig file. By default the configured target is used to deploy the resources",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"updateStrategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UpdateStrategy defines the strategy how the manifest are updated in the cluster.",
@@ -14889,14 +14865,6 @@ func schema_apis_deployer_manifest_v1alpha1_ProviderConfiguration(ref common.Ref
 							Format:      "",
 						},
 					},
-					"kubeconfig": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Kubeconfig is the base64 encoded kubeconfig file. By default the configured target is used to deploy the resources",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"updateStrategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UpdateStrategy defines the strategy how the manifest are updated in the cluster. Defaults to \"update\".",
@@ -15158,14 +15126,6 @@ func schema_apis_deployer_manifest_v1alpha2_ProviderConfiguration(ref common.Ref
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"kubeconfig": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Kubeconfig is the base64 encoded kubeconfig file. By default the configured target is used to deploy the resources",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -61,9 +61,6 @@ spec:
         atomic: true
         force: true
       uninstall: {} # see https://helm.sh/docs/helm/helm_uninstall/#options
- 
-    # base64 encoded kubeconfig pointing to the cluster to install the chart
-    kubeconfig: xxx
 
     updateStrategy: update | patch # optional; defaults to update
 

--- a/pkg/deployer/helm/helm.go
+++ b/pkg/deployer/helm/helm.go
@@ -6,7 +6,6 @@ package helm
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"strings"
 
@@ -17,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -187,35 +185,6 @@ func (h *Helm) Template(ctx context.Context) (map[string]string, map[string]stri
 func (h *Helm) TargetClient(ctx context.Context) (*rest.Config, client.Client, kubernetes.Interface, error) {
 	if h.TargetKubeClient != nil {
 		return h.TargetRestConfig, h.TargetKubeClient, h.TargetClientSet, nil
-	}
-	// use the configured kubeconfig over the target if defined
-	if len(h.ProviderConfiguration.Kubeconfig) != 0 {
-		kubeconfig, err := base64.StdEncoding.DecodeString(h.ProviderConfiguration.Kubeconfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		cConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		restConfig, err := cConfig.ClientConfig()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		kubeClient, err := client.New(restConfig, client.Options{})
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		clientset, err := kubernetes.NewForConfig(restConfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		h.TargetRestConfig = restConfig
-		h.TargetKubeClient = kubeClient
-		return restConfig, kubeClient, clientset, nil
 	}
 	if h.Target != nil {
 		restConfig, kubeClient, clientset, err := lib.GetRestConfigAndClientAndClientSet(ctx, h.Target, h.lsUncachedClient)

--- a/pkg/deployer/manifest/manifest.go
+++ b/pkg/deployer/manifest/manifest.go
@@ -6,13 +6,11 @@ package manifest
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lserrors "github.com/gardener/landscaper/apis/errors"
@@ -106,35 +104,6 @@ func New(lsUncachedClient client.Client, hostUncachedClient client.Client,
 func (m *Manifest) TargetClient(ctx context.Context) (*rest.Config, client.Client, kubernetes.Interface, error) {
 	if m.TargetKubeClient != nil {
 		return m.TargetRestConfig, m.TargetKubeClient, m.TargetClientSet, nil
-	}
-	// use the configured kubeconfig over the target if defined
-	if len(m.ProviderConfiguration.Kubeconfig) != 0 {
-		kubeconfig, err := base64.StdEncoding.DecodeString(m.ProviderConfiguration.Kubeconfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		cConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		restConfig, err := cConfig.ClientConfig()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		kubeClient, err := client.New(restConfig, client.Options{})
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		clientset, err := kubernetes.NewForConfig(restConfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		m.TargetRestConfig = restConfig
-		m.TargetKubeClient = kubeClient
-		return restConfig, kubeClient, clientset, nil
 	}
 	if m.Target != nil {
 		restConfig, kubeClient, clientset, err := lib.GetRestConfigAndClientAndClientSet(ctx, m.Target, m.lsUncachedClient)


### PR DESCRIPTION
**What this PR does / why we need it**:

In DeployItems of the helm and manifest deployer, a kubeconfig could be specified instread of a Target. With this PR, this is no longer possible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Remove obsolete kubeconfig field from provider config of helm and manifest deployer
```
