### PR TITLE
fix: target export with secret reference

### DIFF
--- a/pkg/landscaper/installations/exports/constructor.go
+++ b/pkg/landscaper/installations/exports/constructor.go
@@ -246,6 +246,7 @@ func ConvertTargetTemplateToTargetExtension(tmplData interface{}) (*dataobjects.
 		Spec: lsv1alpha1.TargetSpec{
 			Type:          targetTemplate.Type,
 			Configuration: targetTemplate.Configuration,
+			SecretRef:     targetTemplate.SecretRef,
 		},
 	}
 	return dataobjects.NewTargetExtension(target, nil), nil


### PR DESCRIPTION
**What this PR does / why we need it**:

A target can either contain a kubeconfig or reference a secret that contains it. If an installation exports a target, the second case does not work, because the secretRef gets lost. This pull requests fixes this. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Fix issue concerning target export parameters with secret reference
```
