### PR TITLE
Unauthorized error during GetApiResource

### DIFF
--- a/apis/core/v1alpha1/types_shared.go
+++ b/apis/core/v1alpha1/types_shared.go
@@ -178,6 +178,7 @@ var UnrecoverableErrorCodes = []ErrorCode{
 	ErrorConfigurationProblem,
 	ErrorInternalProblem,
 	ErrorTimeout,
+	ErrorUnauthorized,
 	ErrorCyclicDependencies,
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If a DeployItem fails with the error below, it should directly change to phase `Failed`. Currently, the DeployItem remains in phase `Progressing` and retries until timeout.

```yaml
  lastError:
    message: 'unable to get api resources for v1: Unauthorized'
    operation: GetApiResource
    reason: GetApiResourceList
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Improved error handling
```
