### PR TITLE
feat: add take-ownership and wait options

### DIFF
--- a/apis/deployer/helm/types_provider.go
+++ b/apis/deployer/helm/types_provider.go
@@ -155,6 +155,8 @@ type HelmInstallConfiguration struct {
 	Atomic               bool `json:"atomic,omitempty"`
 	Force                bool `json:"force,omitempty"`
 	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty"`
+	TakeOwnership        bool `json:"takeOwnership,omitempty"`
+	Wait                 bool `json:"wait,omitempty"`
 
 	// Timeout is the timeout for the operation in minutes.
 	// +optional
@@ -166,6 +168,8 @@ type HelmUpgradeConfiguration = HelmInstallConfiguration
 
 // HelmUninstallConfiguration defines settings for a helm uninstall operation.
 type HelmUninstallConfiguration struct {
+	Wait bool `json:"wait,omitempty"`
+
 	// Timeout is the timeout for the operation in minutes.
 	// +optional
 	Timeout *lsv1alpha1.Duration `json:"timeout,omitempty"`

--- a/apis/deployer/helm/v1alpha1/types_provider.go
+++ b/apis/deployer/helm/v1alpha1/types_provider.go
@@ -160,6 +160,8 @@ type HelmInstallConfiguration struct {
 	Atomic               bool `json:"atomic,omitempty"`
 	Force                bool `json:"force,omitempty"`
 	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty"`
+	TakeOwnership        bool `json:"takeOwnership,omitempty"`
+	Wait                 bool `json:"wait,omitempty"`
 
 	// Timeout is the timeout for the operation in minutes.
 	// +optional
@@ -171,6 +173,8 @@ type HelmUpgradeConfiguration = HelmInstallConfiguration
 
 // HelmUninstallConfiguration defines settings for a helm uninstall operation.
 type HelmUninstallConfiguration struct {
+	Wait bool `json:"wait,omitempty"`
+
 	// Timeout is the timeout for the operation in minutes.
 	// +optional
 	Timeout *lsv1alpha1.Duration `json:"timeout,omitempty"`

--- a/apis/deployer/helm/v1alpha1/validation/validation.go
+++ b/apis/deployer/helm/v1alpha1/validation/validation.go
@@ -22,6 +22,8 @@ const (
 	helmArgumentForce                = "force"
 	helmArgumentTimeout              = "timeout"
 	helmArgumentSkipSchemaValidation = "skipSchemaValidation"
+	helmArgumentTakeOwnership        = "takeOwnership"
+	helmArgumentWait                 = "wait"
 )
 
 // ValidateProviderConfiguration validates a helm deployer configuration
@@ -107,15 +109,17 @@ func ValidateHelmDeploymentConfiguration(fldPath *field.Path, deployConfig *helm
 }
 
 func ValidateInstallConfiguration(fldPath *field.Path, conf map[string]lsv1alpha1.AnyJSON) field.ErrorList {
-	return validateHelmArguments(fldPath, conf, []string{helmArgumentAtomic, helmArgumentTimeout, helmArgumentForce, helmArgumentSkipSchemaValidation})
+	return validateHelmArguments(fldPath, conf, []string{helmArgumentAtomic, helmArgumentTimeout, helmArgumentForce,
+		helmArgumentSkipSchemaValidation, helmArgumentTakeOwnership, helmArgumentWait})
 }
 
 func ValidateUpgradeConfiguration(fldPath *field.Path, conf map[string]lsv1alpha1.AnyJSON) field.ErrorList {
-	return validateHelmArguments(fldPath, conf, []string{helmArgumentAtomic, helmArgumentTimeout, helmArgumentForce, helmArgumentSkipSchemaValidation})
+	return validateHelmArguments(fldPath, conf, []string{helmArgumentAtomic, helmArgumentTimeout, helmArgumentForce,
+		helmArgumentSkipSchemaValidation, helmArgumentTakeOwnership, helmArgumentWait})
 }
 
 func ValidateUninstallConfiguration(fldPath *field.Path, conf map[string]lsv1alpha1.AnyJSON) field.ErrorList {
-	return validateHelmArguments(fldPath, conf, []string{helmArgumentTimeout})
+	return validateHelmArguments(fldPath, conf, []string{helmArgumentTimeout, helmArgumentWait})
 }
 
 func validateHelmArguments(fldPath *field.Path, conf map[string]lsv1alpha1.AnyJSON, validArguments []string) field.ErrorList {

--- a/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
+++ b/apis/deployer/helm/v1alpha1/zz_generated.conversion.go
@@ -439,6 +439,8 @@ func autoConvert_v1alpha1_HelmInstallConfiguration_To_helm_HelmInstallConfigurat
 	out.Atomic = in.Atomic
 	out.Force = in.Force
 	out.SkipSchemaValidation = in.SkipSchemaValidation
+	out.TakeOwnership = in.TakeOwnership
+	out.Wait = in.Wait
 	out.Timeout = (*corev1alpha1.Duration)(unsafe.Pointer(in.Timeout))
 	return nil
 }
@@ -452,6 +454,8 @@ func autoConvert_helm_HelmInstallConfiguration_To_v1alpha1_HelmInstallConfigurat
 	out.Atomic = in.Atomic
 	out.Force = in.Force
 	out.SkipSchemaValidation = in.SkipSchemaValidation
+	out.TakeOwnership = in.TakeOwnership
+	out.Wait = in.Wait
 	out.Timeout = (*corev1alpha1.Duration)(unsafe.Pointer(in.Timeout))
 	return nil
 }
@@ -462,6 +466,7 @@ func Convert_helm_HelmInstallConfiguration_To_v1alpha1_HelmInstallConfiguration(
 }
 
 func autoConvert_v1alpha1_HelmUninstallConfiguration_To_helm_HelmUninstallConfiguration(in *HelmUninstallConfiguration, out *helm.HelmUninstallConfiguration, s conversion.Scope) error {
+	out.Wait = in.Wait
 	out.Timeout = (*corev1alpha1.Duration)(unsafe.Pointer(in.Timeout))
 	return nil
 }
@@ -472,6 +477,7 @@ func Convert_v1alpha1_HelmUninstallConfiguration_To_helm_HelmUninstallConfigurat
 }
 
 func autoConvert_helm_HelmUninstallConfiguration_To_v1alpha1_HelmUninstallConfiguration(in *helm.HelmUninstallConfiguration, out *HelmUninstallConfiguration, s conversion.Scope) error {
+	out.Wait = in.Wait
 	out.Timeout = (*corev1alpha1.Duration)(unsafe.Pointer(in.Timeout))
 	return nil
 }

--- a/apis/openapi/zz_generated.openapi.go
+++ b/apis/openapi/zz_generated.openapi.go
@@ -13455,6 +13455,18 @@ func schema_landscaper_apis_deployer_helm_HelmInstallConfiguration(ref common.Re
 							Format: "",
 						},
 					},
+					"takeOwnership": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"wait": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timeout is the timeout for the operation in minutes.",
@@ -13476,6 +13488,12 @@ func schema_landscaper_apis_deployer_helm_HelmUninstallConfiguration(ref common.
 				Description: "HelmUninstallConfiguration defines settings for a helm uninstall operation.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"wait": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timeout is the timeout for the operation in minutes.",
@@ -14131,6 +14149,18 @@ func schema_apis_deployer_helm_v1alpha1_HelmInstallConfiguration(ref common.Refe
 							Format: "",
 						},
 					},
+					"takeOwnership": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"wait": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timeout is the timeout for the operation in minutes.",
@@ -14152,6 +14182,12 @@ func schema_apis_deployer_helm_v1alpha1_HelmUninstallConfiguration(ref common.Re
 				Description: "HelmUninstallConfiguration defines settings for a helm uninstall operation.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"wait": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timeout is the timeout for the operation in minutes.",

--- a/docs/deployer/helm.md
+++ b/docs/deployer/helm.md
@@ -58,11 +58,16 @@ spec:
         atomic: true
         force: true
         skipSchemaValidation: true
+        takeOwnership: true
+        wait: true
       upgrade: # see https://helm.sh/docs/helm/helm_upgrade/#options
         atomic: true
         force: true
         skipSchemaValidation: true
-      uninstall: {} # see https://helm.sh/docs/helm/helm_uninstall/#options
+        takeOwnership: true
+        wait: true
+      uninstall: # see https://helm.sh/docs/helm/helm_uninstall/#options
+        wait: true
 
     updateStrategy: update | patch # optional; defaults to update
 

--- a/pkg/deployer/helm/realhelmdeployer/deploy_config.go
+++ b/pkg/deployer/helm/realhelmdeployer/deploy_config.go
@@ -22,7 +22,9 @@ type installConfiguration struct {
 	Atomic               bool                 `json:"atomic,omitempty"`
 	Force                bool                 `json:"force,omitempty"`
 	SkipSchemaValidation bool                 `json:"skipSchemaValidation,omitempty"`
+	TakeOwnership        bool                 `json:"takeOwnership,omitempty"`
 	Timeout              *lsv1alpha1.Duration `json:"timeout,omitempty"`
+	Wait                 bool                 `json:"wait,omitempty"`
 }
 
 func newInstallConfiguration(conf *helmv1alpha1.HelmDeploymentConfiguration) (*installConfiguration, error) {
@@ -54,7 +56,9 @@ type upgradeConfiguration struct {
 	Atomic               bool                 `json:"atomic,omitempty"`
 	Force                bool                 `json:"force,omitempty"`
 	SkipSchemaValidation bool                 `json:"skipSchemaValidation,omitempty"`
+	TakeOwnership        bool                 `json:"takeOwnership,omitempty"`
 	Timeout              *lsv1alpha1.Duration `json:"timeout,omitempty"`
+	Wait                 bool                 `json:"wait,omitempty"`
 }
 
 func newUpgradeConfiguration(conf *helmv1alpha1.HelmDeploymentConfiguration) (*upgradeConfiguration, error) {
@@ -79,4 +83,28 @@ func newUpgradeConfiguration(conf *helmv1alpha1.HelmDeploymentConfiguration) (*u
 	}
 
 	return upgradeConf, nil
+}
+
+// uninstallConfiguration defines settings for a helm uninstall operation.
+type uninstallConfiguration struct {
+	Wait bool `json:"wait,omitempty"`
+}
+
+func newUninstallConfiguration(conf *helmv1alpha1.HelmDeploymentConfiguration) (*uninstallConfiguration, error) {
+	currOp := "NewUninstallConfiguration"
+
+	uninstallConf := &uninstallConfiguration{}
+
+	if conf != nil && len(conf.Uninstall) > 0 {
+		rawConf, err := json.Marshal(conf.Uninstall)
+		if err != nil {
+			return nil, lserror.NewWrappedError(err, currOp, "MarshalConfig", err.Error())
+		}
+
+		if err := json.Unmarshal(rawConf, uninstallConf); err != nil {
+			return nil, lserror.NewWrappedError(err, currOp, "UnmarshalConfig", err.Error())
+		}
+	}
+
+	return uninstallConf, nil
 }

--- a/pkg/deployer/helm/realhelmdeployer/real_helm_deployer.go
+++ b/pkg/deployer/helm/realhelmdeployer/real_helm_deployer.go
@@ -167,6 +167,8 @@ func (c *RealHelmDeployer) installRelease(ctx context.Context, values map[string
 	install.Atomic = installConfig.Atomic
 	install.Force = installConfig.Force
 	install.SkipSchemaValidation = installConfig.SkipSchemaValidation
+	install.TakeOwnership = installConfig.TakeOwnership
+	install.Wait = installConfig.Wait
 
 	timeout, err := timeout.TimeoutExceeded(ctx, c.di, TimeoutCheckpointHelmBeforeInstallingRelease)
 	if err != nil {
@@ -221,6 +223,8 @@ func (c *RealHelmDeployer) upgradeRelease(ctx context.Context, values map[string
 	upgrade.Atomic = upgradeConfig.Atomic
 	upgrade.Force = upgradeConfig.Force
 	upgrade.SkipSchemaValidation = upgradeConfig.SkipSchemaValidation
+	upgrade.TakeOwnership = upgradeConfig.TakeOwnership
+	upgrade.Wait = upgradeConfig.Wait
 
 	timeout, err := timeout.TimeoutExceeded(ctx, c.di, TimeoutCheckpointHelmBeforeUpgradingRelease)
 	if err != nil {
@@ -275,8 +279,14 @@ func (c *RealHelmDeployer) deleteRelease(ctx context.Context) error {
 		return err
 	}
 
+	uninstallConfig, err := newUninstallConfiguration(c.helmConfig)
+	if err != nil {
+		return err
+	}
+
 	uninstall := action.NewUninstall(actionConfig)
 	uninstall.KeepHistory = false
+	uninstall.Wait = uninstallConfig.Wait
 
 	timeout, err := timeout.TimeoutExceeded(ctx, c.di, TimeoutCheckpointHelmBeforeDeletingRelease)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

With this PR the helm options `take-ownership` and `wait` are supported by the helm deployer. In a helm deployitem they can be specified in the following way:

```yaml
    helmDeploymentConfig:
      install:
        takeOwnership: true
        wait: true
      upgrade:
        takeOwnership: true
        wait: true
      uninstall:
        wait: true
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support for helm options `take-ownership` and `wait`. 
```
