### PR TITLE
docs: correct link to templating

### DIFF
--- a/docs/usage/Blueprints.md
+++ b/docs/usage/Blueprints.md
@@ -349,7 +349,7 @@ The task of a _Blueprint_ is to provide deployitems and final output for
 the data flow among _Installations_ based of their input values provided
 by the actual _Installation_ is evaluated for.
 
-This is described by rule sets consisting of [templates](./Templating) carried together
+This is described by rule sets consisting of [templates](./Templating.md) carried together
 with the blueprint.
 
 All template [executions](./Templating.md) get a common standardized binding:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
- Fix a link to the templating documentation
```
