### PR TITLE
Switch from deprecated `cloudProfileName` to `cloudProfile.name`

### DIFF
--- a/hack/testcluster/pkg/resources/shootcluster_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_template.yaml
@@ -41,7 +41,8 @@ spec:
   networking:
     nodes: 10.180.0.0/16
     type: calico
-  cloudProfileName: gcp
+  cloudProfile:
+    name: gcp
   region: europe-west1
   secretBindingName: laas-canary
   kubernetes:

--- a/hack/testcluster/pkg/resources/shootcluster_workerless_template.yaml
+++ b/hack/testcluster/pkg/resources/shootcluster_workerless_template.yaml
@@ -6,7 +6,8 @@ metadata:
   annotations:
     shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds: '180'
 spec:
-  cloudProfileName: gcp
+  cloudProfile:
+    name: gcp
   region: europe-west1
   provider:
     type: gcp


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch from deprecated `cloudProfileName` to `cloudProfile.name` as `cloudProfileName` will be removed in the future.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9504
